### PR TITLE
#469 fix: use GIT_TERMINAL_PROMPT=0 to suppress auth prompt in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ COPY . $ROS2_WS/src/necst/
 
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
 
-RUN git config --global credential.helper ""
+ENV GIT_TERMINAL_PROMPT=0
 
 RUN pip install setuptools==70.3.0 --break-system-packages
 RUN ( cd $ROS2_WS/src/necst && pip install git+https://github.com/necst-telescope/neclib.git --break-system-packages)


### PR DESCRIPTION
Closes #469

## 変更内容

`credential.helper ""` → `ENV GIT_TERMINAL_PROMPT=0` に置き換え。

前の修正（#467）では `credential.helper = ""` で helper を無効化していたが、git はターミナルに直接認証を求めることができるため、コンテナ内で `git pull` すると依然としてプロンプトが出ていた。

`GIT_TERMINAL_PROMPT=0` はターミナルへの認証プロンプト自体を完全に無効化する。

## Test plan

- [ ] コンテナ内で `git pull` が認証プロンプトなしで成功すること