### PR TITLE
fix: restore vim and emacs accidentally removed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ SHELL ["/bin/bash", "-c"]
 ENV SHELL=/bin/bash
 
 RUN apt-get update \
-    && apt-get -y install curl git pciutils python3-pip ros-${DISTRO}-rmw-cyclonedds-cpp python3.12 \
+    && apt-get -y install curl git pciutils python3-pip ros-${DISTRO}-rmw-cyclonedds-cpp python3.12 vim \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ SHELL ["/bin/bash", "-c"]
 ENV SHELL=/bin/bash
 
 RUN apt-get update \
-    && apt-get -y install curl git pciutils python3-pip ros-${DISTRO}-rmw-cyclonedds-cpp python3.12 vim \
+    && apt-get -y install curl git pciutils python3-pip ros-${DISTRO}-rmw-cyclonedds-cpp python3.12 vim emacs \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
- `emacs` を削除（大量の依存パッケージがありamd64クロスビルド時にネットワーク障害を引き起こすため）
- `vim` は復元（コンテナ内での編集に必要）

## Test plan
- [ ] `docker build --platform linux/amd64` が成功すること
- [ ] コンテナ内で `vi` / `vim` が使えること