### PR TITLE
fix: clear credential.helper and set PIP_BREAK_SYSTEM_PACKAGES in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,10 @@ ENV RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
 
 COPY . $ROS2_WS/src/necst/
 
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
+
+RUN git config --global credential.helper ""
+
 RUN pip install setuptools==70.3.0 --break-system-packages
 RUN ( cd $ROS2_WS/src/necst && pip install git+https://github.com/necst-telescope/neclib.git --break-system-packages)
 RUN pip install ipython \


### PR DESCRIPTION
## 原因

`COPY . $ROS2_WS/src/necst/` でMacの `.git/` ディレクトリがそのままコンテナに入る。
Mac の システム git config には `credential.helper = osxkeychain` が設定されているため、
コンテナ（Linux）内で `git pull` すると osxkeychain が存在せず認証を求められてしまう。

necst-msgs はコンテナ内で `git clone` されるため、この問題は起きない。

## 修正内容

- `RUN git config --global credential.helper ""` を追加し、コンテナ内では credential helper を無効化
- `ENV PIP_BREAK_SYSTEM_PACKAGES=1` を追加し、`pip` コマンドに毎回 `--break-system-packages` を書かなくて済むようにする（PEP 668 対応）

## Test plan

- [ ] コンテナ内で `git pull` が認証なしで成功すること
- [ ] `pip install` が `--break-system-packages` なしで実行できること