### PR TITLE
#467 fix: pip unusable and git pull requires auth in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,10 @@ ENV RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
 
 COPY . $ROS2_WS/src/necst/
 
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
+
+RUN git config --global credential.helper ""
+
 RUN pip install setuptools==70.3.0 --break-system-packages
 RUN ( cd $ROS2_WS/src/necst && pip install git+https://github.com/necst-telescope/neclib.git --break-system-packages)
 RUN pip install ipython \


### PR DESCRIPTION
Closes #467

## 原因と修正

### 1. pip が `--break-system-packages` なしで使えない（PEP 668）

Python 3.12 on Debian/Ubuntu の PEP 668 制約により、コンテナ内で `pip install` するたびに `--break-system-packages` フラグが必要だった。

→ `ENV PIP_BREAK_SYSTEM_PACKAGES=1` を設定

### 2. `git pull` がコンテナ内で認証を求める

`COPY . $ROS2_WS/src/necst/` で Mac の `.git/` がコンテナに入り、Mac の `osxkeychain` credential helper の設定が影響していた。necst-msgs は Dockerfile 内で `git clone` しているためこの問題は起きない。

→ `RUN git config --global credential.helper ""` を追加

## Test plan

- [ ] コンテナ内で `git pull` が認証なしで成功すること
- [ ] `pip install` が `--break-system-packages` なしで実行できること