### PR TITLE
#474 feat: add time sync monitoring, display derivations, and chopper CLI

### DIFF
--- a/.github/actions/setup-necst/action.yml
+++ b/.github/actions/setup-necst/action.yml
@@ -14,7 +14,9 @@ runs:
       run: |
         . /opt/ros/$ROS_DISTRO/setup.bash
         cd ros2_ws/src/
-        git clone https://github.com/necst-telescope/necst-msgs.git
+        # PR #474 uses the Az unwrap services from this dependency branch.
+        git clone --depth 1 --branch '#159-feat/az-unwrap-state-service' \
+          https://github.com/necst-telescope/necst-msgs.git
         cd ../
         colcon build --symlink-install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ ENV SHELL=/bin/bash
 
 RUN apt-get update \
     && apt-get -y install curl git pciutils python3-pip ros-${DISTRO}-rmw-cyclonedds-cpp python3.12 vim emacs \
+    chrony \
+    ntpsec \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,7 @@ SHELL ["/bin/bash", "-c"]
 ENV SHELL=/bin/bash
 
 RUN apt-get update \
-    && apt-get -y install curl git pciutils python3-pip ros-${DISTRO}-rmw-cyclonedds-cpp python3.12 vim emacs \
-    chrony \
-    ntpsec \
+    && apt-get -y install curl git pciutils python3-pip ros-${DISTRO}-rmw-cyclonedds-cpp python3.12 vim emacs chrony ntpsec \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/bin/antenna-az-unwrap-state.py
+++ b/bin/antenna-az-unwrap-state.py
@@ -1,9 +1,0 @@
-#!/usr/bin/env python3
-"""Inspect or initialize the NECST Az unwrap state file."""
-
-import sys
-
-from necst.ctrl.antenna.az_unwrap import main
-
-if __name__ == "__main__":
-    sys.exit(main())

--- a/bin/antenna-az-unwrap-state.py
+++ b/bin/antenna-az-unwrap-state.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+"""Inspect or initialize the NECST Az unwrap state file."""
+
+import sys
+
+from necst.ctrl.antenna.az_unwrap import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bin/az-unwrap-state.py
+++ b/bin/az-unwrap-state.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+"""CLI wrapper for Az unwrap state service/local fallback."""
+
+from necst.ctrl.antenna.az_unwrap import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bin/chopper.py
+++ b/bin/chopper.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+"""Move or query the chopper through the unified `necst` CLI."""
+
+import sys
+
+from necst.core.emergency import main_chopper
+
+if __name__ == "__main__":
+    sys.exit(main_chopper())

--- a/bin/console-check.py
+++ b/bin/console-check.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Run a smoke check against an already running NECST Operator Console."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any, Optional
+
+
+def _load_console_smoke_module() -> Any:
+    try:
+        from necst.web import console_smoke  # type: ignore
+
+        return console_smoke
+    except Exception:
+        module_path = Path(__file__).resolve().parents[1] / "necst" / "web" / "console_smoke.py"
+        spec = importlib.util.spec_from_file_location("necst.web.console_smoke", module_path)
+        if spec is None or spec.loader is None:
+            raise RuntimeError(f"failed to load console_smoke.py from {module_path}")
+        module = importlib.util.module_from_spec(spec)
+        sys.modules.setdefault("necst.web.console_smoke", module)
+        spec.loader.exec_module(module)
+        return module
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Read-only smoke check for a running NECST Operator Console"
+    )
+    parser.add_argument(
+        "--url",
+        default="http://127.0.0.1:8092/",
+        help="operator console base URL",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=3.0,
+        help="per-request timeout [s]",
+    )
+    parser.add_argument(
+        "--skip-action-self-check",
+        action="store_true",
+        help="do not POST action=self_check to /api/action",
+    )
+    parser.add_argument(
+        "--fail-on-warning",
+        action="store_true",
+        help="exit non-zero when warnings are present",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="print full JSON result instead of a compact report",
+    )
+    args = parser.parse_args(argv)
+
+    console_smoke = _load_console_smoke_module()
+    result = console_smoke.run_smoke_test(
+        url=str(args.url),
+        timeout=float(args.timeout),
+        include_action_self_check=not bool(args.skip_action_self_check),
+        fail_on_warning=bool(args.fail_on_warning),
+    )
+    if args.json:
+        print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+    else:
+        console_smoke.print_smoke_report(result)
+    return 0 if bool(result.get("ok")) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bin/console-demo.py
+++ b/bin/console-demo.py
@@ -1408,7 +1408,10 @@ function actualOperationFromStatus(data) {
   const calActive = sys === 'calibrating' || (!finalOrIdle && manual === 'calibration') || (!finalOrIdle && (task.includes('rsky') || task.includes('skydip'))) || (!finalOrIdle && processCategoryActive(data, 'calibration'));
   const explicitTrackingActive = task.includes('target tracking');
   const atTargetIdle = Boolean((data.mount_target_reached || data.mount_hold_at_target) && data.motion_live_active === false);
-  const mountActive = !atTargetIdle && (manual === 'moving' || (manual === 'tracking' && !explicitTrackingActive) || task.includes('mount move') || task.includes('manual mount'));
+  const commandTargetReached = mountPendingReached(data || {}, {kind: 'mount', targetAz: data.command_az, targetEl: data.command_el});
+  const commandTargetPending = Boolean(data.operator_mount_command_pending)
+    || (statusHasCommand(data || {}) && !commandTargetReached && !Boolean(data.operator_safety_release_idle));
+  const mountActive = !atTargetIdle && (commandTargetPending || manual === 'moving' || (manual === 'tracking' && !explicitTrackingActive) || task.includes('mount move') || task.includes('manual mount'));
   const trackingActive = !atTargetIdle && (explicitTrackingActive || manual === 'target tracking');
   if (obsActive) {
     return {phase: 'running', kind: 'observation', label: 'OBSERVATION RUNNING', detail: 'Observation execution is confirmed by status/progress/launcher state.'};

--- a/bin/console-demo.py
+++ b/bin/console-demo.py
@@ -1026,6 +1026,25 @@ function operationFromExclusiveStartGuard(data) {
     detail: `${message} was accepted ${age.toFixed(1)} s ago; waiting for status confirmation. This may have been started from another browser or before this page was reloaded.`
   };
 }
+function statusHasCommand(data) {
+  return finiteStatusNumber((data || {}).command_az) && finiteStatusNumber((data || {}).command_el);
+}
+function safetyReleaseLooksIdle(data, ageSec) {
+  data = data || {};
+  const sys = lowerText(data.state || 'idle');
+  const finalOrIdle = ['idle', 'finished', 'aborted', 'error', 'failed', 'unknown'].includes(sys);
+  if (!finalOrIdle || statusHasCommand(data)) return false;
+  if (data.operator_safety_release_idle) return true;
+  const src = lowerText(data.motion_live_source || '');
+  // Backend versions before this patch may keep stale SKY/moving or
+  // encoder-delta hysteresis after STOP.  STOP/ABORT are release requests, so
+  // once the command is gone and the lifecycle is final/idle, do not let the UI
+  // remain in STOP REQUESTED until ATTENTION.  Use a short grace to avoid
+  // flipping READY while a command topic is still disappearing.
+  if (ageSec >= 1.5 && src !== 'encoder_delta') return true;
+  if (ageSec >= 3.0) return true;
+  return false;
+}
 function actualOperationFromStatus(data) {
   data = data || {};
   const sys = lowerText(data.state || 'idle');
@@ -1085,9 +1104,14 @@ function deriveOperationState(data) {
     // than snapping the banner back to RUNNING.  External CLI stop/abort still
     // clears this as soon as /api/status reports READY.
     if (isSafetyPending) {
-      if (actual.phase === 'ready') {
+      if (actual.phase === 'ready' || safetyReleaseLooksIdle(data || {}, ageSec)) {
         state.pendingOperation = null;
-        return actual;
+        return {
+          phase: 'ready',
+          kind: 'idle',
+          label: 'READY',
+          detail: 'STOP/ABORT release is complete for the operator console: command output is gone and the system lifecycle is final/idle.'
+        };
       }
       if (ageSec > PENDING_ATTENTION_SEC) {
         return {

--- a/bin/console-demo.py
+++ b/bin/console-demo.py
@@ -124,6 +124,37 @@ small { color: var(--faint); }
 .badge.warn { border-color: rgba(242,204,96,0.55); color: var(--warn); }
 .badge.bad { border-color: rgba(255,107,107,0.55); color: var(--bad); }
 .badge.info { border-color: rgba(122,162,255,0.55); color: var(--accent2); }
+.system-banner {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: center;
+  margin: 0 0 12px;
+  padding: 12px 14px;
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  background: rgba(17, 24, 44, 0.94);
+  box-shadow: 0 10px 28px var(--shadow);
+}
+.system-banner .main { min-width: 0; }
+.system-banner .label { font-size: 16px; font-weight: 900; letter-spacing: 0.02em; }
+.system-banner .detail { margin-top: 2px; color: var(--muted); font-size: 12px; }
+.system-banner .safe { color: var(--faint); font-size: 12px; text-align: right; }
+.system-banner.ready { border-color: rgba(86,211,100,0.40); }
+.system-banner.starting { border-color: rgba(122,162,255,0.65); background: rgba(31, 50, 91, 0.94); }
+.system-banner.running { border-color: rgba(242,204,96,0.75); background: rgba(73, 58, 20, 0.94); }
+.system-banner.attention { border-color: rgba(255,107,107,0.80); background: rgba(76, 31, 36, 0.96); }
+.card.op-starting { border-color: rgba(122,162,255,0.75); box-shadow: 0 0 0 2px rgba(122,162,255,0.13), 0 10px 28px var(--shadow); }
+.card.op-running { border-color: rgba(242,204,96,0.85); box-shadow: 0 0 0 2px rgba(242,204,96,0.17), 0 10px 28px var(--shadow); }
+.card.op-attention { border-color: rgba(255,107,107,0.85); box-shadow: 0 0 0 2px rgba(255,107,107,0.16), 0 10px 28px var(--shadow); }
+.card.op-running > .card-head, .card.op-running > .card-body { background: rgba(242,204,96,0.055); }
+.card.op-starting > .card-head, .card.op-starting > .card-body { background: rgba(122,162,255,0.050); }
+.card.op-attention > .card-head, .card.op-attention > .card-body { background: rgba(255,107,107,0.060); }
+.operation-subcard.op-running { border-color: rgba(242,204,96,0.85); }
+.operation-subcard.op-starting { border-color: rgba(122,162,255,0.75); }
+.operation-subcard.op-attention { border-color: rgba(255,107,107,0.85); }
+button.busy:not(:disabled) { border-color: rgba(242,204,96,0.85); background: #4b3a16; }
+button.pending:not(:disabled) { border-color: rgba(122,162,255,0.75); background: #203865; }
 .stop-button {
   min-width: 126px;
   min-height: 48px;
@@ -415,6 +446,13 @@ summary { cursor: pointer; color: var(--muted); }
   </div>
 </header>
 <main class="page">
+  <div class="system-banner ready" id="systemBanner" role="status" aria-live="polite">
+    <div class="main">
+      <div class="label" id="systemStateLabel">READY</div>
+      <div class="detail" id="systemStateDetail">No observation, mount move, or calibration is currently confirmed.</div>
+    </div>
+    <div class="safe">STOP and ABORT remain available.</div>
+  </div>
   <div class="main-grid">
     <section class="card" id="observationCard">
       <div class="card-head">
@@ -552,7 +590,7 @@ summary { cursor: pointer; color: var(--muted); }
           <div class="kv"><span>Motion state</span><b id="motionSummary">idle</b></div>
           <div class="kv"><span>Active task</span><b id="taskSummary">none</b></div>
           <div class="kv"><span>Current Az / El</span><b id="posSummary">180.000 / 45.000</b></div>
-          <div class="kv"><span>Command Az / El</span><b id="cmdSummary">none</b></div>
+          <div class="kv"><span>Command Az / El</span><b id="cmdSummary">- / -</b></div>
           <div class="kv"><span>Chopper</span><b id="chopperSummary">OUT / pos 19700</b></div>
         </div>
         <div class="tabs">
@@ -672,7 +710,7 @@ summary { cursor: pointer; color: var(--muted); }
         <div id="calPanel" class="panel">
           <div class="notice" id="calStatusNotice">RSky / SkyDip running state is also shown in the header Active badge.</div>
           <div class="row">
-            <div class="card" style="box-shadow:none">
+            <div class="card operation-subcard" id="rskyCard" style="box-shadow:none">
               <div class="card-head"><h2>RSky</h2><span class="hint">runtime parameters</span></div>
               <div class="card-body">
                 <div class="row">
@@ -683,7 +721,7 @@ summary { cursor: pointer; color: var(--muted); }
                 <button id="runRsky" class="primary">Run RSky</button>
               </div>
             </div>
-            <div class="card" style="box-shadow:none">
+            <div class="card operation-subcard" id="skydipCard" style="box-shadow:none">
               <div class="card-head"><h2>SkyDip</h2><span class="hint">runtime parameters</span></div>
               <div class="card-body">
                 <div class="field"><label for="skydipInteg">integ [s]</label><input id="skydipInteg" value="2" inputmode="decimal"></div>
@@ -811,6 +849,10 @@ const state = {
   capabilities: {},
   liveActions: {guarded: false, enabled: false},
   lastSelfCheck: null,
+  lastStatus: null,
+  pendingOperation: null,
+  currentOperation: {phase: 'ready', kind: 'idle', label: 'READY'},
+  lastActionResponse: null,
   demoObsBrowser: false,
   selectedObsPath: ""
 };
@@ -821,6 +863,9 @@ function numberOrNaN(value) {
   return Number(value);
 }
 function finite(value) { return Number.isFinite(value); }
+function finiteStatusNumber(value) {
+  return value !== null && value !== undefined && String(value).trim() !== '' && Number.isFinite(Number(value));
+}
 
 function parseSexagesimalAngle(value, isRa) {
   const raw = String(value || '').trim();
@@ -874,9 +919,297 @@ function setDisabled(id, disabled) {
   const el = qs(id);
   if (el) el.disabled = Boolean(disabled);
 }
-function formatMaybeNumber(value, digits=3) {
-  const n = Number(value);
-  return Number.isFinite(n) ? n.toFixed(digits) : String(value ?? 'unknown');
+function formatMaybeNumber(value, digits=4) {
+  return finiteStatusNumber(value) ? Number(value).toFixed(digits) : '-';
+}
+const PENDING_ATTENTION_SEC = 15;
+function lowerText(value) { return String(value ?? '').trim().toLowerCase(); }
+function processCategoryActive(data, category) {
+  const records = Array.isArray(data && data.processes) ? data.processes : [];
+  const want = lowerText(category);
+  return records.some(r => {
+    const active = Boolean(r && (r.active || r.is_active || r.status === 'running' || r.status === 'active'));
+    if (!active) return false;
+    const haystack = [r.category, r.kind, r.name, r.action, r.label, r.command].map(lowerText).join(' ');
+    return haystack === want || haystack.includes(want);
+  });
+}
+function processMatchesKind(record, kind) {
+  if (!record || !kind) return false;
+  const k = lowerText(kind);
+  const haystack = [record.category, record.kind, record.name, record.action, record.label, record.command].map(lowerText).join(' ');
+  if (k === 'observation') return haystack.includes('observation') || haystack.includes('start_observation');
+  if (k === 'rsky') return haystack.includes('rsky');
+  if (k === 'skydip') return haystack.includes('skydip');
+  if (k === 'calibration') return haystack.includes('calibration') || haystack.includes('rsky') || haystack.includes('skydip');
+  return haystack.includes(k);
+}
+function matchingRecentFinalProcess(data, pending) {
+  if (!pending || !['observation', 'rsky', 'skydip', 'calibration'].includes(pending.kind)) return null;
+  const records = Array.isArray(data && data.processes) ? data.processes : [];
+  const startedAt = Number(pending.startedAt || 0) / 1000.0;
+  const candidates = records.filter(r => {
+    if (!processMatchesKind(r, pending.kind)) return false;
+    const status = lowerText(r.status);
+    if (!['exited', 'failed', 'lost', 'unknown'].includes(status)) return false;
+    const recStart = Number(r.started_at || 0);
+    if (Number.isFinite(startedAt) && startedAt > 0 && Number.isFinite(recStart) && recStart + 2.0 < startedAt) return false;
+    return true;
+  });
+  if (!candidates.length) return null;
+  candidates.sort((a, b) => Number(b.started_at || 0) - Number(a.started_at || 0));
+  return candidates[0];
+}
+const MOUNT_REACHED_TOL_DEG = 2.0e-4;
+function mountPendingReached(data, pending) {
+  if (!pending || pending.kind !== 'mount') return false;
+  const targetAz = Number(pending.targetAz);
+  const targetEl = Number(pending.targetEl);
+  const currentAz = Number(data && data.az);
+  const currentEl = Number(data && data.el);
+  return Number.isFinite(targetAz) && Number.isFinite(targetEl)
+    && Number.isFinite(currentAz) && Number.isFinite(currentEl)
+    && Math.abs(currentAz - targetAz) <= MOUNT_REACHED_TOL_DEG
+    && Math.abs(currentEl - targetEl) <= MOUNT_REACHED_TOL_DEG;
+}
+function exclusiveStartActionKind(action) {
+  const a = lowerText(action || '');
+  if (a === 'start_observation') return 'observation';
+  if (a === 'mount_move') return 'mount';
+  if (a === 'run_rsky') return 'rsky';
+  if (a === 'run_skydip') return 'skydip';
+  if (a === 'start_tracking') return 'tracking';
+  return '';
+}
+function operationFromExclusiveStartGuard(data) {
+  const guard = data && data.exclusive_start_guard;
+  if (!guard || typeof guard !== 'object') return null;
+  const kind = exclusiveStartActionKind(guard.action);
+  if (!kind) return null;
+  const age = Number(guard.age_sec);
+  const limit = Number(guard.guard_sec ?? PENDING_ATTENTION_SEC);
+  if (!Number.isFinite(age) || !Number.isFinite(limit) || age < 0 || age > limit) return null;
+  const text = pendingLabel({kind});
+  const message = String(guard.message || guard.action || 'start command');
+
+  // If this page was reloaded after the command and the launcher already
+  // finished, do not keep showing STARTING.  A clean quick exit returns to
+  // READY; a failed exit becomes ATTENTION so the operator is guided to logs.
+  const started = Number(guard.started_at || 0);
+  const finalProcess = matchingRecentFinalProcess(data || {}, {kind, startedAt: started > 0 ? started * 1000.0 : 0});
+  if (finalProcess) {
+    const rc = finalProcess.returncode;
+    const okFinal = rc === 0 || rc === '0';
+    if (okFinal) {
+      return {
+        phase: 'ready',
+        kind: 'idle',
+        label: 'READY',
+        detail: `${message} finished before this status view confirmed RUNNING; launcher exited normally.`
+      };
+    }
+    return {
+      phase: 'attention',
+      kind,
+      label: 'ATTENTION',
+      detail: `${message} launcher ended with status=${finalProcess.status || 'unknown'}, returncode=${rc ?? 'unknown'}. Check launcher logs before starting again.`
+    };
+  }
+
+  return {
+    phase: 'starting',
+    kind,
+    label: text.label,
+    detail: `${message} was accepted ${age.toFixed(1)} s ago; waiting for status confirmation. This may have been started from another browser or before this page was reloaded.`
+  };
+}
+function actualOperationFromStatus(data) {
+  data = data || {};
+  const sys = lowerText(data.state || 'idle');
+  const manual = lowerText(data.manual_state || 'idle');
+  const task = lowerText(data.active_task || 'none');
+  const progress = data.progress || {};
+  const finalOrIdle = ['idle', 'finished', 'aborted', 'error', 'failed'].includes(sys);
+  const obsActive = sys === 'observing' || (!finalOrIdle && task.includes('observation')) || (!finalOrIdle && Boolean(progress.observation_running)) || processCategoryActive(data, 'observation');
+  const calActive = sys === 'calibrating' || (!finalOrIdle && manual === 'calibration') || (!finalOrIdle && (task.includes('rsky') || task.includes('skydip'))) || processCategoryActive(data, 'calibration');
+  const mountActive = manual === 'moving' || task.includes('mount move') || task.includes('manual mount');
+  const trackingActive = manual === 'tracking' || task.includes('target tracking');
+  if (obsActive) {
+    return {phase: 'running', kind: 'observation', label: 'OBSERVATION RUNNING', detail: 'Observation execution is confirmed by status/progress/launcher state.'};
+  }
+  if (calActive) {
+    const kind = task.includes('skydip') ? 'skydip' : (task.includes('rsky') ? 'rsky' : 'calibration');
+    const label = kind === 'skydip' ? 'SKYDIP RUNNING' : (kind === 'rsky' ? 'RSKY RUNNING' : 'CALIBRATION RUNNING');
+    return {phase: 'running', kind, label, detail: 'Calibration execution is confirmed by status or launcher state.'};
+  }
+  if (mountActive) {
+    return {phase: 'running', kind: 'mount', label: 'MOUNT MOVING', detail: 'Mount motion is confirmed by live/manual status.'};
+  }
+  if (trackingActive) {
+    return {phase: 'running', kind: 'tracking', label: 'TARGET TRACKING', detail: 'Target tracking is active. Use STOP to stop antenna motion.'};
+  }
+  const guardedStart = operationFromExclusiveStartGuard(data);
+  if (guardedStart) return guardedStart;
+  return {phase: 'ready', kind: 'idle', label: 'READY', detail: 'No observation, mount move, or calibration is currently confirmed.'};
+}
+function pendingLabel(pending) {
+  if (!pending) return {label: 'STARTING...', detail: 'Command was accepted by the console; waiting for status confirmation.'};
+  const map = {
+    observation: ['STARTING OBSERVATION...', 'Start was accepted; waiting until observation status/progress confirms running.'],
+    mount: ['MOUNT COMMAND SENT', 'Mount command was accepted; waiting for motion confirmation.'],
+    rsky: ['STARTING RSKY...', 'RSky command was accepted; waiting for calibration status/launcher confirmation.'],
+    skydip: ['STARTING SKYDIP...', 'SkyDip command was accepted; waiting for calibration status/launcher confirmation.'],
+    tracking: ['STARTING TRACKING...', 'Tracking command was accepted; waiting for tracking status confirmation.'],
+    stop: ['STOP REQUESTED...', 'STOP was sent; waiting for idle status.'],
+    abort: ['ABORT REQUESTED...', 'ABORT was sent; waiting for idle status.']
+  };
+  const pair = map[pending.kind] || ['STARTING...', 'Command was accepted; waiting for status confirmation.'];
+  return {label: pair[0], detail: pair[1]};
+}
+function deriveOperationState(data) {
+  const actual = actualOperationFromStatus(data || {});
+  const pending = state.pendingOperation;
+  if (pending) {
+    const ageSec = (Date.now() - Number(pending.startedAt || Date.now())) / 1000;
+    const text = pendingLabel(pending);
+    const isSafetyPending = pending.kind === 'stop' || pending.kind === 'abort';
+
+    // STOP/ABORT are user intent, not normal START operations.  If the real
+    // status is still RUNNING immediately after a safety button was pressed,
+    // show the operator that the stop/abort request is being waited on rather
+    // than snapping the banner back to RUNNING.  External CLI stop/abort still
+    // clears this as soon as /api/status reports READY.
+    if (isSafetyPending) {
+      if (actual.phase === 'ready') {
+        state.pendingOperation = null;
+        return actual;
+      }
+      if (ageSec > PENDING_ATTENTION_SEC) {
+        return {
+          phase: 'attention',
+          kind: pending.kind,
+          label: 'ATTENTION',
+          detail: `${text.detail} The system is still not idle after ${Math.round(ageSec)} s. Check progress, launcher logs, and telemetry; STOP/ABORT remain available.`
+        };
+      }
+      return {phase: 'starting', kind: pending.kind, label: text.label, detail: text.detail};
+    }
+
+    const finalProcess = matchingRecentFinalProcess(data || {}, pending);
+    if (finalProcess && actual.phase === 'ready') {
+      state.pendingOperation = null;
+      const rc = finalProcess.returncode;
+      const okFinal = rc === 0 || rc === '0';
+      if (okFinal) {
+        return {phase: 'ready', kind: 'idle', label: 'READY', detail: `${text.label.replace(/\.\.\.$/, '')} finished before the next status update; launcher exited normally.`};
+      }
+      return {phase: 'attention', kind: pending.kind, label: 'ATTENTION', detail: `${text.label.replace(/\.\.\.$/, '')} launcher ended with status=${finalProcess.status || 'unknown'}, returncode=${rc ?? 'unknown'}. Check launcher logs.`};
+    }
+    if (pending.kind === 'mount' && actual.phase === 'ready' && mountPendingReached(data || {}, pending)) {
+      state.pendingOperation = null;
+      return {phase: 'ready', kind: 'idle', label: 'READY', detail: 'Mount command is complete or no motion was needed; Current Az/El matches the requested target.'};
+    }
+    if (actual.phase === 'running') {
+      if (pending.kind === actual.kind || pending.kind === 'observation' || pending.kind === 'rsky' || pending.kind === 'skydip' || pending.kind === 'mount' || pending.kind === 'tracking') {
+        state.pendingOperation = null;
+      }
+      return actual;
+    }
+    if (ageSec > PENDING_ATTENTION_SEC) {
+      return {
+        phase: 'attention',
+        kind: pending.kind,
+        label: 'ATTENTION',
+        detail: pending.kind === 'mount'
+          ? `${text.detail} No motion confirmation after ${Math.round(ageSec)} s. The mount may already be at the target or the motion may have finished quickly; check Current Az/El, telemetry, or use STOP if needed.`
+          : `${text.detail} No confirmation after ${Math.round(ageSec)} s. Check telemetry, progress, or use STOP/ABORT if needed.`
+      };
+    }
+    return {phase: 'starting', kind: pending.kind, label: text.label, detail: text.detail};
+  }
+  return actual;
+}
+function beginPendingOperation(kind, action, details={}) {
+  state.pendingOperation = Object.assign({kind, action, startedAt: Date.now()}, details || {});
+  const op = deriveOperationState(state.lastStatus || {});
+  applyOperationUi(op);
+}
+function clearPendingOperation() {
+  state.pendingOperation = null;
+  applyOperationUi(deriveOperationState(state.lastStatus || {}));
+}
+function setCardState(id, mode) {
+  const el = qs(id);
+  if (!el) return;
+  el.classList.remove('op-starting', 'op-running', 'op-attention');
+  if (mode && mode !== 'ready') el.classList.add('op-' + mode);
+}
+function setButtonText(id, text) {
+  const el = qs(id);
+  if (el) el.textContent = text;
+}
+function setButtonBusyClass(id, mode) {
+  const el = qs(id);
+  if (!el) return;
+  el.classList.remove('busy', 'pending');
+  if (mode === 'running') el.classList.add('busy');
+  if (mode === 'starting') el.classList.add('pending');
+}
+function operationLocksActive(op) {
+  return Boolean(op && ['starting', 'running', 'attention'].includes(op.phase));
+}
+function applyOperationUi(op) {
+  op = op || {phase: 'ready', kind: 'idle', label: 'READY', detail: ''};
+  state.currentOperation = op;
+  const banner = qs('systemBanner');
+  if (banner) {
+    banner.classList.remove('ready', 'starting', 'running', 'attention');
+    banner.classList.add(op.phase === 'ready' ? 'ready' : op.phase);
+  }
+  setText('systemStateLabel', op.label || 'READY');
+  setText('systemStateDetail', op.detail || '');
+  const isObs = op.kind === 'observation';
+  const isMount = op.kind === 'mount';
+  const isCal = ['rsky', 'skydip', 'calibration'].includes(op.kind);
+  setCardState('observationCard', isObs ? op.phase : 'ready');
+  setCardState('manualCard', (isMount || isCal || op.kind === 'tracking') ? op.phase : 'ready');
+  setCardState('rskyCard', (op.kind === 'rsky' || op.kind === 'calibration') ? op.phase : 'ready');
+  setCardState('skydipCard', (op.kind === 'skydip' || op.kind === 'calibration') ? op.phase : 'ready');
+  setButtonText('startObs', isObs ? (op.phase === 'running' ? 'Running...' : (op.phase === 'starting' ? 'Starting...' : (op.phase === 'attention' ? 'Attention' : 'Start observation'))) : 'Start observation');
+  setButtonText('moveMount', isMount ? (op.phase === 'running' ? 'Moving...' : (op.phase === 'starting' ? 'Command sent...' : (op.phase === 'attention' ? 'Check mount' : 'Move mount'))) : 'Move mount');
+  setButtonText('runRsky', op.kind === 'rsky' ? (op.phase === 'running' ? 'RSky running...' : (op.phase === 'starting' ? 'Starting RSky...' : (op.phase === 'attention' ? 'Attention' : 'Run RSky'))) : 'Run RSky');
+  setButtonText('runSkydip', op.kind === 'skydip' ? (op.phase === 'running' ? 'SkyDip running...' : (op.phase === 'starting' ? 'Starting SkyDip...' : (op.phase === 'attention' ? 'Attention' : 'Run SkyDip'))) : 'Run SkyDip');
+  setButtonBusyClass('startObs', isObs ? op.phase : 'ready');
+  setButtonBusyClass('moveMount', isMount ? op.phase : 'ready');
+  setButtonBusyClass('runRsky', op.kind === 'rsky' ? op.phase : 'ready');
+  setButtonBusyClass('runSkydip', op.kind === 'skydip' ? op.phase : 'ready');
+  enforceOperationLocks();
+}
+function enforceOperationLocks() {
+  const op = state.currentOperation || {phase: 'ready', kind: 'idle'};
+  const locked = operationLocksActive(op);
+  const lockIds = [
+    'startObs', 'checkObs', 'dryRunObs', 'openObsChooser', 'previewCurrentObs',
+    'recentDir', 'obsFilename', 'obsMode', 'obsChannel', 'obsPreview', 'obsFile',
+    'moveMount', 'dryRunMount', 'startTracking', 'runRsky', 'runSkydip',
+    'rskyN', 'rskyInteg', 'rskyCh', 'skydipInteg', 'skydipCh', 'skydipTpRange'
+  ];
+  const formOnlyIds = [
+    'openObsChooser', 'previewCurrentObs', 'recentDir', 'obsFilename', 'obsMode',
+    'obsChannel', 'obsPreview', 'obsFile', 'rskyN', 'rskyInteg', 'rskyCh',
+    'skydipInteg', 'skydipCh', 'skydipTpRange'
+  ];
+  if (locked) {
+    lockIds.forEach(id => setDisabled(id, true));
+  } else {
+    // Validation/capability functions own the actual Start buttons.  Restore
+    // only form and chooser controls here so a previous RUNNING lock does not
+    // leave the UI stuck after an external STOP/ABORT.
+    formOnlyIds.forEach(id => setDisabled(id, false));
+  }
+  // STOP and ABORT are safety actions and must remain clickable even if status is stale.
+  setDisabled('stopButton', false);
+  setDisabled('abortObs', false);
 }
 function capabilityText(caps) {
   if (!caps || typeof caps !== 'object') return 'unknown';
@@ -1062,21 +1395,53 @@ function applyCapabilities(data) {
     setDisabled('dryRunMount', true);
   }
 }
-async function api(action, params={}) {
-  const resp = await fetch('/api/action', {
-    method: 'POST',
-    headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify({action, params, session_id: state.sessionId})
-  });
-  const data = await resp.json();
+async function api(action, params={}, pendingKind=null) {
+  if (pendingKind) {
+    const pendingDetails = (typeof pendingKind === 'object') ? pendingKind : {kind: pendingKind};
+    beginPendingOperation(pendingDetails.kind, action, pendingDetails);
+  }
+  let data;
+  try {
+    const resp = await fetch('/api/action', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({action, params, session_id: state.sessionId})
+    });
+    data = await resp.json();
+  } catch (err) {
+    data = {ok: false, action, reason: String(err && err.message ? err.message : err)};
+  }
+  state.lastActionResponse = data;
+  if (!data.ok || data.dry_run) {
+    clearPendingOperation();
+  }
   await refresh();
   return data;
 }
+function renderStatusRefreshError(err) {
+  const message = String(err && err.message ? err.message : err);
+  const op = {
+    phase: 'attention',
+    kind: 'status',
+    label: 'ATTENTION',
+    detail: 'Console status refresh failed. The displayed state may be stale; STOP and ABORT remain available. Error: ' + message
+  };
+  state.currentOperation = op;
+  applyOperationUi(op);
+  const badges = qs('statusBadges');
+  if (badges) badges.innerHTML = `<span class="badge bad">Status refresh failed</span> <span class="badge warn">display may be stale</span>`;
+}
 async function refresh() {
-  const resp = await fetch('/api/status');
-  const data = await resp.json();
-  renderStatus(data);
-  renderLog(data.log || []);
+  try {
+    const resp = await fetch('/api/status');
+    if (!resp.ok) throw new Error('HTTP ' + resp.status);
+    const data = await resp.json();
+    state.lastStatus = data;
+    renderStatus(data);
+    renderLog(data.log || []);
+  } catch (err) {
+    renderStatusRefreshError(err);
+  }
 }
 async function loadServerObsRoots() {
   const rootSel = qs('serverObsRoot');
@@ -1275,6 +1640,12 @@ function closeObsChooser() {
 }
 
 function renderStatus(data) {
+  state.lastStatus = data || {};
+  const operation = deriveOperationState(state.lastStatus);
+  // Store the freshly derived state before validation functions run, so a
+  // just-finished external STOP/ABORT does not leave controls disabled by the
+  // previous RUNNING lock.
+  state.currentOperation = operation;
   const heldByMe = data.authority && data.authority.session_id === state.sessionId;
   state.siteLimits = data.mount_limits || state.siteLimits;
   state.capabilities = data.capabilities || state.capabilities || {};
@@ -1287,7 +1658,7 @@ function renderStatus(data) {
   const authClass = data.authority && data.authority.held ? (heldByMe ? 'ok' : 'warn') : 'info';
   const taskClass = data.active_task && data.active_task !== 'none' ? 'ok' : 'info';
   const motionClass = (data.manual_state === 'moving' || data.manual_state === 'tracking' || data.manual_state === 'calibration' || data.manual_state === 'observing sequence') ? 'ok' : (data.manual_state === 'stopped' ? 'warn' : 'info');
-  const cmd = (finite(Number(data.command_az)) && finite(Number(data.command_el))) ? `${Number(data.command_az).toFixed(3)} / ${Number(data.command_el).toFixed(3)}` : 'none';
+  const cmd = (finiteStatusNumber(data.command_az) && finiteStatusNumber(data.command_el)) ? `${Number(data.command_az).toFixed(4)} / ${Number(data.command_el).toFixed(4)}` : '- / -';
   const progressClass = data.progress && data.progress.running ? 'ok' : 'info';
   const progressText = data.progress && data.progress.running ? 'Progress: running' : 'Progress: not started';
   const counts = data.process_counts || {};
@@ -1307,13 +1678,13 @@ function renderStatus(data) {
   ].join('');
   qs('authorityButton').textContent = heldByMe ? 'Release authority' : 'Acquire authority';
   qs('authorityButton').disabled = Boolean(state.liveActions.guarded) && !heldByMe;
-  qs('obsStateBadge').textContent = data.state;
-  qs('obsStateBadge').className = 'badge ' + (data.state === 'observing' ? 'ok' : (data.state === 'calibrating' ? 'warn' : 'info'));
+  qs('obsStateBadge').textContent = operation.kind === 'observation' ? operation.label : data.state;
+  qs('obsStateBadge').className = 'badge ' + (operation.kind === 'observation' ? (operation.phase === 'attention' ? 'bad' : (operation.phase === 'running' ? 'warn' : 'info')) : (data.state === 'observing' ? 'ok' : (data.state === 'calibrating' ? 'warn' : 'info')));
   // ABORT is a safety action.  It must stay clickable even when the
   // observation state cannot be inferred from status/progress yet.
   qs('abortObs').disabled = false;
-  qs('manualBadge').textContent = data.manual_state;
-  qs('manualBadge').className = 'badge ' + motionClass;
+  qs('manualBadge').textContent = ['mount', 'tracking', 'rsky', 'skydip', 'calibration'].includes(operation.kind) ? operation.label : data.manual_state;
+  qs('manualBadge').className = 'badge ' + (operation.phase === 'attention' ? 'bad' : (operation.phase === 'running' ? 'warn' : motionClass));
   qs('motionSummary').textContent = data.manual_state;
   qs('taskSummary').textContent = data.active_task || 'none';
   qs('posSummary').textContent = `${formatMaybeNumber(data.az)} / ${formatMaybeNumber(data.el)}`;
@@ -1323,13 +1694,21 @@ function renderStatus(data) {
   qs('chopperPos').textContent = data.chopper.position;
   qs('chopperAge').textContent = data.chopper.age || 'live demo';
   qs('stopTracking').disabled = data.manual_state !== 'tracking';
-  qs('calStatusNotice').textContent = `Current active task: ${data.active_task || 'none'}`;
-  qs('calStatusNotice').className = 'notice ' + (data.state === 'calibrating' ? 'ok' : '');
+  if (['rsky', 'skydip', 'calibration'].includes(operation.kind)) {
+    qs('calStatusNotice').textContent = operation.label + ': ' + operation.detail;
+    qs('calStatusNotice').className = 'notice ' + (operation.phase === 'attention' ? 'bad' : 'warn');
+  } else {
+    qs('calStatusNotice').textContent = `Calibration state: standby. Current active task: ${data.active_task || 'none'}`;
+    qs('calStatusNotice').className = 'notice';
+  }
   renderRuntime(data);
   applyCapabilities(data);
   // Capabilities/live guard arrive via /api/status after page load.  Re-run
-  // obs validation so Start does not remain disabled until Check is pressed.
+  // validation so Start buttons do not remain disabled until a user edits a field.
   validateObs();
+  validateMount();
+  validateTarget();
+  applyOperationUi(operation);
 }
 function renderLog(items) {
   qs('log').innerHTML = items.map(item => {
@@ -1408,6 +1787,7 @@ function validateObs() {
     qs('startObs').disabled = true;
     state.obsChecked = false;
     updateObsRunPath();
+    enforceOperationLocks();
     return false;
   }
   qs('checkObs').disabled = false;
@@ -1420,6 +1800,7 @@ function validateObs() {
   const startText = liveGuarded ? 'Live write guard is active; Start is disabled. Use --action-mode dry-run for normal validation, or restart without --guard-live-actions for live operation.' : (startCapable ? 'Start is enabled; Check and Dry run are optional. Start will validate again on the server.' : 'Observation start is disabled by site capability.');
   setNotice(qs('obsValidation'), startCapable ? (state.obsChecked ? 'ok' : 'warn') : 'bad', checkText + previewText + startText);
   updateObsRunPath();
+  enforceOperationLocks();
   return true;
 }
 function validateMount() {
@@ -1447,6 +1828,7 @@ function validateMount() {
   else setNotice(qs('mountValidation'), 'bad', 'Not movable: ' + reasons.join(' / '));
   qs('moveMount').disabled = !ok || liveGuarded;
   qs('dryRunMount').disabled = !ok;
+  enforceOperationLocks();
   return {ok, reasons, az, el};
 }
 function validateTarget() {
@@ -1479,6 +1861,7 @@ function validateTarget() {
   if (ok && liveGuarded) setNotice(qs('targetValidation'), 'warn', 'Target is valid, but live tracking is guarded by --guard-live-actions.');
   else setNotice(qs('targetValidation'), ok ? 'ok' : 'bad', ok ? 'Target tracking can be started. Stop it with STOP.' : 'Cannot track: ' + reasons.join(' / '));
   qs('startTracking').disabled = !ok || liveGuarded;
+  enforceOperationLocks();
   return {ok, reasons};
 }
 function updateTargetFields() {
@@ -1589,10 +1972,10 @@ qs('dryRunObs').addEventListener('click', async () => {
 });
 qs('startObs').addEventListener('click', async () => {
   if (!validateObs()) return;
-  await api('start_observation', {mode: qs('obsMode').value, file: qs('obsPath').value, channel: qs('obsChannel').value});
+  await api('start_observation', {mode: qs('obsMode').value, file: qs('obsPath').value, channel: qs('obsChannel').value}, 'observation');
 });
 qs('abortObs').addEventListener('click', async () => {
-  if (confirm('Abort current observation and request recorder/gate/progress cleanup?')) await api('abort_observation');
+  if (confirm('Abort current observation and request recorder/gate/progress cleanup?')) await api('abort_observation', {}, 'abort');
 });
 qs('authorityButton').addEventListener('click', async () => {
   const resp = await fetch('/api/status');
@@ -1600,11 +1983,11 @@ qs('authorityButton').addEventListener('click', async () => {
   const heldByMe = data.authority && data.authority.session_id === state.sessionId;
   await api(heldByMe ? 'release_authority' : 'acquire_authority');
 });
-qs('stopButton').addEventListener('click', async () => { await api('stop'); });
+qs('stopButton').addEventListener('click', async () => { await api('stop', {}, 'stop'); });
 qs('moveMount').addEventListener('click', async () => {
   const v = validateMount();
   if (!v.ok) return;
-  await api('mount_move', {az: qs('mountAz').value, el: qs('mountEl').value});
+  await api('mount_move', {az: qs('mountAz').value, el: qs('mountEl').value}, {kind: 'mount', targetAz: Number(qs('mountAz').value), targetEl: Number(qs('mountEl').value)});
 });
 qs('dryRunMount').addEventListener('click', async () => {
   const v = validateMount();
@@ -1622,17 +2005,17 @@ qs('startTracking').addEventListener('click', async () => {
     offset_x_arcsec: qs('offsetX').value,
     offset_y_arcsec: qs('offsetY').value,
     cos_correction: qs('cosCorrection').value
-  });
+  }, 'tracking');
 });
-qs('stopTracking').addEventListener('click', async () => { await api('stop_tracking'); });
+qs('stopTracking').addEventListener('click', async () => { await api('stop_tracking', {}, 'stop'); });
 qs('chopperIn').addEventListener('click', () => api('chopper_in'));
 qs('chopperOut').addEventListener('click', () => api('chopper_out'));
 qs('chopperStatus').addEventListener('click', () => api('chopper_status'));
 qs('chopperAlarmReset').addEventListener('click', () => api('chopper_alarm_reset'));
 qs('chopperHome').addEventListener('click', () => api('chopper_home'));
 qs('chopperRecover').addEventListener('click', () => api('chopper_recover'));
-qs('runRsky').addEventListener('click', () => api('run_rsky', {n: qs('rskyN').value, integ: qs('rskyInteg').value, ch: qs('rskyCh').value}));
-qs('runSkydip').addEventListener('click', () => api('run_skydip', {integ: qs('skydipInteg').value, ch: qs('skydipCh').value, tp_range: qs('skydipTpRange').value}));
+qs('runRsky').addEventListener('click', () => api('run_rsky', {n: qs('rskyN').value, integ: qs('rskyInteg').value, ch: qs('rskyCh').value}, 'rsky'));
+qs('runSkydip').addEventListener('click', () => api('run_skydip', {integ: qs('skydipInteg').value, ch: qs('skydipCh').value, tp_range: qs('skydipTpRange').value}, 'skydip'));
 qs('clearLog').addEventListener('click', () => api('clear_log'));
 qs('refreshRuntime').addEventListener('click', refresh);
 qs('loadOperatorLog').addEventListener('click', readOperatorLog);
@@ -1748,9 +2131,25 @@ class DemoState:
     authority_session_id: Optional[str] = None
     chopper_state: str = "OUT"
     chopper_position: int = 19700
+    exclusive_start_action: Optional[str] = None
+    exclusive_start_started_at: Optional[float] = None
+    exclusive_start_message: str = ""
     log: List[LogEntry] = field(default_factory=list)
 
+    def prune_exclusive_start_guard(self) -> None:
+        if self.exclusive_start_started_at is None:
+            return
+        try:
+            age = max(0.0, time.time() - float(self.exclusive_start_started_at))
+        except Exception:
+            age = 999.0
+        if age > EXCLUSIVE_START_STATUS_SEC:
+            self.exclusive_start_action = None
+            self.exclusive_start_started_at = None
+            self.exclusive_start_message = ""
+
     def to_dict(self) -> Dict[str, Any]:
+        self.prune_exclusive_start_guard()
         return {
             "telescope": self.telescope,
             "progress_url": self.progress_url,
@@ -1776,6 +2175,18 @@ class DemoState:
                 "state": self.chopper_state,
                 "position": self.chopper_position,
                 "age": "live demo",
+            },
+            "exclusive_start_guard": {
+                "action": self.exclusive_start_action,
+                "started_at": self.exclusive_start_started_at,
+                "age_sec": (
+                    max(0.0, time.time() - float(self.exclusive_start_started_at))
+                    if self.exclusive_start_started_at is not None
+                    else None
+                ),
+                "message": self.exclusive_start_message,
+                "guard_sec": EXCLUSIVE_START_STATUS_SEC,
+                "blocking_sec": EXCLUSIVE_START_BLOCK_SEC,
             },
             "log": [entry.__dict__ for entry in self.log[-80:]],
         }
@@ -2190,10 +2601,71 @@ def _with_privilege(server: ConsoleDemoServer, session_id: str, action_text: str
     return f"{action_text} with temporary authority acquire/release"
 
 
+
+EXCLUSIVE_START_ACTIONS = {
+    "mount_move",
+    "start_tracking",
+    "start_observation",
+    "run_rsky",
+    "run_skydip",
+}
+EXCLUSIVE_START_BLOCK_SEC = 3.0
+EXCLUSIVE_START_STATUS_SEC = 15.0
+
+
+def _demo_clear_exclusive_start_guard(state: DemoState) -> None:
+    state.exclusive_start_action = None
+    state.exclusive_start_started_at = None
+    state.exclusive_start_message = ""
+
+
+def _demo_mark_exclusive_start_guard(state: DemoState, action: str, message: str) -> None:
+    if action not in EXCLUSIVE_START_ACTIONS:
+        return
+    state.exclusive_start_action = str(action)
+    state.exclusive_start_started_at = time.time()
+    state.exclusive_start_message = str(message or action)
+
+
+def _demo_active_operation_reason(state: DemoState, requested_action: str) -> Optional[str]:
+    """Reject non-safety start actions while another operation is active.
+
+    Browser-side disabled buttons are helpful, but operators can double-click,
+    keep stale tabs open, or hit the HTTP endpoint directly.  The demo server
+    mirrors the real console guard so the UI never relies on frontend state as
+    the only protection against conflicting starts.
+    """
+
+    if requested_action not in EXCLUSIVE_START_ACTIONS:
+        return None
+    guard_action = str(state.exclusive_start_action or "").strip()
+    guard_started = state.exclusive_start_started_at
+    if guard_action and guard_started is not None:
+        age = max(0.0, time.time() - float(guard_started))
+        if age <= EXCLUSIVE_START_BLOCK_SEC:
+            message = state.exclusive_start_message or guard_action
+            return f"cannot start {requested_action}: {message} was accepted {age:.1f} s ago; wait for READY or use STOP/ABORT"
+        _demo_clear_exclusive_start_guard(state)
+    sys_state = str(state.state or "").strip().lower()
+    manual = str(state.manual_state or "").strip().lower()
+    task = str(state.active_task or "").strip().lower()
+    if sys_state in {"observing", "calibrating"}:
+        return f"cannot start {requested_action}: system is {state.state}; use STOP or ABORT before starting another operation"
+    if manual in {"moving", "tracking", "calibration", "observing sequence"}:
+        return f"cannot start {requested_action}: current manual state is {state.manual_state}; use STOP or wait until READY"
+    if task not in {"", "none", "idle", "unknown"}:
+        return f"cannot start {requested_action}: active task is {state.active_task}; use STOP/ABORT or wait until READY"
+    return None
+
 def handle_action(
     server: ConsoleDemoServer, action: str, params: Dict[str, Any], session_id: str
 ) -> Tuple[bool, str]:
     state = server.state
+
+    active_reason = _demo_active_operation_reason(state, action)
+    if active_reason is not None:
+        server.add_log(False, active_reason)
+        return False, active_reason
 
     if action == "launch_progress":
         ok, reason, url = server.launch_progress()
@@ -2233,6 +2705,7 @@ def handle_action(
             reason = "target tracking is not running"
             server.add_log(False, reason)
             return False, reason
+        _demo_clear_exclusive_start_guard(state)
         state.command_az = None
         state.command_el = None
         state.manual_state = "stopped"
@@ -2241,6 +2714,7 @@ def handle_action(
         return True, "tracking stopped"
 
     if action == "stop":
+        _demo_clear_exclusive_start_guard(state)
         state.command_az = None
         state.command_el = None
         state.manual_state = "stopped"
@@ -2267,6 +2741,7 @@ def handle_action(
             server.add_log(False, privilege_msg)
             return False, privilege_msg
         if action == "mount_move":
+            _demo_mark_exclusive_start_guard(state, action, f"mount move Az={az:.4f} deg El={el:.4f} deg")
             state.command_az = az
             state.command_el = el
             state.az = az
@@ -2303,6 +2778,7 @@ def handle_action(
         if "rejected" in privilege_msg:
             server.add_log(False, privilege_msg)
             return False, privilege_msg
+        _demo_mark_exclusive_start_guard(state, action, "observation")
         state.command_az = None
         state.command_el = None
         state.state = "observing"
@@ -2318,6 +2794,7 @@ def handle_action(
             reason = "no running observation to abort"
             server.add_log(False, reason)
             return False, reason
+        _demo_clear_exclusive_start_guard(state)
         state.command_az = None
         state.command_el = None
         state.state = "idle"
@@ -2335,6 +2812,7 @@ def handle_action(
         if "rejected" in privilege_msg:
             server.add_log(False, privilege_msg)
             return False, privilege_msg
+        _demo_mark_exclusive_start_guard(state, action, "target tracking")
         state.command_az = None
         state.command_el = None
         state.manual_state = "tracking"
@@ -2392,6 +2870,7 @@ def handle_action(
         if "rejected" in privilege_msg:
             server.add_log(False, privilege_msg)
             return False, privilege_msg
+        _demo_mark_exclusive_start_guard(state, action, "RSky")
         state.command_az = None
         state.command_el = None
         state.state = "calibrating"
@@ -2425,6 +2904,7 @@ def handle_action(
         if "rejected" in privilege_msg:
             server.add_log(False, privilege_msg)
             return False, privilege_msg
+        _demo_mark_exclusive_start_guard(state, action, "SkyDip")
         state.command_az = None
         state.command_el = None
         state.state = "calibrating"

--- a/bin/console-demo.py
+++ b/bin/console-demo.py
@@ -299,6 +299,80 @@ summary { cursor: pointer; color: var(--muted); }
 .file-row.selected { background: rgba(86,211,100,0.12); box-shadow: inset 0 0 0 1px rgba(86,211,100,0.28); }
 .file-empty { color: var(--muted); padding: 12px; }
 
+.obs-main-row { align-items: end; }
+.obs-file-line {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  gap: 8px;
+  align-items: center;
+}
+.path-edit-details { margin-top: 4px; }
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 18px;
+  background: rgba(0, 0, 0, 0.62);
+  backdrop-filter: blur(6px);
+}
+.modal-backdrop.open { display: flex; }
+.modal-card {
+  width: min(980px, calc(100vw - 32px));
+  max-height: calc(100vh - 42px);
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  background: var(--panel);
+  box-shadow: 0 24px 60px rgba(0,0,0,0.55);
+  overflow: hidden;
+}
+.modal-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: center;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--line);
+  background: rgba(255,255,255,0.03);
+}
+.modal-head h3 { margin: 0; font-size: 16px; }
+.modal-head .hint { color: var(--muted); font-size: 12px; }
+.modal-card .file-chooser-card {
+  margin: 0;
+  border: 0;
+  border-radius: 0;
+  display: grid;
+  grid-template-rows: auto auto minmax(240px, 1fr) auto;
+  min-height: 0;
+}
+.modal-card .server-file-browser {
+  height: auto;
+  min-height: 260px;
+  max-height: 58vh;
+}
+.file-chooser-toolbar select {
+  flex: 1 1 260px;
+  min-width: 180px;
+}
+.chooser-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  margin-top: 8px;
+}
+@media (max-width: 760px) {
+  .obs-file-line { grid-template-columns: 1fr; }
+  .modal-backdrop { padding: 8px; }
+  .modal-card { width: calc(100vw - 16px); max-height: calc(100vh - 16px); }
+  .chooser-footer { align-items: stretch; flex-direction: column; }
+}
+
+
 .callout {
   display: grid;
   gap: 4px;
@@ -371,7 +445,7 @@ summary { cursor: pointer; color: var(--muted); }
           <b>Start and ABORT are the primary observation actions.</b>
           <span>Check is a safe static check; Dry run is a safe simulated plan. They are optional and never change hardware state.</span>
         </div>
-        <div class="row">
+        <div class="row obs-main-row">
           <div class="field">
             <label for="obsMode">Observation mode</label>
             <select id="obsMode" title="Observation modes supported by the obs-file launcher. RSky and SkyDip are calibration actions, not observation modes.">
@@ -381,66 +455,79 @@ summary { cursor: pointer; color: var(--muted); }
               <option value="radio_pointing">Radio Pointing</option>
             </select>
           </div>
-          <div class="field">
-            <label for="serverObsRoot" title="Browse obs files from the NECST side, meaning the environment where this console server is running. If console is in Docker, this is the Docker/container filesystem.">NECST-side file location</label>
-            <select id="serverObsRoot" title="Starting location for the NECST-side file chooser."></select>
-            <small>This is a file chooser for the side running the console. In Docker it shows container files; outside Docker it shows that PC filesystem.</small>
-          </div>
-        </div>
-        <div class="row">
-          <div class="field">
-            <label for="recentDir" title="Directory on the NECST-side filesystem. This is editable; selecting a file fills it automatically.">Obs directory on NECST side</label>
-            <input id="recentDir" list="recentDirList" placeholder="/path/on/NECST/side" title="Directory used to construct the run path. This is a NECST-side path, not the browser PC path.">
-            <datalist id="recentDirList"></datalist>
-            <small>NECST-side path. Use the file chooser below to choose and preview the exact file used for execution.</small>
-          </div>
-          <div class="field">
-            <label for="obsFilename" title="Filename on the NECST side. Choosing a file fills this automatically.">Obs filename</label>
-            <input id="obsFilename" placeholder="e.g. orion_otf.obs" title="Filename to combine with the NECST-side directory. Accepts .obs or .toml.">
-            <small>Filled from the NECST-side file chooser, then editable.</small>
-          </div>
-        </div>
-        <div class="field">
-          <label for="obsPath" title="Read-only confirmation. This is computed from Obs directory + Obs filename; edit those fields if this path is wrong.">Computed run path on NECST side</label>
-          <input id="obsPath" readonly placeholder="directory + filename" title="Read-only computed path used by Start observation.">
-          <small>Read-only confirmation. Check, Dry run, Start, and preview use this same NECST-side path.</small>
-        </div>
-        <div class="file-chooser-card" aria-label="NECST-side file chooser">
-          <div class="file-chooser-toolbar">
-            <button id="serverObsHome" class="secondary compact" type="button" title="Return to the selected location.">Home</button>
-            <button id="serverObsUp" class="secondary compact" type="button" title="Move to the parent directory.">Up</button>
-            <button id="refreshServerObs" class="secondary compact" type="button" title="Refresh the NECST-side directory listing.">Refresh</button>
-            <small id="serverObsInfo">NECST-side file chooser: not loaded</small>
-          </div>
-          <div class="file-chooser-path">
-            <div class="field" style="margin-bottom:0">
-              <label for="serverObsDir" title="Directory to browse on the NECST/console-side filesystem.">Current folder on NECST side</label>
-              <input id="serverObsDir" placeholder="choose a location or type a folder" title="Directory to list on the NECST/console side. This is not the browser PC path.">
+          <div class="field obs-file-field">
+            <label for="obsPath" title="This is the NECST-side path used by Preview, Check, Dry run, and Start.">Obs file on NECST side</label>
+            <div class="obs-file-line">
+              <input id="obsPath" readonly placeholder="choose an obs file" title="Read-only computed NECST-side path used by Start observation.">
+              <button id="openObsChooser" class="primary compact" type="button" title="Open the NECST-side file chooser in a dialog.">Choose...</button>
+              <button id="previewCurrentObs" class="secondary compact" type="button" title="Preview the file currently shown in Obs file on NECST side.">Preview</button>
             </div>
-            <button id="goServerObsDir" class="secondary compact" type="button" title="Open the typed NECST-side folder.">Open</button>
+            <small>Click Choose to browse files visible to the console process. In Docker, this means Docker/container files.</small>
           </div>
-          <div id="serverObsFiles" class="server-file-browser" role="listbox" aria-label="NECST-side files">
-            <div class="file-empty">Choose a location to browse NECST-side files.</div>
-          </div>
-          <small>Folders open in this browser. Clicking an .obs/.toml file previews the exact file used by Check / Dry run / Start.</small>
         </div>
-        <div id="obsValidation" class="notice">Set the NECST-side directory and filename.</div>
+        <details class="path-edit-details">
+          <summary>Edit path manually</summary>
+          <div class="row" style="margin-top:10px">
+            <div class="field">
+              <label for="recentDir" title="Directory on the NECST-side filesystem. This is editable; selecting a file fills it automatically.">Obs directory on NECST side</label>
+              <input id="recentDir" list="recentDirList" placeholder="/path/on/NECST/side" title="Directory used to construct the run path. This is a NECST-side path, not the browser PC path.">
+              <datalist id="recentDirList"></datalist>
+              <small>NECST-side directory. The file chooser fills this automatically.</small>
+            </div>
+            <div class="field">
+              <label for="obsFilename" title="Filename on the NECST side. Choosing a file fills this automatically.">Obs filename</label>
+              <input id="obsFilename" placeholder="e.g. orion_otf.obs" title="Filename to combine with the NECST-side directory. Accepts .obs or .toml.">
+              <small>NECST-side filename. The file chooser fills this automatically.</small>
+            </div>
+          </div>
+        </details>
+        <div id="obsValidation" class="notice">Choose a NECST-side obs file or enter a NECST-side path.</div>
         <details open>
           <summary>Preview selected obs file</summary>
           <div class="field" style="margin-top:10px">
             <label for="obsPreview">Preview text</label>
-            <textarea id="obsPreview" spellcheck="false" placeholder="Select a NECST-side obs file above to preview the exact file that Check/Dry run/Start will use." title="NECST-side preview. The Start button uses the same computed run path."></textarea>
+            <textarea id="obsPreview" spellcheck="false" placeholder="Select a NECST-side obs file to preview the exact file that Check/Dry run/Start will use." title="NECST-side preview. The Start button uses the same computed run path."></textarea>
             <small id="previewInfo">Preview: empty</small>
           </div>
         </details>
         <details>
           <summary>Optional local preview only</summary>
           <div class="field" style="margin-top:10px">
-            <label for="obsFile" title="This reads a file from the browser computer only. It does not provide a server/Docker path and is not used for Start.">Choose local file for visual comparison only</label>
-            <input id="obsFile" type="file" accept=".obs,.toml,.txt" title="Preview only. The browser does not expose the Docker/server absolute path.">
+            <label for="obsFile" title="This reads a file from the browser computer only. It does not provide a Docker/NECST absolute path and is not used for Start.">Choose local file for visual comparison only</label>
+            <input id="obsFile" type="file" accept=".obs,.toml,.txt" title="Preview only. The browser does not expose the Docker/NECST absolute path.">
             <small>Use this only to compare text. Observation execution uses the NECST-side path above, not the browser local file.</small>
           </div>
         </details>
+        <div id="obsChooserModal" class="modal-backdrop" role="dialog" aria-modal="true" aria-label="Choose NECST-side obs file">
+          <div class="modal-card obs-chooser-modal">
+            <div class="modal-head">
+              <div>
+                <h3>Choose NECST-side obs file</h3>
+                <div class="hint">This behaves like a file chooser for the filesystem visible to the console process.</div>
+              </div>
+              <button id="closeObsChooser" class="secondary compact" type="button">Close</button>
+            </div>
+            <div class="file-chooser-card" aria-label="NECST-side file chooser">
+              <div class="file-chooser-toolbar">
+                <button id="serverObsHome" class="secondary compact" type="button" title="Return to the selected location.">Home</button>
+                <button id="serverObsUp" class="secondary compact" type="button" title="Move to the parent directory.">Up</button>
+                <button id="refreshServerObs" class="secondary compact" type="button" title="Refresh the NECST-side directory listing.">Refresh</button>
+                <select id="serverObsRoot" title="Quick locations visible to the console process."></select>
+              </div>
+              <div class="file-chooser-path">
+                <input id="serverObsDir" placeholder="type or browse a folder visible to the console" title="Directory to list on the NECST/console side. This is not the browser PC path.">
+                <button id="goServerObsDir" class="secondary compact" type="button" title="Open the typed NECST-side folder.">Open</button>
+              </div>
+              <div id="serverObsFiles" class="server-file-browser" role="listbox" aria-label="NECST-side files">
+                <div class="file-empty">Loading...</div>
+              </div>
+              <div class="chooser-footer">
+                <small id="serverObsInfo">NECST-side file chooser: not loaded</small>
+                <button id="useSelectedObs" class="primary compact" type="button" disabled>Use selected file</button>
+              </div>
+            </div>
+          </div>
+        </div>
         <details>
           <summary>Advanced observation options</summary>
           <div class="field" style="margin-top:10px">
@@ -723,7 +810,8 @@ const state = {
   capabilities: {},
   liveActions: {guarded: false, enabled: false},
   lastSelfCheck: null,
-  demoObsBrowser: false
+  demoObsBrowser: false,
+  selectedObsPath: ""
 };
 localStorage.setItem('necstConsoleDemoSession', state.sessionId);
 
@@ -1006,7 +1094,7 @@ async function loadServerObsRoots() {
       if (info) info.textContent = `NECST-side file chooser: ${roots.length} root(s)`;
       await browseServerObs(roots[0].path);
     } else if (info) {
-      info.textContent = 'NECST-side file chooser: no locations are available. Check filesystem permissions or use --obs-root.';
+      info.textContent = 'NECST-side file chooser: no readable locations are available.';
     }
   } catch (err) {
     await useDemoObsBrowser(String(err && err.message ? err.message : err));
@@ -1095,7 +1183,8 @@ function renderServerObsEntries(entries, directory) {
     const icon = type === 'directory' ? (e.name === '..' ? '↩' : '📁') : '📄';
     const meta = type === 'directory' ? 'folder' : formatFileSize(e.size);
     const name = e.name === '..' ? '.. parent folder' : e.name;
-    return `<button type="button" class="file-row ${type}" role="option" data-index="${idx}" data-type="${escapeHtml(type)}" data-path="${escapeHtml(e.path || '')}" title="${escapeHtml(e.path || '')}">` +
+    const selected = e.path && e.path === state.selectedObsPath ? ' selected' : '';
+    return `<button type="button" class="file-row ${type}${selected}" role="option" data-index="${idx}" data-type="${escapeHtml(type)}" data-path="${escapeHtml(e.path || '')}" title="${escapeHtml(e.path || '')}">` +
       `<span class="file-icon">${icon}</span>` +
       `<span class="file-name">${escapeHtml(name || '')}</span>` +
       `<span class="file-meta">${escapeHtml(meta || '')}</span>` +
@@ -1109,7 +1198,7 @@ async function browseServerObs(dir) {
   const browseDir = String(dir || qs('serverObsDir').value || qs('serverObsRoot').value || '').trim();
   if (!browseDir) {
     if (info) info.textContent = 'NECST-side file chooser: choose a root or folder.';
-    list.innerHTML = '<div class="file-empty">No location is available. Check filesystem permissions or use --obs-root.</div>';
+    list.innerHTML = '<div class="file-empty">No readable NECST-side location is available.</div>';
     return;
   }
   try {
@@ -1148,6 +1237,9 @@ async function previewServerObsFile(path) {
       data = await resp.json();
     }
     if (!data.ok) throw new Error(data.reason || 'preview failed');
+    state.selectedObsPath = data.path || path;
+    const useButton = qs('useSelectedObs');
+    if (useButton) useButton.disabled = false;
     setObsPathFromServerPath(data.path || path);
     qs('obsPreview').value = data.text || '';
     updatePreviewInfo();
@@ -1159,6 +1251,28 @@ async function previewServerObsFile(path) {
     if (info) info.textContent = 'NECST-side preview failed: ' + err;
   }
 }
+
+function openObsChooser() {
+  const modal = qs('obsChooserModal');
+  if (!modal) return;
+  modal.classList.add('open');
+  document.body.style.overflow = 'hidden';
+  const current = qs('obsPath').value.trim() || qs('serverObsDir').value.trim() || (qs('serverObsRoot') ? qs('serverObsRoot').value : '');
+  if (current) {
+    const dir = current.match(/\.(obs|toml)$/i) ? dirnameOf(current) : current;
+    browseServerObs(dir);
+  } else {
+    loadServerObsRoots();
+  }
+  setTimeout(() => { try { qs('serverObsDir').focus(); } catch (_) {} }, 0);
+}
+function closeObsChooser() {
+  const modal = qs('obsChooserModal');
+  if (!modal) return;
+  modal.classList.remove('open');
+  document.body.style.overflow = '';
+}
+
 function renderStatus(data) {
   const heldByMe = data.authority && data.authority.session_id === state.sessionId;
   state.siteLimits = data.mount_limits || state.siteLimits;
@@ -1379,6 +1493,19 @@ qs('obsFile').addEventListener('change', async (ev) => {
   updatePreviewInfo();
   setNotice(qs('obsValidation'), 'warn', 'Local preview loaded for visual comparison only. Start still uses the NECST-side computed run path.');
 });
+qs('openObsChooser').addEventListener('click', openObsChooser);
+qs('closeObsChooser').addEventListener('click', closeObsChooser);
+qs('obsChooserModal').addEventListener('click', (ev) => { if (ev.target === qs('obsChooserModal')) closeObsChooser(); });
+document.addEventListener('keydown', (ev) => { if (ev.key === 'Escape' && qs('obsChooserModal').classList.contains('open')) closeObsChooser(); });
+qs('previewCurrentObs').addEventListener('click', async () => {
+  const path = qs('obsPath').value.trim();
+  if (path) await previewServerObsFile(path);
+});
+qs('useSelectedObs').addEventListener('click', async () => {
+  if (!state.selectedObsPath) return;
+  await previewServerObsFile(state.selectedObsPath);
+  closeObsChooser();
+});
 qs('serverObsRoot').addEventListener('change', async () => {
   qs('serverObsDir').value = qs('serverObsRoot').value;
   await browseServerObs(qs('serverObsRoot').value);
@@ -1412,7 +1539,11 @@ qs('serverObsFiles').addEventListener('click', async (ev) => {
     qs('serverObsDir').value = path;
     await browseServerObs(path);
   } else {
+    state.selectedObsPath = path;
+    const useButton = qs('useSelectedObs');
+    if (useButton) useButton.disabled = false;
     await previewServerObsFile(path);
+    closeObsChooser();
   }
 });
 qs('serverObsFiles').addEventListener('keydown', async (ev) => {

--- a/bin/console-demo.py
+++ b/bin/console-demo.py
@@ -1039,7 +1039,7 @@ summary { cursor: pointer; color: var(--muted); }
                 <div class="field"><label for="skydipInteg">integ [s]</label><input id="skydipInteg" type="number" min="0.1" step="0.5" value="10" inputmode="decimal"></div>
                 <details><summary>Advanced</summary>
                   <div class="field" style="margin-top:10px"><label for="skydipCh">channel</label><input id="skydipCh" placeholder="empty = default"></div>
-                  <div class="field"><label for="skydipTpRange">tp_range</label><input id="skydipTpRange" placeholder="e.g. 5000 6000 17000 18000"></div>
+                  <div class="field"><label for="skydipTpRange">TP channel range</label><input id="skydipTpRange" placeholder="blank = default; e.g. 5000 6000 17000 18000" inputmode="numeric" title="Optional. Leave blank for the default SkyDip total-power range, or enter START END integer pairs."><small id="skydipTpRangeHelp">Optional. Leave blank unless a specific total-power channel range is needed. Use integer START END pairs.</small></div>
                 </details>
                 <button id="runSkydip" class="primary">Run SkyDip</button>
               </div>
@@ -1260,6 +1260,10 @@ function saveFormField(id) {
   try { localStorage.setItem(storageKeyForField(id), el.value); } catch (_) {}
 }
 function restoreFormField(id) {
+  if (id === 'skydipTpRange') {
+    restoreSkydipTpRangeField();
+    return;
+  }
   const el = qs(id);
   if (!el) return;
   try {
@@ -1283,6 +1287,72 @@ function numberOrNaN(value) {
 function finite(value) { return Number.isFinite(value); }
 function finiteStatusNumber(value) {
   return value !== null && value !== undefined && String(value).trim() !== '' && Number.isFinite(Number(value));
+}
+function parseSkydipTpRange(value) {
+  const raw = String(value || '').trim();
+  if (!raw) return {ok: true, value: '', tokens: []};
+  const tokens = raw.replace(/,/g, ' ').split(/\s+/).filter(Boolean);
+  const bad = tokens.find(t => !/^[-+]?\d+$/.test(t));
+  if (bad) {
+    return {ok: false, value: raw, reason: `SkyDip TP channel range must be blank or integer START END pairs. Invalid token: ${bad}`};
+  }
+  if (tokens.length % 2 !== 0) {
+    return {ok: false, value: raw, reason: 'SkyDip TP channel range must contain START END integer pairs.'};
+  }
+  return {ok: true, value: tokens.map(t => String(Number(t))).join(' '), tokens};
+}
+function setSkydipTpRangeValidation(result) {
+  const input = qs('skydipTpRange');
+  const help = qs('skydipTpRangeHelp');
+  if (!input || !help) return;
+  const ok = !result || result.ok;
+  input.classList.toggle('invalid', !ok);
+  if (ok) {
+    help.textContent = 'Optional. Leave blank unless a specific total-power channel range is needed. Use integer START END pairs.';
+    help.style.color = '';
+  } else {
+    help.textContent = result.reason || 'Invalid TP channel range.';
+    help.style.color = 'var(--bad)';
+  }
+}
+function restoreSkydipTpRangeField() {
+  const el = qs('skydipTpRange');
+  if (!el) return;
+  try {
+    const saved = localStorage.getItem(storageKeyForField('skydipTpRange'));
+    if (saved !== null && saved !== undefined) {
+      const parsed = parseSkydipTpRange(saved);
+      if (parsed.ok) {
+        el.value = parsed.value;
+      } else {
+        el.value = '';
+        localStorage.removeItem(storageKeyForField('skydipTpRange'));
+        setSkydipTpRangeValidation({ok: false, reason: 'A previously saved invalid SkyDip TP range was cleared. Leave blank for default.'});
+      }
+    }
+  } catch (_) {}
+}
+function skydipParamsFromUi() {
+  const parsed = parseSkydipTpRange(qs('skydipTpRange') ? qs('skydipTpRange').value : '');
+  setSkydipTpRangeValidation(parsed);
+  if (!parsed.ok) return {ok: false, reason: parsed.reason};
+  if (qs('skydipTpRange')) {
+    qs('skydipTpRange').value = parsed.value;
+    saveFormField('skydipTpRange');
+  }
+  return {ok: true, params: {integ: qs('skydipInteg').value, ch: qs('skydipCh').value, tp_range: parsed.value}};
+}
+function runSkydipFromUi() {
+  const prepared = skydipParamsFromUi();
+  if (!prepared.ok) {
+    const msg = prepared.reason || 'Invalid SkyDip TP channel range.';
+    try { console.warn(msg); } catch (_) {}
+    const op = {phase: 'attention', kind: 'skydip', label: 'SKYDIP INPUT CHECK', detail: msg};
+    state.currentOperation = op;
+    applyOperationUi(op);
+    return Promise.resolve({ok: false, action: 'run_skydip', reason: msg, local_validation: true});
+  }
+  return api('run_skydip', prepared.params, 'skydip');
 }
 
 function parseSexagesimalAngle(value, isRa) {
@@ -2831,6 +2901,7 @@ function selectPanel(id) {
 
 document.querySelectorAll('.tab').forEach(b => b.addEventListener('click', () => selectPanel(b.dataset.panel)));
 ['recentDir','obsFilename','obsPreview','obsChannel','obsMode'].forEach(id => qs(id).addEventListener('input', () => { state.obsChecked = false; validateObs(); }));
+if (qs('skydipTpRange')) qs('skydipTpRange').addEventListener('input', () => setSkydipTpRangeValidation(parseSkydipTpRange(qs('skydipTpRange').value)));
 ['mountAz','mountEl'].forEach(id => qs(id).addEventListener('input', validateMount));
 ['targetKind','targetName','coord1','coord2','offsetFrame','offsetX','offsetY','cosCorrection'].forEach(id => qs(id).addEventListener('input', updateTargetFields));
 qs('obsFile').addEventListener('change', async (ev) => {
@@ -2982,7 +3053,7 @@ qs('chopperAlarmReset').addEventListener('click', () => api('chopper_alarm_reset
 qs('chopperHome').addEventListener('click', () => api('chopper_home'));
 qs('chopperRecover').addEventListener('click', () => api('chopper_recover'));
 qs('runRsky').addEventListener('click', () => api('run_rsky', {n: qs('rskyN').value, integ: qs('rskyInteg').value, ch: qs('rskyCh').value}, 'rsky'));
-qs('runSkydip').addEventListener('click', () => api('run_skydip', {integ: qs('skydipInteg').value, ch: qs('skydipCh').value, tp_range: qs('skydipTpRange').value}, 'skydip'));
+qs('runSkydip').addEventListener('click', () => runSkydipFromUi());
 qs('addObsLogComment').addEventListener('click', async () => {
   const comment = qs('obsLogComment').value;
   const data = await api('obslog_comment', {comment});
@@ -4107,6 +4178,22 @@ def _validate_positive_float(value: Any, name: str) -> Tuple[bool, str, Optional
     return True, "ok", number
 
 
+def _demo_parse_skydip_tp_range(value: Any) -> Tuple[bool, str, List[int]]:
+    raw = str(value or "").strip()
+    if not raw:
+        return True, "", []
+    tokens = raw.replace(",", " ").split()
+    values: List[int] = []
+    for token in tokens:
+        try:
+            values.append(int(token))
+        except Exception:
+            return False, f"SkyDip TP channel range must be blank or integer START END pairs (invalid token: {token!r})", []
+    if len(values) % 2 != 0:
+        return False, "SkyDip TP channel range must contain START END integer pairs", []
+    return True, "", values
+
+
 def _with_authority(server: ConsoleDemoServer, session_id: str, action_text: str) -> str:
     state = server.state
     if state.authority_held:
@@ -4566,18 +4653,10 @@ def handle_action(
         if err:
             server.add_log(False, f"SkyDip not started: {err}")
             return False, err
-        tp = str(params.get("tp_range") or "").split()
-        if tp:
-            try:
-                tp_values = [int(x) for x in tp]
-            except Exception:
-                reason = "tp_range must be integers"
-                server.add_log(False, f"SkyDip not started: {reason}")
-                return False, reason
-            if len(tp_values) % 2 != 0:
-                reason = "tp_range must contain START END pairs"
-                server.add_log(False, f"SkyDip not started: {reason}")
-                return False, reason
+        tp_ok, tp_reason, _tp_values = _demo_parse_skydip_tp_range(params.get("tp_range"))
+        if not tp_ok:
+            server.add_log(False, f"SkyDip not started: {tp_reason}")
+            return False, tp_reason
         authority_msg = _with_authority(server, session_id, "SkyDip")
         if "rejected" in authority_msg:
             server.add_log(False, authority_msg)

--- a/bin/console-demo.py
+++ b/bin/console-demo.py
@@ -960,17 +960,19 @@ function matchingRecentFinalProcess(data, pending) {
   candidates.sort((a, b) => Number(b.started_at || 0) - Number(a.started_at || 0));
   return candidates[0];
 }
-const MOUNT_REACHED_TOL_DEG = 2.0e-4;
+const MOUNT_REACHED_TOL_DEG = 5.0e-4;
 function mountPendingReached(data, pending) {
   if (!pending || pending.kind !== 'mount') return false;
   const targetAz = Number(pending.targetAz);
   const targetEl = Number(pending.targetEl);
   const currentAz = Number(data && data.az);
   const currentEl = Number(data && data.el);
+  const azDelta = Math.min(Math.abs(currentAz - targetAz), Math.abs(((currentAz - targetAz + 180.0) % 360.0) - 180.0));
+  const elDelta = Math.abs(currentEl - targetEl);
   return Number.isFinite(targetAz) && Number.isFinite(targetEl)
     && Number.isFinite(currentAz) && Number.isFinite(currentEl)
-    && Math.abs(currentAz - targetAz) <= MOUNT_REACHED_TOL_DEG
-    && Math.abs(currentEl - targetEl) <= MOUNT_REACHED_TOL_DEG;
+    && azDelta <= MOUNT_REACHED_TOL_DEG
+    && elDelta <= MOUNT_REACHED_TOL_DEG;
 }
 function exclusiveStartActionKind(action) {
   const a = lowerText(action || '');
@@ -1032,8 +1034,9 @@ function actualOperationFromStatus(data) {
   const finalOrIdle = ['idle', 'finished', 'aborted', 'error', 'failed'].includes(sys);
   const obsActive = sys === 'observing' || (!finalOrIdle && task.includes('observation')) || (!finalOrIdle && Boolean(progress.observation_running)) || processCategoryActive(data, 'observation');
   const calActive = sys === 'calibrating' || (!finalOrIdle && manual === 'calibration') || (!finalOrIdle && (task.includes('rsky') || task.includes('skydip'))) || processCategoryActive(data, 'calibration');
-  const mountActive = manual === 'moving' || task.includes('mount move') || task.includes('manual mount');
-  const trackingActive = manual === 'tracking' || task.includes('target tracking');
+  const explicitTrackingActive = task.includes('target tracking');
+  const mountActive = manual === 'moving' || (manual === 'tracking' && !explicitTrackingActive) || task.includes('mount move') || task.includes('manual mount');
+  const trackingActive = explicitTrackingActive || manual === 'target tracking';
   if (obsActive) {
     return {phase: 'running', kind: 'observation', label: 'OBSERVATION RUNNING', detail: 'Observation execution is confirmed by status/progress/launcher state.'};
   }
@@ -1046,7 +1049,7 @@ function actualOperationFromStatus(data) {
     return {phase: 'running', kind: 'mount', label: 'MOUNT MOVING', detail: 'Mount motion is confirmed by live/manual status.'};
   }
   if (trackingActive) {
-    return {phase: 'running', kind: 'tracking', label: 'TARGET TRACKING', detail: 'Target tracking is active. Use STOP to stop antenna motion.'};
+    return {phase: 'running', kind: 'tracking', label: 'TARGET TRACKING', detail: 'Time-dependent target tracking is active. Fixed Az/El mount-move hold is not treated as target tracking.'};
   }
   const guardedStart = operationFromExclusiveStartGuard(data);
   if (guardedStart) return guardedStart;

--- a/bin/console-demo.py
+++ b/bin/console-demo.py
@@ -1035,8 +1035,9 @@ function actualOperationFromStatus(data) {
   const obsActive = sys === 'observing' || (!finalOrIdle && task.includes('observation')) || (!finalOrIdle && Boolean(progress.observation_running)) || processCategoryActive(data, 'observation');
   const calActive = sys === 'calibrating' || (!finalOrIdle && manual === 'calibration') || (!finalOrIdle && (task.includes('rsky') || task.includes('skydip'))) || processCategoryActive(data, 'calibration');
   const explicitTrackingActive = task.includes('target tracking');
-  const mountActive = manual === 'moving' || (manual === 'tracking' && !explicitTrackingActive) || task.includes('mount move') || task.includes('manual mount');
-  const trackingActive = explicitTrackingActive || manual === 'target tracking';
+  const atTargetIdle = Boolean((data.mount_target_reached || data.mount_hold_at_target) && data.motion_live_active === false);
+  const mountActive = !atTargetIdle && (manual === 'moving' || (manual === 'tracking' && !explicitTrackingActive) || task.includes('mount move') || task.includes('manual mount'));
+  const trackingActive = !atTargetIdle && (explicitTrackingActive || manual === 'target tracking');
   if (obsActive) {
     return {phase: 'running', kind: 'observation', label: 'OBSERVATION RUNNING', detail: 'Observation execution is confirmed by status/progress/launcher state.'};
   }
@@ -1660,7 +1661,8 @@ function renderStatus(data) {
   const authText = data.authority && data.authority.held ? (heldByMe ? 'Authority: held here' : 'Authority: held elsewhere') : 'Authority: auto';
   const authClass = data.authority && data.authority.held ? (heldByMe ? 'ok' : 'warn') : 'info';
   const taskClass = data.active_task && data.active_task !== 'none' ? 'ok' : 'info';
-  const motionClass = (data.manual_state === 'moving' || data.manual_state === 'tracking' || data.manual_state === 'calibration' || data.manual_state === 'observing sequence') ? 'ok' : (data.manual_state === 'stopped' ? 'warn' : 'info');
+  const motionAtTargetIdle = Boolean((data.mount_target_reached || data.mount_hold_at_target) && data.motion_live_active === false);
+  const motionClass = (!motionAtTargetIdle && (data.manual_state === 'moving' || data.manual_state === 'tracking' || data.manual_state === 'calibration' || data.manual_state === 'observing sequence')) ? 'ok' : (data.manual_state === 'stopped' ? 'warn' : 'info');
   const cmd = (finiteStatusNumber(data.command_az) && finiteStatusNumber(data.command_el)) ? `${Number(data.command_az).toFixed(4)} / ${Number(data.command_el).toFixed(4)}` : '- / -';
   const progressClass = data.progress && data.progress.running ? 'ok' : 'info';
   const progressText = data.progress && data.progress.running ? 'Progress: running' : 'Progress: not started';

--- a/bin/console-demo.py
+++ b/bin/console-demo.py
@@ -562,6 +562,7 @@ summary { cursor: pointer; color: var(--muted); }
             <div>Action mode: <b id="runtimeActionMode">loading</b></div>
             <div>Live writes: <b id="runtimeLiveWrites">loading</b></div>
             <div>Status refresh: <b id="runtimeStatusRefresh">loading</b></div>
+            <div>Live telemetry: <b id="runtimeLiveTelemetry">loading</b></div>
             <div>Observatory: <b id="runtimeObservatory">loading</b></div>
             <div>Config source: <b id="runtimeConfigSource">loading</b></div>
             <div class="path-text" title="site config path">Path: <b id="runtimeConfigPath">loading</b></div>
@@ -578,6 +579,14 @@ summary { cursor: pointer; color: var(--muted); }
               <button id="terminateCalLauncher" class="secondary" title="Terminate local calibration launcher subprocess only; does not send telescope STOP">Terminate cal launcher</button>
               <button id="terminateAllLaunchers" class="secondary" title="Terminate all local launcher subprocesses started by this console">Terminate all launchers</button>
             </div>
+          </div>
+        </div>
+        <div class="runtime-card">
+          <h3>Current observation data</h3>
+          <div class="runtime-list">
+            <div>Record: <b id="runtimeRecordName">loading</b></div>
+            <div class="path-text" title="Expected NECST recorder output directory">Data directory: <b id="runtimeRecordingDir">loading</b></div>
+            <div class="path-text" title="Progress sidecar directory">Progress directory: <b id="runtimeProgressRecordDir">loading</b></div>
           </div>
         </div>
         <div class="runtime-card">
@@ -816,6 +825,8 @@ function renderRuntime(data) {
   setText('runtimeLiveWrites', liveActions.guarded ? 'guarded by CLI option' : (liveActions.enabled ? 'enabled' : 'dry-run / not live'));
   const refreshMs = Number(data.status_refresh_ms || getStatusRefreshMs());
   setText('runtimeStatusRefresh', `${refreshMs} ms`);
+  const liveTelemetry = data.live_telemetry || {};
+  setText('runtimeLiveTelemetry', liveTelemetry.requested === false ? 'disabled' : (liveTelemetry.available ? `available (${liveTelemetry.spin_mode || 'spin'})` : `unavailable${liveTelemetry.error ? ': ' + liveTelemetry.error : ''}`));
   setText('runtimeObservatory', site.observatory || 'unknown');
   setText('runtimeConfigSource', site.source || 'unknown');
   setText('runtimeConfigPath', site.source_path || '(none)');
@@ -823,6 +834,10 @@ function renderRuntime(data) {
   setText('runtimeProcessCounts', processSummary(counts));
   const processEl = qs('runtimeProcesses');
   if (processEl) processEl.innerHTML = renderProcessRows(processes);
+  const obs = data.observation || {};
+  setText('runtimeRecordName', obs.record_name || '(none)');
+  setText('runtimeRecordingDir', obs.recording_dir || '(not available yet)');
+  setText('runtimeProgressRecordDir', obs.progress_record_dir || '(not available yet)');
   renderLauncherLogChoices(processes);
   setText('runtimeProgressMonitor', progressMonitorText(progress));
   setText('runtimeOperatorLog', data.operator_log_path || '(not configured)');
@@ -923,7 +938,7 @@ function renderStatus(data) {
   qs('manualBadge').className = 'badge ' + motionClass;
   qs('motionSummary').textContent = data.manual_state;
   qs('taskSummary').textContent = data.active_task || 'none';
-  qs('posSummary').textContent = `${data.az.toFixed(3)} / ${data.el.toFixed(3)}`;
+  qs('posSummary').textContent = `${formatMaybeNumber(data.az)} / ${formatMaybeNumber(data.el)}`;
   qs('cmdSummary').textContent = cmd;
   qs('chopperSummary').textContent = `${data.chopper.state} / pos ${data.chopper.position}`;
   qs('chopperState').textContent = data.chopper.state;

--- a/bin/console-demo.py
+++ b/bin/console-demo.py
@@ -514,6 +514,7 @@ summary { cursor: pointer; color: var(--muted); }
           <div class="run-actions">
             <button id="startObs" class="primary large" disabled title="Start the selected observation sequence. Check and Dry run are optional; Start always performs server-side validation before launching.">Start observation</button>
             <button id="abortObs" class="danger large" title="Abort a running observation sequence and request recorder/gate/progress cleanup. Safety action: kept clickable even if status has not yet detected observing.">ABORT observation</button>
+            <button id="clearStaleObs" class="secondary compact" type="button" disabled title="Recover the console from stale progress state after confirming the telescope/recorder are safe. This archives only current progress pointer files; it does not send hardware commands or delete data.">Clear stale state</button>
           </div>
         </div>
         <div id="obsOutputDirBox" class="obs-output-dir" aria-live="polite">
@@ -1130,6 +1131,18 @@ function safetyReleaseLooksIdle(data, ageSec) {
 }
 function actualOperationFromStatus(data) {
   data = data || {};
+  const stale = data.stale_observation || {};
+  if (stale.running_stale) {
+    const age = Number(stale.age_sec);
+    const ageText = Number.isFinite(age) ? `${age.toFixed(1)} s` : 'unknown age';
+    const record = stale.record_name || 'unknown record';
+    return {
+      phase: 'attention',
+      kind: 'observation',
+      label: 'ATTENTION: STALE OBSERVATION STATE',
+      detail: `Progress still says observation is running for ${record}, but no active launcher/fresh progress update is confirmed (${ageText}). Confirm the hardware is safe, then use Clear stale state.`
+    };
+  }
   const sys = lowerText(data.state || 'idle');
   const manual = lowerText(data.manual_state || 'idle');
   const task = lowerText(data.active_task || 'none');
@@ -1980,6 +1993,17 @@ function renderStatus(data) {
   // ABORT is a safety action.  It must stay clickable even when the
   // observation state cannot be inferred from status/progress yet.
   qs('abortObs').disabled = false;
+  const staleObs = data.stale_observation || {};
+  const staleButton = qs('clearStaleObs');
+  if (staleButton) {
+    const canClearStale = Boolean(staleObs.can_clear || staleObs.running_stale || operation.label === 'ATTENTION: STALE OBSERVATION STATE');
+    staleButton.disabled = !canClearStale;
+    staleButton.style.display = canClearStale ? '' : 'none';
+    if (canClearStale) {
+      const record = staleObs.record_name || 'unknown record';
+      staleButton.title = `Clear stale console/progress state for ${record}. Confirm hardware is safe first. This does not send hardware commands or delete data.`;
+    }
+  }
   qs('manualBadge').textContent = ['mount', 'tracking', 'rsky', 'skydip', 'calibration'].includes(operation.kind) ? operation.label : data.manual_state;
   qs('manualBadge').className = 'badge ' + (operation.phase === 'attention' ? 'bad' : (operation.phase === 'running' ? 'warn' : motionClass));
   qs('motionSummary').textContent = data.manual_state;
@@ -2278,6 +2302,14 @@ qs('startObs').addEventListener('click', async () => {
 qs('abortObs').addEventListener('click', async () => {
   if (confirm('Abort current observation and request recorder/gate/progress cleanup?')) await api('abort_observation', {}, 'abort');
 });
+qs('clearStaleObs').addEventListener('click', async () => {
+  const stale = (state.lastStatus || {}).stale_observation || {};
+  const record = stale.record_name || 'unknown record';
+  if (!confirm(`Clear stale observation/progress state for ${record}?\n\nOnly use this after confirming the telescope, recorder, and XFFTS are safe. This does not send hardware commands and does not delete observation data.`)) return;
+  clearPendingOperation();
+  const resp = await api('clear_stale_observation_state');
+  if (!resp.ok) alert('Clear stale state failed: ' + (resp.reason || 'unknown reason'));
+});
 qs('copyObsOutputDir').addEventListener('click', copyObservationOutputDir);
 qs('authorityButton').addEventListener('click', async () => {
   const resp = await fetch('/api/status');
@@ -2459,6 +2491,11 @@ class DemoState:
                 "url": self.progress_url,
                 "running": self.progress_running,
                 "owned_by_console": self.progress_owned_by_console,
+            },
+            "stale_observation": {
+                "running_stale": False,
+                "can_clear": False,
+                "record_name": self.record_name,
             },
             "state": self.state,
             "observation": {
@@ -2992,6 +3029,16 @@ def handle_action(
         state.log.clear()
         server.add_log(True, "operation log cleared")
         return True, "cleared"
+
+    if action == "clear_stale_observation_state":
+        _demo_clear_exclusive_start_guard(state)
+        state.state = "idle"
+        state.manual_state = "idle"
+        state.active_task = "none"
+        state.command_az = None
+        state.command_el = None
+        server.add_log(True, "stale observation state cleared in demo")
+        return True, "stale observation state cleared"
 
     if action == "acquire_authority":
         if state.authority_held and state.authority_session_id != session_id:

--- a/bin/console-demo.py
+++ b/bin/console-demo.py
@@ -265,6 +265,29 @@ button.selected:not(:disabled) { border-color: rgba(86,211,100,0.70); box-shadow
 .mini-actions { display:flex; flex-wrap:wrap; gap:6px; margin-top:8px; }
 .process-row button { margin-top:5px; padding:5px 8px; font-size:12px; }
 .path-text { overflow:hidden; text-overflow:ellipsis; white-space:nowrap; direction:rtl; text-align:left; }
+.copy-path-text { direction:ltr; text-align:left; user-select:text; }
+.obs-output-dir {
+  display: none;
+  margin: 8px 0 12px;
+  padding: 10px;
+  border: 1px solid rgba(86,211,100,0.45);
+  border-radius: 12px;
+  background: rgba(86,211,100,0.08);
+}
+.obs-output-dir.visible { display: block; }
+.obs-output-dir .output-title { color: var(--ok); font-weight: 800; margin-bottom: 6px; }
+.obs-output-dir .output-path-row { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 8px; align-items: center; }
+.obs-output-dir code {
+  display: block;
+  overflow-x: auto;
+  white-space: nowrap;
+  padding: 7px 8px;
+  border: 1px solid rgba(86,211,100,0.25);
+  border-radius: 9px;
+  background: rgba(0,0,0,0.22);
+  color: var(--text);
+}
+.obs-output-dir .output-meta { color: var(--muted); font-size: 12px; margin-top: 6px; }
 .log-browser-text { max-height:220px; overflow:auto; white-space:pre-wrap; word-break:break-word; background:#080d1b; border:1px solid var(--line); border-radius:10px; padding:8px; font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace; font-size:11px; color:var(--muted); }
 .log-choice { display:block; width:100%; text-align:left; margin-top:4px; padding:5px 7px; font-size:12px; }
 .warning-list { color:var(--warn); }
@@ -331,12 +354,23 @@ summary { cursor: pointer; color: var(--muted); }
 .file-row.selected { background: rgba(86,211,100,0.12); box-shadow: inset 0 0 0 1px rgba(86,211,100,0.28); }
 .file-empty { color: var(--muted); padding: 12px; }
 
-.obs-main-row { align-items: end; }
+.obs-main-row {
+  grid-template-columns: minmax(0, 1fr);
+  align-items: stretch;
+}
+.obs-file-field { min-width: 0; }
 .obs-file-line {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto auto;
+  grid-template-columns: minmax(220px, 1fr) auto auto;
   gap: 8px;
   align-items: center;
+}
+.obs-full-path {
+  direction: ltr;
+  text-align: left;
+  white-space: nowrap;
+  overflow-x: auto;
+  text-overflow: clip;
 }
 .path-edit-details { margin-top: 4px; }
 .modal-backdrop {
@@ -398,6 +432,7 @@ summary { cursor: pointer; color: var(--muted); }
   margin-top: 8px;
 }
 @media (max-width: 760px) {
+  .obs-output-dir .output-path-row { grid-template-columns: 1fr; }
   .obs-file-line { grid-template-columns: 1fr; }
   .modal-backdrop { padding: 8px; }
   .modal-card { width: calc(100vw - 16px); max-height: calc(100vh - 16px); }
@@ -473,6 +508,14 @@ summary { cursor: pointer; color: var(--muted); }
             <button id="startObs" class="primary large" disabled title="Start the selected observation sequence. Check and Dry run are optional; Start always performs server-side validation before launching.">Start observation</button>
             <button id="abortObs" class="danger large" title="Abort a running observation sequence and request recorder/gate/progress cleanup. Safety action: kept clickable even if status has not yet detected observing.">ABORT observation</button>
           </div>
+        </div>
+        <div id="obsOutputDirBox" class="obs-output-dir" aria-live="polite">
+          <div class="output-title">Latest observation data directory</div>
+          <div class="output-path-row">
+            <code id="obsOutputDirPath">not available yet</code>
+            <button id="copyObsOutputDir" class="secondary compact" type="button" title="Copy the observation data directory path for analysis notebooks.">Copy</button>
+          </div>
+          <div class="output-meta" id="obsOutputDirMeta">Shown when the console knows the latest record name.</div>
         </div>
         <div class="optional-checks" title="Optional checks. They never move the telescope, move the chopper, start recording, open gates, or apply SG settings.">
           <span class="label">Optional before Start:</span>
@@ -1207,6 +1250,56 @@ function updateChopperButtons(chopper) {
   if (inButton) inButton.title = isIn ? 'Current chopper state is IN.' : 'Move chopper to IN.';
   if (outButton) outButton.title = isOut ? 'Current chopper state is OUT.' : 'Move chopper to OUT.';
 }
+function observationOutputInfo(data) {
+  const obs = (data && data.observation) || {};
+  const dir = String(obs.recording_dir || '').trim();
+  const record = String(obs.record_name || '').trim();
+  const progressDir = String(obs.progress_record_dir || '').trim();
+  return {dir, record, progressDir};
+}
+function updateObservationOutputBox(data) {
+  const box = qs('obsOutputDirBox');
+  const pathEl = qs('obsOutputDirPath');
+  const metaEl = qs('obsOutputDirMeta');
+  const copyBtn = qs('copyObsOutputDir');
+  if (!box || !pathEl || !metaEl) return;
+  const info = observationOutputInfo(data || {});
+  const hasDir = Boolean(info.dir);
+  box.classList.toggle('visible', hasDir);
+  pathEl.textContent = hasDir ? info.dir : 'not available yet';
+  pathEl.title = hasDir ? info.dir : 'Observation data directory is not available yet.';
+  const pieces = [];
+  if (info.record) pieces.push(`record: ${info.record}`);
+  if (info.progressDir) pieces.push(`progress: ${info.progressDir}`);
+  metaEl.textContent = hasDir ? (pieces.join(' / ') || 'Copy this path into the analysis notebook.') : 'Shown when the console knows the latest record name.';
+  if (copyBtn) {
+    copyBtn.disabled = !hasDir;
+    copyBtn.title = hasDir ? 'Copy the observation data directory path for analysis notebooks.' : 'No observation data directory is available yet.';
+  }
+}
+async function copyObservationOutputDir() {
+  const info = observationOutputInfo(state.lastStatus || {});
+  if (!info.dir) {
+    log(false, 'No observation data directory is available to copy.');
+    return;
+  }
+  try {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      await navigator.clipboard.writeText(info.dir);
+      log(true, `Copied observation data directory: ${info.dir}`);
+      const btn = qs('copyObsOutputDir');
+      if (btn) {
+        const old = btn.textContent;
+        btn.textContent = 'Copied';
+        setTimeout(() => { btn.textContent = old || 'Copy'; }, 1200);
+      }
+      return;
+    }
+  } catch (err) {
+    // Fall through to the manual copy prompt below.
+  }
+  window.prompt('Copy observation data directory', info.dir);
+}
 function operationLocksActive(op) {
   return Boolean(op && ['starting', 'running', 'attention'].includes(op.phase));
 }
@@ -1747,6 +1840,7 @@ function renderStatus(data) {
   qs('chopperPos').textContent = data.chopper.position;
   qs('chopperAge').textContent = data.chopper.age || 'live demo';
   updateChopperButtons(data.chopper || {});
+  updateObservationOutputBox(data);
   qs('stopTracking').disabled = data.manual_state !== 'tracking';
   if (['rsky', 'skydip', 'calibration'].includes(operation.kind)) {
     qs('calStatusNotice').textContent = operation.label + ': ' + operation.detail;
@@ -2031,6 +2125,7 @@ qs('startObs').addEventListener('click', async () => {
 qs('abortObs').addEventListener('click', async () => {
   if (confirm('Abort current observation and request recorder/gate/progress cleanup?')) await api('abort_observation', {}, 'abort');
 });
+qs('copyObsOutputDir').addEventListener('click', copyObservationOutputDir);
 qs('authorityButton').addEventListener('click', async () => {
   const resp = await fetch('/api/status');
   const data = await resp.json();

--- a/bin/console-demo.py
+++ b/bin/console-demo.py
@@ -826,7 +826,18 @@ function renderRuntime(data) {
   const refreshMs = Number(data.status_refresh_ms || getStatusRefreshMs());
   setText('runtimeStatusRefresh', `${refreshMs} ms`);
   const liveTelemetry = data.live_telemetry || {};
-  setText('runtimeLiveTelemetry', liveTelemetry.requested === false ? 'disabled' : (liveTelemetry.available ? `available (${liveTelemetry.spin_mode || 'spin'})` : `unavailable${liveTelemetry.error ? ': ' + liveTelemetry.error : ''}`));
+  let liveTelemetryText = 'disabled';
+  if (liveTelemetry.requested !== false) {
+    if (liveTelemetry.available) {
+      const counts = liveTelemetry.sample_counts || {};
+      const topics = Object.entries(counts).filter(([, v]) => Number(v) > 0).map(([k, v]) => `${k}:${v}`).slice(0, 5).join(', ');
+      const pos = liveTelemetry.has_position ? 'position OK' : 'waiting for position sample';
+      liveTelemetryText = `available (${liveTelemetry.spin_mode || 'spin'}, ${pos}${topics ? '; ' + topics : ''})`;
+    } else {
+      liveTelemetryText = `unavailable${liveTelemetry.error ? ': ' + liveTelemetry.error : ''}`;
+    }
+  }
+  setText('runtimeLiveTelemetry', liveTelemetryText);
   setText('runtimeObservatory', site.observatory || 'unknown');
   setText('runtimeConfigSource', site.source || 'unknown');
   setText('runtimeConfigPath', site.source_path || '(none)');

--- a/bin/console-demo.py
+++ b/bin/console-demo.py
@@ -431,8 +431,8 @@ summary { cursor: pointer; color: var(--muted); }
             <div class="sub" id="runBarSub">Set the NECST-side directory and filename. Start will run server-side validation before any simulated command.</div>
           </div>
           <div class="run-actions">
-            <button id="startObs" class="primary large" disabled title="Start the selected observation sequence. Check and Dry run are optional; the server still validates the obs-file path and options before starting.">Start observation</button>
-            <button id="abortObs" class="danger large" disabled title="Abort a running observation sequence and request recorder/gate/progress cleanup.">ABORT observation</button>
+            <button id="startObs" class="primary large" disabled title="Start the selected observation sequence. Check and Dry run are optional; Start always performs server-side validation before launching.">Start observation</button>
+            <button id="abortObs" class="danger large" title="Abort a running observation sequence and request recorder/gate/progress cleanup. Safety action: kept clickable even if status has not yet detected observing.">ABORT observation</button>
           </div>
         </div>
         <div class="optional-checks" title="Optional checks. They never move the telescope, move the chopper, start recording, open gates, or apply SG settings.">
@@ -462,6 +462,7 @@ summary { cursor: pointer; color: var(--muted); }
               <button id="openObsChooser" class="primary compact" type="button" title="Open the NECST-side file chooser in a dialog.">Choose...</button>
               <button id="previewCurrentObs" class="secondary compact" type="button" title="Preview the file currently shown in Obs file on NECST side.">Preview</button>
             </div>
+            <div id="obsPathFull" class="path-text obs-full-path" title="Full NECST-side path used by Preview, Check, Dry run, and Start.">No obs file selected</div>
             <small>Click Choose to browse files visible to the console process. In Docker, this means Docker/container files.</small>
           </div>
         </div>
@@ -1308,7 +1309,9 @@ function renderStatus(data) {
   qs('authorityButton').disabled = Boolean(state.liveActions.guarded) && !heldByMe;
   qs('obsStateBadge').textContent = data.state;
   qs('obsStateBadge').className = 'badge ' + (data.state === 'observing' ? 'ok' : (data.state === 'calibrating' ? 'warn' : 'info'));
-  qs('abortObs').disabled = data.state !== 'observing';
+  // ABORT is a safety action.  It must stay clickable even when the
+  // observation state cannot be inferred from status/progress yet.
+  qs('abortObs').disabled = false;
   qs('manualBadge').textContent = data.manual_state;
   qs('manualBadge').className = 'badge ' + motionClass;
   qs('motionSummary').textContent = data.manual_state;
@@ -1324,6 +1327,9 @@ function renderStatus(data) {
   qs('calStatusNotice').className = 'notice ' + (data.state === 'calibrating' ? 'ok' : '');
   renderRuntime(data);
   applyCapabilities(data);
+  // Capabilities/live guard arrive via /api/status after page load.  Re-run
+  // obs validation so Start does not remain disabled until Check is pressed.
+  validateObs();
 }
 function renderLog(items) {
   qs('log').innerHTML = items.map(item => {
@@ -1366,8 +1372,15 @@ function updateObsRunPath() {
     const name = nameRaw.replace(/^\/+/, '');
     qs('obsPath').value = (dir && name) ? `${dir}/${name}` : '';
   }
-  qs('runBarTitle').textContent = qs('obsPath').value || 'No obs file selected';
-  qs('runBarSub').textContent = qs('obsPath').value ? `${qs('obsMode').value.toUpperCase()} / ${state.obsChecked ? 'checked' : 'unchecked, Start will validate'}` : 'Set the NECST-side directory and filename.';
+  const fullPath = qs('obsPath').value || '';
+  qs('obsPath').title = fullPath || 'Read-only computed NECST-side path used by Start observation.';
+  const fullPathEl = qs('obsPathFull');
+  if (fullPathEl) {
+    fullPathEl.textContent = fullPath || 'No obs file selected';
+    fullPathEl.title = fullPath || 'Full NECST-side path used by Preview, Check, Dry run, and Start.';
+  }
+  qs('runBarTitle').textContent = fullPath || 'No obs file selected';
+  qs('runBarSub').textContent = fullPath ? `${qs('obsMode').value.toUpperCase()} / ${state.obsChecked ? 'checked' : 'unchecked, Start will validate'}` : 'Set the NECST-side directory and filename.';
 }
 function updatePreviewInfo() {
   const text = qs('obsPreview').value;

--- a/bin/console-demo.py
+++ b/bin/console-demo.py
@@ -200,6 +200,7 @@ button.pending:not(:disabled) { border-color: rgba(122,162,255,0.75); background
 .danger { background: #7a2027; border-color: #d35d68; font-weight: 700; }
 .secondary { background: #18213b; }
 .ghost { background: transparent; }
+button.selected:not(:disabled) { border-color: rgba(86,211,100,0.70); box-shadow: 0 0 0 2px rgba(86,211,100,0.12); }
 .run-bar {
   position: sticky;
   top: 78px;
@@ -692,8 +693,8 @@ summary { cursor: pointer; color: var(--muted); }
           </div>
           <div class="notice ok">The current chopper state is shown continuously. The status button only logs a manual refresh.</div>
           <div class="actions">
-            <button id="chopperIn" class="primary">Chopper IN</button>
-            <button id="chopperOut" class="secondary">Chopper OUT</button>
+            <button id="chopperIn" class="secondary" aria-pressed="false">Chopper IN</button>
+            <button id="chopperOut" class="primary selected" aria-pressed="true">Chopper OUT (current)</button>
             <button id="chopperStatus" class="ghost">Log status</button>
           </div>
           <details>
@@ -1158,6 +1159,29 @@ function setButtonBusyClass(id, mode) {
   el.classList.remove('busy', 'pending');
   if (mode === 'running') el.classList.add('busy');
   if (mode === 'starting') el.classList.add('pending');
+}
+function setActionButtonCurrent(id, active, currentText, normalText) {
+  const el = qs(id);
+  if (!el) return;
+  el.classList.toggle('primary', Boolean(active));
+  el.classList.toggle('secondary', !active);
+  el.classList.toggle('selected', Boolean(active));
+  el.setAttribute('aria-pressed', active ? 'true' : 'false');
+  if (currentText || normalText) el.textContent = active ? currentText : normalText;
+}
+function normalizeChopperState(value) {
+  return String(value ?? '').trim().toUpperCase().replace(/[?！!]+$/g, '');
+}
+function updateChopperButtons(chopper) {
+  const stateText = normalizeChopperState(chopper && chopper.state);
+  const isIn = stateText === 'IN';
+  const isOut = stateText === 'OUT';
+  setActionButtonCurrent('chopperIn', isIn, 'Chopper IN (current)', 'Chopper IN');
+  setActionButtonCurrent('chopperOut', isOut, 'Chopper OUT (current)', 'Chopper OUT');
+  const inButton = qs('chopperIn');
+  const outButton = qs('chopperOut');
+  if (inButton) inButton.title = isIn ? 'Current chopper state is IN.' : 'Move chopper to IN.';
+  if (outButton) outButton.title = isOut ? 'Current chopper state is OUT.' : 'Move chopper to OUT.';
 }
 function operationLocksActive(op) {
   return Boolean(op && ['starting', 'running', 'attention'].includes(op.phase));
@@ -1698,6 +1722,7 @@ function renderStatus(data) {
   qs('chopperState').textContent = data.chopper.state;
   qs('chopperPos').textContent = data.chopper.position;
   qs('chopperAge').textContent = data.chopper.age || 'live demo';
+  updateChopperButtons(data.chopper || {});
   qs('stopTracking').disabled = data.manual_state !== 'tracking';
   if (['rsky', 'skydip', 'calibration'].includes(operation.kind)) {
     qs('calStatusNotice').textContent = operation.label + ': ' + operation.detail;
@@ -2597,7 +2622,7 @@ def _validate_positive_float(value: Any, name: str) -> Tuple[bool, str, Optional
     return True, "ok", number
 
 
-def _with_privilege(server: ConsoleDemoServer, session_id: str, action_text: str) -> str:
+def _with_authority(server: ConsoleDemoServer, session_id: str, action_text: str) -> str:
     state = server.state
     if state.authority_held:
         if state.authority_session_id == session_id:
@@ -2741,10 +2766,10 @@ def handle_action(
             return False, reason
         assert az is not None and el is not None
         prefix = "dry-run mount move" if action == "mount_move_dry_run" else "mount move"
-        privilege_msg = _with_privilege(server, session_id, prefix)
-        if "rejected" in privilege_msg:
-            server.add_log(False, privilege_msg)
-            return False, privilege_msg
+        authority_msg = _with_authority(server, session_id, prefix)
+        if "rejected" in authority_msg:
+            server.add_log(False, authority_msg)
+            return False, authority_msg
         if action == "mount_move":
             _demo_mark_exclusive_start_guard(state, action, f"mount move Az={az:.4f} deg El={el:.4f} deg")
             state.command_az = az
@@ -2753,7 +2778,7 @@ def handle_action(
             state.el = el
             state.manual_state = "moving"
             state.active_task = "manual mount move"
-        server.add_log(True, f"{privilege_msg}: Az={az:.6f} deg, El={el:.6f} deg")
+        server.add_log(True, f"{authority_msg}: Az={az:.6f} deg, El={el:.6f} deg")
         return True, "ok"
 
     if action == "check_observation":
@@ -2779,10 +2804,10 @@ def handle_action(
         if not ok:
             server.add_log(False, f"observation not started: {reason}")
             return False, reason
-        privilege_msg = _with_privilege(server, session_id, "start observation")
-        if "rejected" in privilege_msg:
-            server.add_log(False, privilege_msg)
-            return False, privilege_msg
+        authority_msg = _with_authority(server, session_id, "start observation")
+        if "rejected" in authority_msg:
+            server.add_log(False, authority_msg)
+            return False, authority_msg
         _demo_mark_exclusive_start_guard(state, action, "observation")
         state.command_az = None
         state.command_el = None
@@ -2791,7 +2816,7 @@ def handle_action(
         state.active_task = "observation"
         mode = str(params.get("mode") or "")
         path = str(params.get("file") or "").strip()
-        server.add_log(True, f"{privilege_msg}: mode={mode}, file={path}")
+        server.add_log(True, f"{authority_msg}: mode={mode}, file={path}")
         return True, "observation started"
 
     if action == "abort_observation":
@@ -2813,10 +2838,10 @@ def handle_action(
         if not ok:
             server.add_log(False, f"tracking not started: {reason}")
             return False, reason
-        privilege_msg = _with_privilege(server, session_id, "start tracking")
-        if "rejected" in privilege_msg:
-            server.add_log(False, privilege_msg)
-            return False, privilege_msg
+        authority_msg = _with_authority(server, session_id, "start tracking")
+        if "rejected" in authority_msg:
+            server.add_log(False, authority_msg)
+            return False, authority_msg
         _demo_mark_exclusive_start_guard(state, action, "target tracking")
         state.command_az = None
         state.command_el = None
@@ -2827,15 +2852,15 @@ def handle_action(
         off_y = float(params.get("offset_y_arcsec") or 0)
         server.add_log(
             True,
-            f"{privilege_msg}: target={kind}, offset=({off_x:g}, {off_y:g}) arcsec; stop with STOP",
+            f"{authority_msg}: target={kind}, offset=({off_x:g}, {off_y:g}) arcsec; stop with STOP",
         )
         return True, "tracking started"
 
     if action.startswith("chopper_"):
-        privilege_msg = _with_privilege(server, session_id, action.replace("_", " "))
-        if "rejected" in privilege_msg:
-            server.add_log(False, privilege_msg)
-            return False, privilege_msg
+        authority_msg = _with_authority(server, session_id, action.replace("_", " "))
+        if "rejected" in authority_msg:
+            server.add_log(False, authority_msg)
+            return False, authority_msg
         if action == "chopper_in":
             state.chopper_state = "IN"
             state.chopper_position = 4750
@@ -2855,7 +2880,7 @@ def handle_action(
             return True, "status"
         else:
             return False, f"unknown chopper action: {action}"
-        server.add_log(True, f"{privilege_msg}: state={state.chopper_state}, position={state.chopper_position}")
+        server.add_log(True, f"{authority_msg}: state={state.chopper_state}, position={state.chopper_position}")
         return True, "ok"
 
     if action == "run_rsky":
@@ -2871,17 +2896,17 @@ def handle_action(
         if err:
             server.add_log(False, f"RSky not started: {err}")
             return False, err
-        privilege_msg = _with_privilege(server, session_id, "RSky")
-        if "rejected" in privilege_msg:
-            server.add_log(False, privilege_msg)
-            return False, privilege_msg
+        authority_msg = _with_authority(server, session_id, "RSky")
+        if "rejected" in authority_msg:
+            server.add_log(False, authority_msg)
+            return False, authority_msg
         _demo_mark_exclusive_start_guard(state, action, "RSky")
         state.command_az = None
         state.command_el = None
         state.state = "calibrating"
         state.manual_state = "calibration"
         state.active_task = "RSky"
-        server.add_log(True, f"{privilege_msg}: n={n or 1}, integ={integ:g} s")
+        server.add_log(True, f"{authority_msg}: n={n or 1}, integ={integ:g} s")
         return True, "RSky started"
 
     if action == "run_skydip":
@@ -2905,17 +2930,17 @@ def handle_action(
                 reason = "tp_range must contain START END pairs"
                 server.add_log(False, f"SkyDip not started: {reason}")
                 return False, reason
-        privilege_msg = _with_privilege(server, session_id, "SkyDip")
-        if "rejected" in privilege_msg:
-            server.add_log(False, privilege_msg)
-            return False, privilege_msg
+        authority_msg = _with_authority(server, session_id, "SkyDip")
+        if "rejected" in authority_msg:
+            server.add_log(False, authority_msg)
+            return False, authority_msg
         _demo_mark_exclusive_start_guard(state, action, "SkyDip")
         state.command_az = None
         state.command_el = None
         state.state = "calibrating"
         state.manual_state = "calibration"
         state.active_task = "SkyDip"
-        server.add_log(True, f"{privilege_msg}: integ={integ:g} s")
+        server.add_log(True, f"{authority_msg}: integ={integ:g} s")
         return True, "SkyDip started"
 
     reason = f"unknown action: {action!r}"

--- a/bin/console-demo.py
+++ b/bin/console-demo.py
@@ -112,6 +112,42 @@ small { color: var(--faint); }
 .title h1 { margin: 0; font-size: 18px; letter-spacing: 0.01em; }
 .title .subtitle { color: var(--muted); font-size: 12px; }
 .status-line { display: flex; flex-wrap: wrap; gap: 7px; align-items: center; margin-top: 7px; }
+.node-health {
+  margin-top: 6px;
+  max-width: 100%;
+  border: 1px solid rgba(40,50,74,0.9);
+  border-radius: 12px;
+  background: rgba(255,255,255,0.035);
+  color: var(--muted);
+}
+.node-health[hidden] { display: none; }
+.node-health summary {
+  cursor: pointer;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+  padding: 5px 8px;
+  list-style: none;
+}
+.node-health summary::-webkit-details-marker { display: none; }
+.node-health summary::before { content: "▸"; color: var(--faint); }
+.node-health[open] summary::before { content: "▾"; }
+.node-health-details {
+  display: grid;
+  gap: 4px;
+  padding: 0 8px 8px 22px;
+  font-size: 12px;
+}
+.node-health-row {
+  display: grid;
+  grid-template-columns: 34px minmax(120px, 210px) minmax(180px, 1fr);
+  gap: 8px;
+  align-items: baseline;
+  min-width: 0;
+}
+.node-health-row .name { overflow-wrap: anywhere; word-break: break-word; color: var(--faint); }
+.node-health-note { color: var(--faint); overflow-wrap: anywhere; word-break: break-word; }
 .header-actions { display: flex; flex-wrap: wrap; gap: 8px; justify-content: flex-end; align-items: center; }
 .badge {
   display: inline-flex;
@@ -642,6 +678,10 @@ summary { cursor: pointer; color: var(--muted); }
         <span class="subtitle">standalone layout preview / no ROS / no telescope command</span>
       </div>
       <div class="status-line" id="statusBadges"></div>
+      <details class="node-health" id="nodeHealthBox" hidden>
+        <summary id="nodeHealthSummary">ROS node health</summary>
+        <div class="node-health-details" id="nodeHealthDetails"></div>
+      </details>
     </div>
     <div class="header-actions">
       <button id="openProgress" class="secondary" title="Start or open the progress-monitor server managed by this console. If this console exits, only a console-owned progress server stops.">Launch progress monitor</button>
@@ -1791,6 +1831,51 @@ function processSummary(counts) {
 function escapeHtml(value) {
   return String(value ?? '').replace(/[&<>"']/g, ch => ({'&':'&amp;', '<':'&lt;', '>':'&gt;', '"':'&quot;', "'":'&#39;'}[ch]));
 }
+function healthClass(value) {
+  const text = String(value || '').toUpperCase();
+  if (text === 'OK') return 'ok';
+  if (text === 'NG') return 'bad';
+  if (text === 'DEGRADED' || text === 'UNKNOWN') return 'warn';
+  return 'info';
+}
+function renderNodeHealth(payload) {
+  const box = qs('nodeHealthBox');
+  const summary = qs('nodeHealthSummary');
+  const details = qs('nodeHealthDetails');
+  if (!box || !summary || !details) return;
+  if (!payload || payload.enabled !== true) {
+    box.hidden = true;
+    return;
+  }
+  box.hidden = false;
+  const system = payload.system || 'UNKNOWN';
+  const manual = payload.manual_mount || 'UNKNOWN';
+  const observation = payload.observation || 'UNKNOWN';
+  const missingRequired = Array.isArray(payload.missing_required) ? payload.missing_required : [];
+  const missingOptional = Array.isArray(payload.missing_optional) ? payload.missing_optional : [];
+  const missingText = missingRequired.length ? `Missing: ${missingRequired.slice(0, 4).join(', ')}${missingRequired.length > 4 ? ', ...' : ''}` : (missingOptional.length ? `Optional missing: ${missingOptional.slice(0, 4).join(', ')}${missingOptional.length > 4 ? ', ...' : ''}` : 'All configured nodes present');
+  summary.innerHTML = [
+    `<span class="badge ${healthClass(system)}">Node Health: ${escapeHtml(system)}</span>`,
+    `<span class="badge ${healthClass(manual)}">Manual mount: ${escapeHtml(manual)}</span>`,
+    `<span class="badge ${healthClass(observation)}">Observation: ${escapeHtml(observation)}</span>`,
+    `<span class="node-health-note">${escapeHtml(missingText)}</span>`
+  ].join('');
+  const rows = Array.isArray(payload.nodes) ? payload.nodes : [];
+  const rowHtml = rows.length ? rows.map(node => {
+    const present = node.present;
+    const cls = present === true ? 'ok' : (present === false ? 'bad' : 'warn');
+    const mark = present === true ? 'OK' : (present === false ? 'NG' : '--');
+    const label = node.label || node.name || 'node';
+    const nodeClass = node.class || 'optional';
+    return `<div class="node-health-row"><span class="badge ${cls}">${mark}</span><b>${escapeHtml(label)}</b><span class="name">${escapeHtml(node.name || '')} <small>${escapeHtml(nodeClass)}</small></span></div>`;
+  }).join('') : '<div class="node-health-note">No expected nodes are configured.</div>';
+  const errorHtml = payload.error ? `<div class="node-health-note">Error: ${escapeHtml(payload.error)}</div>` : '';
+  const warningHtml = Array.isArray(payload.config_warnings) && payload.config_warnings.length ? `<div class="node-health-note">Config warning: ${escapeHtml(payload.config_warnings.join('; '))}</div>` : '';
+  const checkedHtml = payload.last_checked_utc ? `<div class="node-health-note">Last checked: ${escapeHtml(payload.last_checked_utc)} / poll ${escapeHtml(payload.poll_interval_sec ?? '')} sec</div>` : '';
+  const noteHtml = payload.note ? `<div class="node-health-note">${escapeHtml(payload.note)}</div>` : '';
+  details.innerHTML = `${errorHtml}${warningHtml}${rowHtml}${checkedHtml}${noteHtml}`;
+}
+
 function parseProcessTime(p) {
   const raw = Number(p && p.started_at);
   if (Number.isFinite(raw)) return raw;
@@ -2328,6 +2413,7 @@ function renderStatus(data) {
     `<span class="badge ${processClass}">Launchers: ${runningCount} active</span>`,
     `<span class="badge ${data.warning_count ? 'warn' : 'ok'}">Warnings: ${data.warning_count || 0}</span>`
   ].join('');
+  renderNodeHealth(data.node_health);
   qs('authorityButton').textContent = heldByMe ? 'Release authority' : 'Acquire authority';
   qs('authorityButton').disabled = Boolean(state.liveActions.guarded) && !heldByMe;
   qs('obsStateBadge').textContent = operation.kind === 'observation' ? operation.label : data.state;
@@ -3287,6 +3373,83 @@ class LogEntry:
     message: str
 
 
+
+DEMO_NODE_HEALTH_NODES = [
+    {
+        "name": "/necst/OMU1P85M/ctrl/antenna/encoder_readout",
+        "label": "Antenna encoder",
+        "class": "manual_mount_required",
+        "present": True,
+    },
+    {
+        "name": "/necst/OMU1P85M/ctrl/antenna/motor_driver",
+        "label": "Antenna motor",
+        "class": "manual_mount_required",
+        "present": True,
+    },
+    {
+        "name": "/necst/OMU1P85M/ctrl/antenna/controller",
+        "label": "Antenna controller",
+        "class": "manual_mount_required",
+        "present": True,
+    },
+    {
+        "name": "/necst/OMU1P85M/ctrl/antenna/altaz_coord",
+        "label": "AltAz coordinate",
+        "class": "manual_mount_required",
+        "present": True,
+    },
+    {
+        "name": "/necst/OMU1P85M/rx/spectrometer",
+        "label": "Spectrometer",
+        "class": "observation_required",
+        "present": True,
+    },
+    {
+        "name": "/necst/OMU1P85M/core/recorder",
+        "label": "Recorder",
+        "class": "observation_required",
+        "present": True,
+    },
+    {
+        "name": "/necst/OMU1P85M/ctrl/calib/chopper",
+        "label": "Chopper",
+        "class": "optional",
+        "present": True,
+    },
+    {
+        "name": "/necst/OMU1P85M/thermometer_reader",
+        "label": "Weather station",
+        "class": "optional",
+        "present": True,
+    },
+]
+
+
+def demo_node_health_payload() -> Dict[str, Any]:
+    """Return a static ROS-node-health payload for the standalone demo.
+
+    The real console intentionally hides node health when [console.health] is
+    absent from the site TOML.  The standalone demo has no site TOML or ROS
+    graph, so it publishes a small simulated payload to make the compact UI
+    strip and details view directly checkable.
+    """
+
+    return {
+        "enabled": True,
+        "demo": True,
+        "system": "OK",
+        "manual_mount": "OK",
+        "observation": "OK",
+        "poll_interval_sec": 2.0,
+        "last_checked_utc": datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z"),
+        "missing_required": [],
+        "missing_optional": [],
+        "nodes": [dict(node) for node in DEMO_NODE_HEALTH_NODES],
+        "note": "console-demo uses simulated ROS node health; the real console still requires [console.health] in the site TOML.",
+    }
+
+
 @dataclass
 class DemoState:
     telescope: str = "OMU1.85m demo"
@@ -3384,6 +3547,7 @@ class DemoState:
                 "blocking_sec": EXCLUSIVE_START_BLOCK_SEC,
             },
             "log": [entry.__dict__ for entry in self.log[-80:]],
+            "node_health": demo_node_health_payload(),
         }
 
 

--- a/bin/console-demo.py
+++ b/bin/console-demo.py
@@ -104,16 +104,19 @@ small { color: var(--faint); }
 .header-inner {
   display: grid;
   grid-template-columns: minmax(420px, 1fr) auto;
-  gap: 12px;
+  gap: 8px 12px;
   align-items: center;
   padding: 10px 16px;
 }
+.header-main { min-width: 0; }
 .title { display: flex; flex-wrap: wrap; gap: 8px; align-items: baseline; }
 .title h1 { margin: 0; font-size: 18px; letter-spacing: 0.01em; }
 .title .subtitle { color: var(--muted); font-size: 12px; }
 .status-line { display: flex; flex-wrap: wrap; gap: 7px; align-items: center; margin-top: 7px; }
 .node-health {
-  margin-top: 6px;
+  grid-column: 1 / -1;
+  margin-top: 2px;
+  width: 100%;
   max-width: 100%;
   border: 1px solid rgba(40,50,74,0.9);
   border-radius: 12px;
@@ -127,6 +130,8 @@ small { color: var(--faint); }
   flex-wrap: wrap;
   gap: 6px;
   align-items: center;
+  justify-content: center;
+  text-align: center;
   padding: 5px 8px;
   list-style: none;
 }
@@ -136,6 +141,8 @@ small { color: var(--faint); }
 .node-health-details {
   display: grid;
   gap: 4px;
+  max-width: min(100%, 980px);
+  margin: 0 auto;
   padding: 0 8px 8px 22px;
   font-size: 12px;
 }
@@ -526,6 +533,37 @@ summary { cursor: pointer; color: var(--muted); }
 .invalid { border-color: var(--bad) !important; }
 .valid { border-color: rgba(86,211,100,0.8) !important; }
 
+.launcher-failure {
+  margin: 10px 0 0;
+  border: 1px solid rgba(255,91,110,0.45);
+  border-radius: 14px;
+  background: rgba(255,91,110,0.08);
+  padding: 10px 12px;
+  box-shadow: 0 10px 26px rgba(0,0,0,0.13);
+}
+.launcher-failure .failure-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: start;
+}
+.launcher-failure .failure-title { color: var(--bad); font-weight: 800; letter-spacing: 0.01em; }
+.launcher-failure .failure-summary { margin-top: 3px; color: var(--text); font-size: 12px; line-height: 1.45; overflow-wrap: anywhere; }
+.launcher-failure .failure-meta { margin-top: 3px; color: var(--muted); font-size: 11px; overflow-wrap: anywhere; }
+.launcher-failure .failure-actions { display: flex; gap: 6px; justify-content: flex-end; flex-wrap: wrap; }
+.launcher-failure pre {
+  margin: 9px 0 0;
+  max-height: 260px;
+  overflow: auto;
+  white-space: pre-wrap;
+  border: 1px solid rgba(255,91,110,0.25);
+  border-radius: 10px;
+  padding: 8px;
+  background: rgba(0,0,0,0.22);
+  color: var(--text);
+  font-size: 12px;
+}
+
 .obslog-card {
   margin: 12px 0 0;
   border-radius: 14px;
@@ -664,6 +702,8 @@ summary { cursor: pointer; color: var(--muted); }
   .run-bar { position: static; grid-template-columns: 1fr; }
   .run-actions { justify-content: stretch; flex-wrap: wrap; }
   .run-actions button { flex: 1 1 180px; }
+  .launcher-failure .failure-row { grid-template-columns: 1fr; }
+  .launcher-failure .failure-actions { justify-content: flex-start; }
   .row, .row3 { grid-template-columns: 1fr; }
   .stop-button { width: 100%; }
 }
@@ -672,22 +712,22 @@ summary { cursor: pointer; color: var(--muted); }
 <body>
 <header class="header">
   <div class="header-inner">
-    <div>
+    <div class="header-main">
       <div class="title">
         <h1>NECST Operator Console Demo</h1>
         <span class="subtitle">standalone layout preview / no ROS / no telescope command</span>
       </div>
       <div class="status-line" id="statusBadges"></div>
-      <details class="node-health" id="nodeHealthBox" hidden>
-        <summary id="nodeHealthSummary">ROS node health</summary>
-        <div class="node-health-details" id="nodeHealthDetails"></div>
-      </details>
     </div>
     <div class="header-actions">
       <button id="openProgress" class="secondary" title="Start or open the progress-monitor server managed by this console. If this console exits, only a console-owned progress server stops.">Launch progress monitor</button>
       <button id="authorityButton" class="secondary">Acquire authority</button>
       <button id="stopButton" class="stop-button">STOP</button>
     </div>
+    <details class="node-health" id="nodeHealthBox" hidden>
+      <summary id="nodeHealthSummary">ROS node health</summary>
+      <div class="node-health-details" id="nodeHealthDetails"></div>
+    </details>
   </div>
 </header>
 <main class="page">
@@ -697,6 +737,22 @@ summary { cursor: pointer; color: var(--muted); }
       <div class="detail" id="systemStateDetail">No observation, mount move, or calibration is currently confirmed.</div>
     </div>
     <div class="safe">STOP and ABORT remain available.</div>
+  </div>
+  <div class="launcher-failure" id="launcherFailureBanner" hidden aria-live="polite">
+    <div class="failure-row">
+      <div>
+        <div class="failure-title" id="launcherFailureTitle">Last launcher error</div>
+        <div class="failure-summary" id="launcherFailureSummary"></div>
+        <div class="failure-meta" id="launcherFailureMeta"></div>
+      </div>
+      <div class="failure-actions">
+        <button id="launcherFailureStderr" class="secondary compact" type="button">Show stderr</button>
+        <button id="launcherFailureStdout" class="secondary compact" type="button">Show stdout</button>
+        <button id="launcherFailureCopy" class="secondary compact" type="button">Copy summary</button>
+        <button id="launcherFailureClear" class="secondary compact" type="button" title="Hide only this displayed error summary. Logs and CSV records are kept.">Clear</button>
+      </div>
+    </div>
+    <pre id="launcherFailureText" hidden></pre>
   </div>
   <div class="main-grid">
     <section class="card" id="observationCard">
@@ -2015,6 +2071,66 @@ async function readLogFile(path) {
   const resp = await fetch('/api/log-file?max_bytes=32768&path=' + encodeURIComponent(path));
   const data = await resp.json();
   renderLauncherLogBrowser(data);
+  return data;
+}
+function launcherFailurePayload() {
+  const payload = (state.lastStatus || {}).last_launcher_failure || {};
+  return (payload && typeof payload === 'object') ? payload : {};
+}
+function renderLauncherFailure(payload) {
+  const box = qs('launcherFailureBanner');
+  if (!box) return;
+  const f = (payload && typeof payload === 'object') ? payload : {};
+  const summary = String(f.summary || f.message || '').trim();
+  if (!summary) {
+    box.hidden = true;
+    const text = qs('launcherFailureText');
+    if (text) { text.hidden = true; text.textContent = ''; }
+    return;
+  }
+  box.hidden = false;
+  const title = f.label || f.category || 'local launcher';
+  const rc = (f.returncode === null || f.returncode === undefined || f.returncode === '') ? 'unknown' : f.returncode;
+  setText('launcherFailureTitle', `Last ${f.category || 'launcher'} error: ${title}`);
+  setText('launcherFailureSummary', summary);
+  const meta = [
+    f.pid ? `pid=${f.pid}` : '',
+    f.status ? `status=${f.status}` : '',
+    `returncode=${rc}`,
+    f.stream ? `summary from ${f.stream}` : '',
+    f.time || ''
+  ].filter(Boolean).join(' · ');
+  setText('launcherFailureMeta', meta);
+  const stderrBtn = qs('launcherFailureStderr');
+  const stdoutBtn = qs('launcherFailureStdout');
+  if (stderrBtn) stderrBtn.disabled = !f.stderr_path;
+  if (stdoutBtn) stdoutBtn.disabled = !f.stdout_path;
+}
+async function showLauncherFailureLog(stream) {
+  const f = launcherFailurePayload();
+  const path = stream === 'stdout' ? f.stdout_path : f.stderr_path;
+  const out = qs('launcherFailureText');
+  if (!path || !out) return;
+  out.hidden = false;
+  out.textContent = `Loading ${stream} log...\n${path}`;
+  try {
+    const data = await readLogFile(path);
+    const header = `${stream.toUpperCase()} ${data.ok ? 'tail' : 'read failed'}: ${data.path || path}\n${data.reason || ''}\n\n`;
+    out.textContent = header + (data.text || '(log is empty)');
+  } catch (err) {
+    out.textContent = `Failed to read ${stream} log: ${err}`;
+  }
+}
+async function copyLauncherFailureSummary() {
+  const f = launcherFailurePayload();
+  const text = [
+    f.message || f.summary || 'launcher failed',
+    f.pid ? `pid=${f.pid}` : '',
+    f.returncode !== undefined && f.returncode !== null ? `returncode=${f.returncode}` : '',
+    f.stderr_path ? `stderr=${f.stderr_path}` : '',
+    f.stdout_path ? `stdout=${f.stdout_path}` : ''
+  ].filter(Boolean).join('\n');
+  try { await navigator.clipboard.writeText(text); } catch (_) {}
 }
 function progressMonitorText(progress) {
   const mon = progress && (progress.monitor || progress.monitor_status || progress.progress_monitor);
@@ -2414,6 +2530,7 @@ function renderStatus(data) {
     `<span class="badge ${data.warning_count ? 'warn' : 'ok'}">Warnings: ${data.warning_count || 0}</span>`
   ].join('');
   renderNodeHealth(data.node_health);
+  renderLauncherFailure(data.last_launcher_failure);
   qs('authorityButton').textContent = heldByMe ? 'Release authority' : 'Acquire authority';
   qs('authorityButton').disabled = Boolean(state.liveActions.guarded) && !heldByMe;
   qs('obsStateBadge').textContent = operation.kind === 'observation' ? operation.label : data.state;
@@ -2905,6 +3022,16 @@ qs('runtimeLauncherLogChoices').addEventListener('click', async (ev) => {
   const btn = ev.target && ev.target.closest ? ev.target.closest('.log-choice') : null;
   if (!btn) return;
   await readLogFile(btn.dataset.path);
+});
+qs('launcherFailureStderr').addEventListener('click', () => showLauncherFailureLog('stderr'));
+qs('launcherFailureStdout').addEventListener('click', () => showLauncherFailureLog('stdout'));
+qs('launcherFailureCopy').addEventListener('click', copyLauncherFailureSummary);
+qs('launcherFailureClear').addEventListener('click', async () => {
+  const box = qs('launcherFailureBanner');
+  if (box) box.hidden = true;
+  const text = qs('launcherFailureText');
+  if (text) { text.hidden = true; text.textContent = ''; }
+  await api('clear_launcher_failure');
 });
 qs('runSelfCheck').addEventListener('click', async () => {
   const resp = await fetch('/api/self-check');
@@ -3481,6 +3608,7 @@ class DemoState:
     recording_dir: Optional[str] = None
     local_recording_dir: Optional[str] = None
     progress_record_dir: Optional[str] = None
+    last_launcher_failure: Dict[str, Any] = field(default_factory=dict)
     log: List[LogEntry] = field(default_factory=list)
 
     def prune_exclusive_start_guard(self) -> None:
@@ -3548,6 +3676,7 @@ class DemoState:
             },
             "log": [entry.__dict__ for entry in self.log[-80:]],
             "node_health": demo_node_health_payload(),
+            "last_launcher_failure": dict(self.last_launcher_failure or {}),
         }
 
 
@@ -3697,14 +3826,31 @@ class Handler(BaseHTTPRequestHandler):
         if parsed.path == "/api/log-file":
             query = urllib.parse.parse_qs(parsed.query)
             requested = (query.get("path") or ["demo://launcher.log"])[0]
+            if requested.startswith("demo://start_observation.stderr"):
+                text = (
+                    "Traceback (most recent call last):\n"
+                    "  File \"/root/ros2_ws/src/necst/bin/psw_file.py\", line 36, in <module>\n"
+                    "    obs.execute()\n"
+                    "  File \"/root/ros2_ws/build/necst/necst/rx/spectral_recording_sg.py\", line 597, in poll_sg_readback\n"
+                    "    raise SpectralRecordingSGValidationError(message)\n"
+                    "necst.rx.spectral_recording_sg.SpectralRecordingSGValidationError: output_required=true but readback output is off\n"
+                )
+            elif requested.startswith("demo://start_observation.stdout"):
+                text = (
+                    "2026-06-10 06:04:28,941: [INFO] Importing configuration from /root/.necst/OMU1p85m_config.toml\n"
+                    "2026-06-10 06:04:42,549: [INFO] Observation finished, took 0.21 min.\n"
+                    "2026-06-10 06:04:42,549: [INFO] Record name: necst_psw_20260610_060429_irc+10216\n"
+                )
+            else:
+                text = "This is the standalone console demo. No real launcher log file exists.\n"
             self._send_json({
                 "ok": True,
                 "reason": "demo launcher log read",
                 "path": requested,
-                "size_bytes": 0,
-                "returned_bytes": 0,
+                "size_bytes": len(text.encode("utf-8")),
+                "returned_bytes": len(text.encode("utf-8")),
                 "truncated_head": False,
-                "text": "This is the standalone console demo. No real launcher log file exists.\n",
+                "text": text,
             })
             return
         if parsed.path == "/api/self-check":
@@ -4167,6 +4313,12 @@ def handle_action(
         server.add_log(True, "operation log cleared")
         return True, "cleared"
 
+    if action == "clear_launcher_failure":
+        had_failure = bool(state.last_launcher_failure)
+        state.last_launcher_failure = {}
+        server.add_log(True, "last launcher error display cleared" if had_failure else "last launcher error display was already clear")
+        return True, "last launcher error display cleared"
+
     if action == "clear_stale_observation_state":
         _demo_clear_exclusive_start_guard(state)
         state.state = "idle"
@@ -4288,6 +4440,29 @@ def handle_action(
         path = str(params.get("file") or "").strip()
         stem = Path(path).name.rsplit('.', 1)[0] if path else 'demo_observation'
         _demo_set_record(state, f"{stem}_{int(time.time())}")
+        if "fail" in path.lower() or "sgfail" in path.lower():
+            _demo_clear_exclusive_start_guard(state)
+            state.state = "idle"
+            state.manual_state = "idle"
+            state.active_task = "none"
+            state.last_launcher_failure = {
+                "ok": False,
+                "category": "observation",
+                "label": f"observation:{mode}",
+                "action": "start_observation",
+                "pid": 12345,
+                "status": "exited",
+                "returncode": 1,
+                "summary": "necst.rx.spectral_recording_sg.SpectralRecordingSGValidationError: output_required=true but readback output is off",
+                "message": "observation launcher failed: output_required=true but readback output is off",
+                "stream": "stderr",
+                "stderr_path": "demo://start_observation.stderr.log",
+                "stdout_path": "demo://start_observation.stdout.log",
+                "time": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+            }
+            server.add_log(False, "demo observation launcher failed: output_required=true but readback output is off")
+            return False, "demo observation launcher failed; see Last observation error"
+        state.last_launcher_failure = {}
         server.add_log(True, f"{authority_msg}: mode={mode}, file={path}")
         return True, "observation started"
 

--- a/bin/console-demo.py
+++ b/bin/console-demo.py
@@ -514,7 +514,6 @@ summary { cursor: pointer; color: var(--muted); }
           <div class="run-actions">
             <button id="startObs" class="primary large" disabled title="Start the selected observation sequence. Check and Dry run are optional; Start always performs server-side validation before launching.">Start observation</button>
             <button id="abortObs" class="danger large" title="Abort a running observation sequence and request recorder/gate/progress cleanup. Safety action: kept clickable even if status has not yet detected observing.">ABORT observation</button>
-            <button id="clearStaleObs" class="secondary compact" type="button" disabled title="Recover the console from stale progress state after confirming the telescope/recorder are safe. This archives only current progress pointer files; it does not send hardware commands or delete data.">Clear stale state</button>
           </div>
         </div>
         <div id="obsOutputDirBox" class="obs-output-dir" aria-live="polite">
@@ -1131,18 +1130,6 @@ function safetyReleaseLooksIdle(data, ageSec) {
 }
 function actualOperationFromStatus(data) {
   data = data || {};
-  const stale = data.stale_observation || {};
-  if (stale.running_stale) {
-    const age = Number(stale.age_sec);
-    const ageText = Number.isFinite(age) ? `${age.toFixed(1)} s` : 'unknown age';
-    const record = stale.record_name || 'unknown record';
-    return {
-      phase: 'attention',
-      kind: 'observation',
-      label: 'ATTENTION: STALE OBSERVATION STATE',
-      detail: `Progress still says observation is running for ${record}, but no active launcher/fresh progress update is confirmed (${ageText}). Confirm the hardware is safe, then use Clear stale state.`
-    };
-  }
   const sys = lowerText(data.state || 'idle');
   const manual = lowerText(data.manual_state || 'idle');
   const task = lowerText(data.active_task || 'none');
@@ -1993,17 +1980,6 @@ function renderStatus(data) {
   // ABORT is a safety action.  It must stay clickable even when the
   // observation state cannot be inferred from status/progress yet.
   qs('abortObs').disabled = false;
-  const staleObs = data.stale_observation || {};
-  const staleButton = qs('clearStaleObs');
-  if (staleButton) {
-    const canClearStale = Boolean(staleObs.can_clear || staleObs.running_stale || operation.label === 'ATTENTION: STALE OBSERVATION STATE');
-    staleButton.disabled = !canClearStale;
-    staleButton.style.display = canClearStale ? '' : 'none';
-    if (canClearStale) {
-      const record = staleObs.record_name || 'unknown record';
-      staleButton.title = `Clear stale console/progress state for ${record}. Confirm hardware is safe first. This does not send hardware commands or delete data.`;
-    }
-  }
   qs('manualBadge').textContent = ['mount', 'tracking', 'rsky', 'skydip', 'calibration'].includes(operation.kind) ? operation.label : data.manual_state;
   qs('manualBadge').className = 'badge ' + (operation.phase === 'attention' ? 'bad' : (operation.phase === 'running' ? 'warn' : motionClass));
   qs('motionSummary').textContent = data.manual_state;
@@ -2302,14 +2278,6 @@ qs('startObs').addEventListener('click', async () => {
 qs('abortObs').addEventListener('click', async () => {
   if (confirm('Abort current observation and request recorder/gate/progress cleanup?')) await api('abort_observation', {}, 'abort');
 });
-qs('clearStaleObs').addEventListener('click', async () => {
-  const stale = (state.lastStatus || {}).stale_observation || {};
-  const record = stale.record_name || 'unknown record';
-  if (!confirm(`Clear stale observation/progress state for ${record}?\n\nOnly use this after confirming the telescope, recorder, and XFFTS are safe. This does not send hardware commands and does not delete observation data.`)) return;
-  clearPendingOperation();
-  const resp = await api('clear_stale_observation_state');
-  if (!resp.ok) alert('Clear stale state failed: ' + (resp.reason || 'unknown reason'));
-});
 qs('copyObsOutputDir').addEventListener('click', copyObservationOutputDir);
 qs('authorityButton').addEventListener('click', async () => {
   const resp = await fetch('/api/status');
@@ -2491,11 +2459,6 @@ class DemoState:
                 "url": self.progress_url,
                 "running": self.progress_running,
                 "owned_by_console": self.progress_owned_by_console,
-            },
-            "stale_observation": {
-                "running_stale": False,
-                "can_clear": False,
-                "record_name": self.record_name,
             },
             "state": self.state,
             "observation": {
@@ -3029,16 +2992,6 @@ def handle_action(
         state.log.clear()
         server.add_log(True, "operation log cleared")
         return True, "cleared"
-
-    if action == "clear_stale_observation_state":
-        _demo_clear_exclusive_start_guard(state)
-        state.state = "idle"
-        state.manual_state = "idle"
-        state.active_task = "none"
-        state.command_az = None
-        state.command_el = None
-        server.add_log(True, "stale observation state cleared in demo")
-        return True, "stale observation state cleared"
 
     if action == "acquire_authority":
         if state.authority_held and state.authority_session_id != session_id:

--- a/bin/console-demo.py
+++ b/bin/console-demo.py
@@ -1,0 +1,2023 @@
+#!/usr/bin/env python3
+"""Serve a standalone NECST operator-console UI demo.
+
+This tool is intentionally independent of NECST, neclib, ROS, and the real
+observation program.  It is a layout and workflow preview for the future
+operator console.  All actions are simulated, but every write-like action is
+validated both in the browser and on this demo server so the UI can be checked
+from the operator's point of view before connecting it to real telescope
+commands.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import signal
+import sys
+import threading
+import time
+import uuid
+import webbrowser
+import urllib.parse
+from dataclasses import dataclass, field
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, Dict, List, Optional, Tuple
+
+
+HTML = r"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>NECST Operator Console Demo</title>
+<style>
+:root {
+  --bg: #0b1020;
+  --panel: #11182c;
+  --panel2: #151f37;
+  --line: #28324a;
+  --text: #eaf0ff;
+  --muted: #aab6d4;
+  --faint: #7380a0;
+  --ok: #56d364;
+  --warn: #f2cc60;
+  --bad: #ff6b6b;
+  --accent: #7aa2ff;
+  --accent2: #9fd1ff;
+  --shadow: rgba(0, 0, 0, 0.35);
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  color: var(--text);
+  background: radial-gradient(circle at top left, #1b2c58 0, var(--bg) 34rem);
+  font: 14px/1.45 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+button, input, select, textarea { font: inherit; }
+button {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  color: var(--text);
+  background: #1a2440;
+  padding: 8px 12px;
+  cursor: pointer;
+}
+button:hover:not(:disabled) { border-color: var(--accent); background: #202d52; }
+button:disabled { opacity: 0.45; cursor: not-allowed; }
+button.compact { padding: 7px 10px; min-width: 72px; }
+button.primary.large, button.danger.large { min-width: 160px; min-height: 44px; }
+input, select, textarea {
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  color: var(--text);
+  background: #0d1428;
+  padding: 8px 10px;
+  outline: none;
+}
+input:focus, select:focus, textarea:focus { border-color: var(--accent); }
+input[readonly] { color: var(--muted); background: #10182e; }
+textarea {
+  resize: vertical;
+  min-height: 160px;
+  max-height: 460px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+label { display: block; color: var(--muted); font-size: 12px; margin: 0 0 4px; }
+small { color: var(--faint); }
+.header {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  background: rgba(11, 16, 32, 0.94);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid var(--line);
+  box-shadow: 0 6px 24px var(--shadow);
+}
+.header-inner {
+  display: grid;
+  grid-template-columns: minmax(420px, 1fr) auto;
+  gap: 12px;
+  align-items: center;
+  padding: 10px 16px;
+}
+.title { display: flex; flex-wrap: wrap; gap: 8px; align-items: baseline; }
+.title h1 { margin: 0; font-size: 18px; letter-spacing: 0.01em; }
+.title .subtitle { color: var(--muted); font-size: 12px; }
+.status-line { display: flex; flex-wrap: wrap; gap: 7px; align-items: center; margin-top: 7px; }
+.header-actions { display: flex; flex-wrap: wrap; gap: 8px; justify-content: flex-end; align-items: center; }
+.badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 3px 9px;
+  background: rgba(255,255,255,0.04);
+  color: var(--muted);
+  white-space: nowrap;
+}
+.badge.ok { border-color: rgba(86,211,100,0.5); color: var(--ok); }
+.badge.warn { border-color: rgba(242,204,96,0.55); color: var(--warn); }
+.badge.bad { border-color: rgba(255,107,107,0.55); color: var(--bad); }
+.badge.info { border-color: rgba(122,162,255,0.55); color: var(--accent2); }
+.stop-button {
+  min-width: 126px;
+  min-height: 48px;
+  font-weight: 900;
+  color: #fff;
+  background: #aa2630;
+  border-color: #ff8991;
+  box-shadow: 0 0 0 2px rgba(255,107,107,0.15);
+}
+.stop-button:hover:not(:disabled) { background: #c12e39; border-color: #ffb0b5; }
+.page { padding: 14px 16px 24px; max-width: 1540px; margin: 0 auto; }
+.main-grid {
+  display: grid;
+  grid-template-columns: minmax(520px, 1.05fr) minmax(430px, 0.95fr);
+  gap: 14px;
+  align-items: start;
+}
+.card {
+  background: linear-gradient(180deg, rgba(255,255,255,0.035), rgba(255,255,255,0.01)), var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  box-shadow: 0 10px 28px var(--shadow);
+  overflow: hidden;
+}
+.card.sticky { position: sticky; top: 88px; }
+.card-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: center;
+  padding: 13px 14px 8px;
+  border-bottom: 1px solid rgba(40,50,74,0.8);
+}
+.card-head h2 { margin: 0; font-size: 16px; }
+.card-head .hint { color: var(--muted); font-size: 12px; }
+.card-body { padding: 14px; }
+.row { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
+.row3 { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 10px; }
+.field { margin-bottom: 11px; }
+.actions { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
+.primary { background: #1c3f86; border-color: #5e8fff; font-weight: 700; }
+.primary:hover:not(:disabled) { background: #2450a5; }
+.danger { background: #7a2027; border-color: #d35d68; font-weight: 700; }
+.secondary { background: #18213b; }
+.ghost { background: transparent; }
+.run-bar {
+  position: sticky;
+  top: 78px;
+  z-index: 8;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 14px;
+  align-items: center;
+  margin: -2px -2px 12px;
+  padding: 10px;
+  border: 1px solid rgba(122,162,255,0.28);
+  border-radius: 14px;
+  background: rgba(17, 24, 44, 0.96);
+  box-shadow: 0 8px 20px rgba(0,0,0,0.25);
+}
+.run-target { min-width: 0; }
+.run-target .name { color: var(--text); font-weight: 700; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.run-target .sub { color: var(--muted); font-size: 12px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.run-actions { display: flex; gap: 8px; justify-content: flex-end; align-items: center; flex-wrap: nowrap; }
+.optional-checks { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin: 2px 0 10px; color: var(--muted); }
+.optional-checks .label { color: var(--faint); font-size: 12px; }
+.tabs { display: flex; gap: 6px; margin-bottom: 10px; flex-wrap: wrap; }
+.tab { padding: 7px 9px; border-radius: 999px; font-size: 13px; }
+.tab.active { background: #203865; border-color: var(--accent); color: #fff; }
+.panel { display: none; }
+.panel.active { display: block; }
+.notice {
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 9px 10px;
+  margin: 10px 0;
+  background: rgba(255,255,255,0.035);
+  color: var(--muted);
+}
+.notice.ok { border-color: rgba(86,211,100,0.45); color: var(--ok); }
+.notice.warn { border-color: rgba(242,204,96,0.5); color: var(--warn); }
+.notice.bad { border-color: rgba(255,107,107,0.5); color: var(--bad); }
+.compact-list { display: grid; gap: 6px; }
+.kv { display: grid; grid-template-columns: 142px 1fr; gap: 8px; color: var(--muted); }
+.kv b { color: var(--text); font-weight: 600; }
+.log {
+  height: 260px;
+  overflow: auto;
+  padding: 10px;
+  background: #080d1b;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+}
+.log-entry { padding: 4px 0; border-bottom: 1px dashed rgba(255,255,255,0.08); }
+.log-entry .time { color: var(--faint); }
+.log-entry .ok { color: var(--ok); }
+.log-entry .bad { color: var(--bad); }
+.runtime-grid { display:grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap:10px; }
+.runtime-card { border:1px solid var(--line); border-radius:12px; padding:10px; background:rgba(255,255,255,0.025); }
+.runtime-card h3 { margin:0 0 8px; font-size:13px; color:var(--accent2); }
+.runtime-list { display:grid; gap:6px; font-size:12px; color:var(--muted); }
+.runtime-list b { color:var(--text); font-weight:600; }
+.process-row { border-top:1px dashed rgba(255,255,255,0.10); padding-top:6px; margin-top:6px; color:var(--muted); }
+.process-row:first-child { border-top:0; margin-top:0; padding-top:0; }
+.mini-actions { display:flex; flex-wrap:wrap; gap:6px; margin-top:8px; }
+.process-row button { margin-top:5px; padding:5px 8px; font-size:12px; }
+.path-text { overflow:hidden; text-overflow:ellipsis; white-space:nowrap; direction:rtl; text-align:left; }
+.log-browser-text { max-height:220px; overflow:auto; white-space:pre-wrap; word-break:break-word; background:#080d1b; border:1px solid var(--line); border-radius:10px; padding:8px; font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace; font-size:11px; color:var(--muted); }
+.log-choice { display:block; width:100%; text-align:left; margin-top:4px; padding:5px 7px; font-size:12px; }
+.warning-list { color:var(--warn); }
+details {
+  margin-top: 10px;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 8px 10px;
+  background: rgba(255,255,255,0.02);
+}
+summary { cursor: pointer; color: var(--muted); }
+.callout {
+  display: grid;
+  gap: 4px;
+  border-left: 3px solid var(--accent);
+  padding: 8px 10px;
+  margin-bottom: 10px;
+  background: rgba(122,162,255,0.08);
+  color: var(--muted);
+}
+.callout b { color: var(--text); }
+.invalid { border-color: var(--bad) !important; }
+.valid { border-color: rgba(86,211,100,0.8) !important; }
+@media (max-width: 1050px) {
+  .header-inner { grid-template-columns: 1fr; }
+  .main-grid { grid-template-columns: 1fr; }
+  .card.sticky { position: static; }
+  .run-bar { position: static; grid-template-columns: 1fr; }
+  .run-actions { justify-content: stretch; flex-wrap: wrap; }
+  .run-actions button { flex: 1 1 180px; }
+  .row, .row3 { grid-template-columns: 1fr; }
+  .stop-button { width: 100%; }
+}
+</style>
+</head>
+<body>
+<header class="header">
+  <div class="header-inner">
+    <div>
+      <div class="title">
+        <h1>NECST Operator Console Demo</h1>
+        <span class="subtitle">standalone layout preview / no ROS / no telescope command</span>
+      </div>
+      <div class="status-line" id="statusBadges"></div>
+    </div>
+    <div class="header-actions">
+      <button id="openProgress" class="secondary" title="Start or open the progress-monitor server managed by this console. If this console exits, only a console-owned progress server stops.">Launch progress monitor</button>
+      <button id="authorityButton" class="secondary">Acquire authority</button>
+      <button id="stopButton" class="stop-button">STOP</button>
+    </div>
+  </div>
+</header>
+<main class="page">
+  <div class="main-grid">
+    <section class="card" id="observationCard">
+      <div class="card-head">
+        <div>
+          <h2>Observation setup and start</h2>
+          <div class="hint">Choose the obs file and start. Check and Dry run are optional pre-start checks.</div>
+        </div>
+        <span class="badge info" id="obsStateBadge">Idle</span>
+      </div>
+      <div class="card-body">
+        <div class="run-bar">
+          <div class="run-target">
+            <div class="name" id="runBarTitle">No obs file selected</div>
+            <div class="sub" id="runBarSub">Set the NECST-side directory and filename. Start will run server-side validation before any simulated command.</div>
+          </div>
+          <div class="run-actions">
+            <button id="startObs" class="primary large" disabled title="Start the selected observation sequence. Check and Dry run are optional; the server still validates the obs-file path and options before starting.">Start observation</button>
+            <button id="abortObs" class="danger large" disabled title="Abort a running observation sequence and request recorder/gate/progress cleanup.">ABORT observation</button>
+          </div>
+        </div>
+        <div class="optional-checks" title="Optional checks. They never move the telescope, move the chopper, start recording, open gates, or apply SG settings.">
+          <span class="label">Optional before Start:</span>
+          <button id="checkObs" class="secondary compact" title="Static obs-file check only: path/name, extension, mode, channel override, and defaults that would be applied. No hardware state changes.">Check</button>
+          <button id="dryRunObs" class="secondary compact" disabled title="Build a simulated execution plan. No mount/chopper/recording/gate/SG apply commands are sent.">Dry run</button>
+          <small>Start is allowed without these, but it still performs server-side validation.</small>
+        </div>
+        <div class="callout">
+          <b>Start and ABORT are the primary observation actions.</b>
+          <span>Check is a safe static check; Dry run is a safe simulated plan. They are optional and never change hardware state.</span>
+        </div>
+        <div class="row">
+          <div class="field">
+            <label for="obsMode">Observation mode</label>
+            <select id="obsMode" title="Observation modes supported by the obs-file launcher. RSky and SkyDip are calibration actions, not observation modes.">
+              <option value="otf">OTF</option>
+              <option value="psw">PSW</option>
+              <option value="grid">Grid</option>
+              <option value="radio_pointing">Radio Pointing</option>
+            </select>
+          </div>
+          <div class="field">
+            <label for="obsFile" title="Choose a file from this browser computer only to preview its text. The real NECST-side run path is computed below from directory + filename.">Choose local obs file for preview</label>
+            <input id="obsFile" type="file" accept=".obs,.toml,.txt" title="Preview only. The browser does not expose the real local absolute path.">
+            <small>This reads the local file into the preview box and copies its filename. Browsers do not provide the real local path.</small>
+          </div>
+        </div>
+        <div class="row">
+          <div class="field">
+            <label for="recentDir" title="Directory on the NECST computer. The real implementation should remember recent directories.">Obs directory on NECST computer</label>
+            <select id="recentDir" title="NECST-side directory used to construct the computed run path.">
+              <option>/home/necst/obs</option>
+              <option>/home/necst/obs/commissioning</option>
+              <option>/data/observations/current</option>
+            </select>
+            <small>The real console should remember recently used directories.</small>
+          </div>
+          <div class="field">
+            <label for="obsFilename" title="Filename on the NECST computer. Choosing a local preview file copies only its filename here.">Obs filename</label>
+            <input id="obsFilename" placeholder="e.g. orion_otf.obs" title="Filename to combine with the NECST-side directory. Accepts .obs or .toml in this demo.">
+            <small>Filled from the local preview file name, then editable.</small>
+          </div>
+        </div>
+        <div class="field">
+          <label for="obsPath" title="Read-only confirmation. This is computed from Obs directory + Obs filename; edit those fields if this path is wrong.">Computed run path on NECST computer</label>
+          <input id="obsPath" readonly placeholder="directory + filename" title="Read-only computed path used by Start observation.">
+          <small>Read-only confirmation. Start uses this computed NECST-side path. The preview text itself is not executed.</small>
+        </div>
+        <div id="obsValidation" class="notice">Set the NECST-side directory and filename.</div>
+        <details open>
+          <summary>Preview selected obs file</summary>
+          <div class="field" style="margin-top:10px">
+            <label for="obsPreview">Preview text</label>
+            <textarea id="obsPreview" spellcheck="false" placeholder="Choose a local file above, or paste obs-file text here for visual checking." title="Preview/check copy only. The Start button uses the computed NECST-side run path, not this text."></textarea>
+            <small id="previewInfo">Preview: empty</small>
+          </div>
+        </details>
+        <details>
+          <summary>Advanced observation options</summary>
+          <div class="field" style="margin-top:10px">
+            <label for="obsChannel">Channel override</label>
+            <input id="obsChannel" inputmode="numeric" placeholder="empty = obs file/default">
+          </div>
+        </details>
+      </div>
+    </section>
+
+    <section class="card sticky" id="manualCard">
+      <div class="card-head">
+        <div>
+          <h2>Manual telescope control</h2>
+          <div class="hint">Right-side control area aligned with the always-visible STOP button.</div>
+        </div>
+        <span class="badge" id="manualBadge">Ready</span>
+      </div>
+      <div class="card-body">
+        <div class="compact-list" style="margin-bottom:12px">
+          <div class="kv"><span>Motion state</span><b id="motionSummary">idle</b></div>
+          <div class="kv"><span>Active task</span><b id="taskSummary">none</b></div>
+          <div class="kv"><span>Current Az / El</span><b id="posSummary">180.000 / 45.000</b></div>
+          <div class="kv"><span>Command Az / El</span><b id="cmdSummary">none</b></div>
+          <div class="kv"><span>Chopper</span><b id="chopperSummary">OUT / pos 19700</b></div>
+        </div>
+        <div class="tabs">
+          <button class="tab active" data-panel="mountPanel">Mount Az/El</button>
+          <button class="tab" data-panel="targetPanel">Target tracking</button>
+          <button class="tab" data-panel="chopperPanel">Chopper</button>
+          <button class="tab" data-panel="calPanel">RSky / SkyDip</button>
+        </div>
+
+        <div id="mountPanel" class="panel active">
+          <div class="callout">
+            <b>Mount Az/El means mechanical mount angle.</b>
+            <span>Az=360 is not automatically treated as Az=0. Invalid inputs are not sent, and the reason is shown.</span>
+          </div>
+          <div class="row">
+            <div class="field">
+              <label for="mountAz" title="Mechanical mount Azimuth in degrees. Valid range comes from the active site TOML, not from the GUI.">Command mount Az [deg]</label>
+              <input id="mountAz" inputmode="decimal" placeholder="e.g. 180.0" title="Decimal degrees. Mechanical mount Az, not sky Az. Must be within the site TOML Az limit.">
+            </div>
+            <div class="field">
+              <label for="mountEl" title="Mechanical mount Elevation in degrees. Valid range comes from the active site TOML, not from the GUI.">Command mount El [deg]</label>
+              <input id="mountEl" inputmode="decimal" placeholder="e.g. 45.0" title="Decimal degrees. Mechanical mount El. Must be within the site TOML El limit.">
+            </div>
+          </div>
+          <div class="notice" id="limitSummary">Site TOML limit: loading...</div>
+          <small>Limits are supplied by the console server and are rechecked server-side before any command is sent.</small>
+          <div id="mountValidation" class="notice">Enter Az/El.</div>
+          <div class="actions">
+            <button id="moveMount" class="primary" disabled title="Send a mechanical mount Az/El move only after client and server validation pass.">Move mount</button>
+            <button id="dryRunMount" class="secondary" disabled title="Validate and log the mount command without changing demo state.">Dry-run</button>
+          </div>
+        </div>
+
+        <div id="targetPanel" class="panel">
+          <div class="row">
+            <div class="field">
+              <label for="targetKind">Target kind</label>
+              <select id="targetKind" title="Choose a built-in solar-system target, object name, RA/Dec, or Galactic coordinates.">
+                <option value="sun">Sun</option>
+                <option value="moon">Moon</option>
+                <option value="name">Object name</option>
+                <option value="radec">RA/Dec</option>
+                <option value="galactic">Galactic l/b</option>
+              </select>
+            </div>
+            <div class="field">
+              <label for="cosCorrection">cos correction</label>
+              <select id="cosCorrection" title="Default for offset coordinate handling. The real implementation should use site/user defaults but allow explicit override here.">
+                <option value="true" selected>on</option>
+                <option value="false">off</option>
+              </select>
+            </div>
+          </div>
+          <div id="targetNameBlock" class="field" style="display:none">
+            <label for="targetName">Object name</label>
+            <input id="targetName" placeholder="e.g. Orion-KL" title="Object name resolved by the real telescope system. The demo only validates that it is not empty.">
+          </div>
+          <div id="coordBlock" class="row" style="display:none">
+            <div class="field">
+              <label id="coord1Label" for="coord1">RA or l [deg]</label>
+              <input id="coord1" inputmode="text" title="For RA/Dec: RA accepts decimal degrees, HH:MM:SS.s, or 05h35m17.3s. For Galactic: decimal degrees.">
+            </div>
+            <div class="field">
+              <label id="coord2Label" for="coord2">Dec or b [deg]</label>
+              <input id="coord2" inputmode="text" title="For RA/Dec: Dec accepts decimal degrees, ±DD:MM:SS.s, or -05d23m28s. For Galactic: decimal degrees.">
+            </div>
+          </div>
+          <div class="row3">
+            <div class="field">
+              <label for="offsetFrame">Offset frame</label>
+              <select id="offsetFrame" title="Coordinate frame in which offset X/Y are interpreted.">
+                <option value="target_frame">target frame</option>
+                <option value="altaz">AltAz</option>
+                <option value="radec">RA/Dec</option>
+                <option value="galactic">Galactic</option>
+              </select>
+            </div>
+            <div class="field">
+              <label for="offsetX">Offset X [arcsec]</label>
+              <input id="offsetX" value="0" inputmode="decimal" title="Offset X in arcseconds. The real implementation converts this to degrees internally.">
+            </div>
+            <div class="field">
+              <label for="offsetY">Offset Y [arcsec]</label>
+              <input id="offsetY" value="0" inputmode="decimal" title="Offset Y in arcseconds. The real implementation converts this to degrees internally.">
+            </div>
+          </div>
+          <div id="targetValidation" class="notice">Target tracking can be started.</div>
+          <div class="actions">
+            <button id="startTracking" class="primary">Start tracking</button>
+            <button id="stopTracking" class="secondary" title="Stops target tracking by sending the same antenna-stop operation used by STOP, but is enabled only for tracking context.">Stop tracking</button>
+          </div>
+        </div>
+
+        <div id="chopperPanel" class="panel">
+          <div class="compact-list">
+            <div class="kv"><span>Chopper state</span><b id="chopperState">OUT</b></div>
+            <div class="kv"><span>Position</span><b id="chopperPos">19700</b></div>
+            <div class="kv"><span>Status age</span><b id="chopperAge">live demo</b></div>
+          </div>
+          <div class="notice ok">The current chopper state is shown continuously. The status button only logs a manual refresh.</div>
+          <div class="actions">
+            <button id="chopperIn" class="primary">Chopper IN</button>
+            <button id="chopperOut" class="secondary">Chopper OUT</button>
+            <button id="chopperStatus" class="ghost">Log status</button>
+          </div>
+          <details>
+            <summary>Maintenance actions</summary>
+            <div class="notice warn">Home/recover/alarm reset are maintenance actions and should not be visually dominant.</div>
+            <div class="actions">
+              <button id="chopperAlarmReset" class="secondary">Alarm reset</button>
+              <button id="chopperHome" class="secondary">Home</button>
+              <button id="chopperRecover" class="danger">Recover</button>
+            </div>
+          </details>
+        </div>
+
+        <div id="calPanel" class="panel">
+          <div class="notice" id="calStatusNotice">RSky / SkyDip running state is also shown in the header Active badge.</div>
+          <div class="row">
+            <div class="card" style="box-shadow:none">
+              <div class="card-head"><h2>RSky</h2><span class="hint">runtime parameters</span></div>
+              <div class="card-body">
+                <div class="row">
+                  <div class="field"><label for="rskyN">n</label><input id="rskyN" value="1" inputmode="numeric"></div>
+                  <div class="field"><label for="rskyInteg">integ [s]</label><input id="rskyInteg" value="2" inputmode="decimal"></div>
+                </div>
+                <details><summary>Advanced</summary><div class="field" style="margin-top:10px"><label for="rskyCh">channel</label><input id="rskyCh" placeholder="empty = default"></div></details>
+                <button id="runRsky" class="primary">Run RSky</button>
+              </div>
+            </div>
+            <div class="card" style="box-shadow:none">
+              <div class="card-head"><h2>SkyDip</h2><span class="hint">runtime parameters</span></div>
+              <div class="card-body">
+                <div class="field"><label for="skydipInteg">integ [s]</label><input id="skydipInteg" value="2" inputmode="decimal"></div>
+                <details><summary>Advanced</summary>
+                  <div class="field" style="margin-top:10px"><label for="skydipCh">channel</label><input id="skydipCh" placeholder="empty = default"></div>
+                  <div class="field"><label for="skydipTpRange">tp_range</label><input id="skydipTpRange" placeholder="e.g. 5000 6000 17000 18000"></div>
+                </details>
+                <button id="runSkydip" class="primary">Run SkyDip</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+
+  <section class="card" style="margin-top:14px">
+    <div class="card-head">
+      <div>
+        <h2>Operation log</h2>
+        <div class="hint">Actions accepted by the console server and validation results.</div>
+      </div>
+      <button id="clearLog" class="secondary">Clear</button>
+    </div>
+    <div class="card-body">
+      <div id="log" class="log"></div>
+    </div>
+  </section>
+
+  <section class="card" style="margin-top:14px">
+    <div class="card-head">
+      <div>
+        <h2>Runtime status</h2>
+        <div class="hint">Site config, process lifecycle, progress monitor ownership, and persistent log paths.</div>
+      </div>
+      <button id="refreshRuntime" class="secondary">Refresh</button>
+    </div>
+    <div class="card-body">
+      <div class="runtime-grid">
+        <div class="runtime-card">
+          <h3>Site and action mode</h3>
+          <div class="runtime-list">
+            <div>Action mode: <b id="runtimeActionMode">loading</b></div>
+            <div>Live writes: <b id="runtimeLiveWrites">loading</b></div>
+            <div>Status refresh: <b id="runtimeStatusRefresh">loading</b></div>
+            <div>Observatory: <b id="runtimeObservatory">loading</b></div>
+            <div>Config source: <b id="runtimeConfigSource">loading</b></div>
+            <div class="path-text" title="site config path">Path: <b id="runtimeConfigPath">loading</b></div>
+            <div>Capabilities: <b id="runtimeCapabilities">loading</b></div>
+          </div>
+        </div>
+        <div class="runtime-card">
+          <h3>Process lifecycle</h3>
+          <div class="runtime-list">
+            <div>Counts: <b id="runtimeProcessCounts">loading</b></div>
+            <div id="runtimeProcesses">loading</div>
+            <div class="mini-actions">
+              <button id="terminateObsLauncher" class="secondary" title="Terminate local observation launcher subprocess only; does not send telescope STOP">Terminate obs launcher</button>
+              <button id="terminateCalLauncher" class="secondary" title="Terminate local calibration launcher subprocess only; does not send telescope STOP">Terminate cal launcher</button>
+              <button id="terminateAllLaunchers" class="secondary" title="Terminate all local launcher subprocesses started by this console">Terminate all launchers</button>
+            </div>
+          </div>
+        </div>
+        <div class="runtime-card">
+          <h3>Progress monitor and logs</h3>
+          <div class="runtime-list">
+            <div>Progress: <b id="runtimeProgressMonitor">loading</b></div>
+            <div class="path-text" title="operator log path">Operator log: <b id="runtimeOperatorLog">loading</b></div>
+            <div class="path-text" title="launcher log directory">Launcher logs: <b id="runtimeLauncherLogDir">loading</b></div>
+            <div class="mini-actions">
+              <button id="loadOperatorLog" class="secondary" title="Read the persistent operator_console.jsonl tail">Read operator log</button>
+            </div>
+          </div>
+        </div>
+        <div class="runtime-card">
+          <h3>Log browser</h3>
+          <div class="runtime-list">
+            <div id="runtimeLogBrowserSummary">Operator and launcher logs are read-only.</div>
+            <div id="runtimeLauncherLogChoices"><span style="color:var(--faint)">No launcher log recorded.</span></div>
+            <div id="runtimeLogBrowserText" class="log-browser-text">Select a log to display its tail.</div>
+          </div>
+        </div>
+        <div class="runtime-card">
+          <h3>Shutdown cleanup</h3>
+          <div class="runtime-list">
+            <div>Status: <b id="runtimeShutdownStatus">loading</b></div>
+            <div>Terminate launchers: <b id="runtimeShutdownTerminate">loading</b></div>
+            <div>Last cleanup: <b id="runtimeShutdownLast">loading</b></div>
+            <div id="runtimeShutdownSummary" class="path-text">loading</div>
+          </div>
+        </div>
+        <div class="runtime-card">
+          <h3>Self-check</h3>
+          <div class="runtime-list">
+            <div>Status: <b id="runtimeSelfCheckStatus">not run</b></div>
+            <div id="runtimeSelfCheckSummary" class="path-text">Run self-check before live operation.</div>
+            <div class="mini-actions">
+              <button id="runSelfCheck" class="secondary" title="Run read-only console self-checks; no telescope command is sent">Run self-check</button>
+            </div>
+          </div>
+        </div>
+        <div class="runtime-card">
+          <h3>Warnings</h3>
+          <div id="runtimeWarnings" class="runtime-list warning-list">loading</div>
+        </div>
+      </div>
+    </div>
+  </section>
+</main>
+<script>
+const qs = (id) => document.getElementById(id);
+const state = {
+  sessionId: localStorage.getItem('necstConsoleDemoSession') || crypto.randomUUID(),
+  obsChecked: false,
+  siteLimits: {az_min: 5, az_max: 355, el_min: 5, el_max: 85},
+  capabilities: {},
+  liveActions: {guarded: false, enabled: false},
+  lastSelfCheck: null
+};
+localStorage.setItem('necstConsoleDemoSession', state.sessionId);
+
+function numberOrNaN(value) {
+  if (String(value).trim() === '') return NaN;
+  return Number(value);
+}
+function finite(value) { return Number.isFinite(value); }
+
+function parseSexagesimalAngle(value, isRa) {
+  const raw = String(value || '').trim();
+  if (!raw) return {ok: false, reason: 'empty coordinate'};
+  const numeric = Number(raw);
+  if (Number.isFinite(numeric) && /^[-+]?\d+(\.\d+)?([eE][-+]?\d+)?$/.test(raw)) {
+    return {ok: true, deg: numeric, format: 'decimal degrees'};
+  }
+  let s = raw.replace(/−/g, '-').trim().toLowerCase();
+  let sign = 1;
+  if (s.startsWith('+')) s = s.slice(1).trim();
+  if (s.startsWith('-')) { sign = -1; s = s.slice(1).trim(); }
+  if (isRa && sign < 0) return {ok: false, reason: 'RA cannot be negative'};
+  s = s
+    .replace(/[hHdD°]/g, ':')
+    .replace(/[mM′']/g, ':')
+    .replace(/[sS″"]/g, '')
+    .replace(/\s+/g, ':')
+    .replace(/:+/g, ':')
+    .replace(/^:/, '')
+    .replace(/:$/, '');
+  const parts = s.split(':').filter(x => x !== '').map(Number);
+  if (parts.length < 1 || parts.length > 3 || !parts.every(Number.isFinite)) {
+    return {ok: false, reason: isRa ? 'RA must be decimal degrees or HH:MM:SS.s' : 'Dec must be decimal degrees or ±DD:MM:SS.s'};
+  }
+  const a0 = Math.abs(parts[0]);
+  const a1 = parts.length > 1 ? parts[1] : 0;
+  const a2 = parts.length > 2 ? parts[2] : 0;
+  if (a1 < 0 || a1 >= 60 || a2 < 0 || a2 >= 60) {
+    return {ok: false, reason: 'sexagesimal minutes/seconds must be in 0..60'};
+  }
+  const sex = a0 + a1 / 60 + a2 / 3600;
+  const deg = isRa ? sex * 15 : sign * sex;
+  return {ok: true, deg, format: isRa ? 'sexagesimal hours' : 'sexagesimal degrees'};
+}
+function setNotice(el, kind, text) {
+  el.className = 'notice' + (kind ? ' ' + kind : '');
+  el.textContent = text;
+}
+function markInput(el, ok) {
+  el.classList.remove('valid', 'invalid');
+  if (ok === true) el.classList.add('valid');
+  if (ok === false) el.classList.add('invalid');
+}
+
+function setText(id, text) {
+  const el = qs(id);
+  if (el) el.textContent = text;
+}
+function setDisabled(id, disabled) {
+  const el = qs(id);
+  if (el) el.disabled = Boolean(disabled);
+}
+function formatMaybeNumber(value, digits=3) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n.toFixed(digits) : String(value ?? 'unknown');
+}
+function capabilityText(caps) {
+  if (!caps || typeof caps !== 'object') return 'unknown';
+  const enabled = Object.entries(caps).filter(([, v]) => Boolean(v)).map(([k]) => k);
+  const disabled = Object.entries(caps).filter(([, v]) => !Boolean(v)).map(([k]) => k);
+  const head = enabled.length ? enabled.join(', ') : 'none';
+  return disabled.length ? `${head}; disabled: ${disabled.join(', ')}` : head;
+}
+function processSummary(counts) {
+  counts = counts || {};
+  return `total ${counts.total ?? 0}, active ${counts.active ?? counts.running ?? 0}, running ${counts.running ?? 0}, terminating ${counts.terminating ?? 0}, exited ${counts.exited ?? 0}, failed ${counts.failed ?? 0}, lost ${counts.lost ?? 0}`;
+}
+function escapeHtml(value) {
+  return String(value ?? '').replace(/[&<>"']/g, ch => ({'&':'&amp;', '<':'&lt;', '>':'&gt;', '"':'&quot;', "'":'&#39;'}[ch]));
+}
+function renderProcessRows(processes) {
+  if (!Array.isArray(processes) || processes.length === 0) return '<span style="color:var(--faint)">No launcher process recorded.</span>';
+  return processes.slice(0, 8).map(p => {
+    const rc = (p.returncode === null || p.returncode === undefined) ? '' : `, rc=${p.returncode}`;
+    const pidValue = p.pid;
+    const pid = pidValue === undefined ? 'pid=?' : `pid=${pidValue}`;
+    const started = escapeHtml(p.started_at_iso || '');
+    const label = escapeHtml(p.label || p.action || 'launcher');
+    const status = escapeHtml(p.status || 'unknown');
+    const logs = [p.stdout_path ? `stdout: ${escapeHtml(p.stdout_path)}` : '', p.stderr_path ? `stderr: ${escapeHtml(p.stderr_path)}` : ''].filter(Boolean).join('<br>');
+    const canTerminate = p.can_terminate || ['running', 'terminating', 'killing'].includes(String(p.status || ''));
+    const button = canTerminate && pidValue !== undefined ? `<br><button class="secondary process-stop" data-pid="${escapeHtml(pidValue)}">Terminate local launcher</button>` : '';
+    return `<div class="process-row"><b>${label}</b> ${pid}, ${status}${rc}<br><small>${started}</small>${logs ? '<br><small>' + logs + '</small>' : ''}${button}</div>`;
+  }).join('');
+}
+function renderLauncherLogChoices(processes) {
+  const el = qs('runtimeLauncherLogChoices');
+  if (!el) return;
+  const choices = [];
+  if (Array.isArray(processes)) {
+    processes.slice(0, 8).forEach(p => {
+      const label = p.label || p.action || 'launcher';
+      if (p.stdout_path) choices.push({label, stream:'stdout', path:p.stdout_path, pid:p.pid});
+      if (p.stderr_path) choices.push({label, stream:'stderr', path:p.stderr_path, pid:p.pid});
+    });
+  }
+  if (!choices.length) {
+    el.innerHTML = '<span style="color:var(--faint)">No launcher log recorded.</span>';
+    return;
+  }
+  el.innerHTML = choices.slice(0, 12).map(c => `<button class="secondary log-choice" data-path="${escapeHtml(c.path)}">${escapeHtml(c.label)} ${escapeHtml(c.stream)} pid=${escapeHtml(c.pid ?? '?')}</button>`).join('');
+}
+function renderLogBrowser(payload) {
+  const summary = qs('runtimeLogBrowserSummary');
+  const body = qs('runtimeLogBrowserText');
+  if (!summary || !body) return;
+  if (!payload) {
+    summary.textContent = 'Operator and launcher logs are read-only.';
+    body.textContent = 'Select a log to display its tail.';
+    return;
+  }
+  summary.textContent = payload.reason || (payload.ok ? 'log read' : 'log read failed');
+  if (Array.isArray(payload.entries)) {
+    body.textContent = payload.entries.map(e => {
+      const when = e.time_iso || e.time || '';
+      const mark = e.ok === false ? 'NG' : 'OK';
+      const action = e.action ? ` ${e.action}` : '';
+      const msg = e.message || e.reason || '';
+      return `${when} ${mark}${action}: ${msg}`;
+    }).join('\n') || '(operator log is empty)';
+    return;
+  }
+  body.textContent = payload.text || '(log is empty)';
+}
+async function readOperatorLog() {
+  const resp = await fetch('/api/operator-log?limit=80');
+  const data = await resp.json();
+  renderLogBrowser(data);
+}
+async function readLogFile(path) {
+  const resp = await fetch('/api/log-file?max_bytes=32768&path=' + encodeURIComponent(path));
+  const data = await resp.json();
+  renderLogBrowser(data);
+}
+function progressMonitorText(progress) {
+  const mon = progress && (progress.monitor || progress.monitor_status || progress.progress_monitor);
+  if (mon && typeof mon === 'object') {
+    const owner = mon.owned_by_console ? 'console-owned' : (mon.running ? 'external/not owned' : 'not running');
+    const pid = mon.pid ? ` pid=${mon.pid}` : '';
+    return `${mon.status || (mon.running ? 'running' : 'stopped')} (${owner})${pid}`;
+  }
+  return progress && progress.running ? 'running' : 'not running';
+}
+function renderSelfCheck(result) {
+  const statusEl = qs('runtimeSelfCheckStatus');
+  const summaryEl = qs('runtimeSelfCheckSummary');
+  if (!statusEl || !summaryEl) return;
+  if (!result) {
+    statusEl.textContent = 'not run';
+    summaryEl.innerHTML = '<span style="color:var(--faint)">Run self-check before live operation.</span>';
+    return;
+  }
+  const summary = result.summary || {};
+  const status = result.status || (result.ok ? 'ok' : 'error');
+  statusEl.textContent = `${status} (${summary.error_count ?? 0} errors, ${summary.warning_count ?? 0} warnings)`;
+  const checks = Array.isArray(result.checks) ? result.checks : [];
+  summaryEl.innerHTML = checks.slice(0, 10).map(item => {
+    const icon = item.ok ? (item.severity === 'warning' ? '⚠' : '✓') : '✗';
+    const cls = item.ok ? (item.severity === 'warning' ? 'warn' : 'ok') : 'bad';
+    return `<div><span class="${cls}">${icon}</span> <b>${escapeHtml(item.name)}</b>: ${escapeHtml(item.message)}</div>`;
+  }).join('') || '<span style="color:var(--faint)">No self-check details.</span>';
+}
+function renderRuntime(data) {
+  const site = data.site || {};
+  const progress = data.progress || {};
+  const processes = Array.isArray(data.processes) ? data.processes : [];
+  const counts = data.process_counts || {};
+  const liveActions = data.live_actions || {};
+  setText('runtimeActionMode', data.action_mode || 'unknown');
+  setText('runtimeLiveWrites', liveActions.guarded ? 'guarded by CLI option' : (liveActions.enabled ? 'enabled' : 'dry-run / not live'));
+  const refreshMs = Number(data.status_refresh_ms || getStatusRefreshMs());
+  setText('runtimeStatusRefresh', `${refreshMs} ms`);
+  setText('runtimeObservatory', site.observatory || 'unknown');
+  setText('runtimeConfigSource', site.source || 'unknown');
+  setText('runtimeConfigPath', site.source_path || '(none)');
+  setText('runtimeCapabilities', capabilityText(data.capabilities || {}));
+  setText('runtimeProcessCounts', processSummary(counts));
+  const processEl = qs('runtimeProcesses');
+  if (processEl) processEl.innerHTML = renderProcessRows(processes);
+  renderLauncherLogChoices(processes);
+  setText('runtimeProgressMonitor', progressMonitorText(progress));
+  setText('runtimeOperatorLog', data.operator_log_path || '(not configured)');
+  setText('runtimeLauncherLogDir', data.launcher_log_dir || '(not configured)');
+  const shutdown = data.shutdown || {};
+  setText('runtimeShutdownStatus', shutdown.status || 'not_started');
+  setText('runtimeShutdownTerminate', shutdown.terminate_launchers === false ? 'no' : 'yes');
+  setText('runtimeShutdownLast', shutdown.cleanup_finished_at_iso || shutdown.cleanup_started_at_iso || '(none)');
+  const shutdownSummary = shutdown.summary || {};
+  const shutdownEl = qs('runtimeShutdownSummary');
+  if (shutdownEl) {
+    const launcher = shutdownSummary.launchers || {};
+    const progress = shutdownSummary.progress_monitor || {};
+    shutdownEl.innerHTML = [
+      launcher.message ? `Launchers: ${escapeHtml(launcher.message)}` : '',
+      progress.message ? `Progress: ${escapeHtml(progress.message)}` : ''
+    ].filter(Boolean).join('<br>') || '<span style="color:var(--faint)">No shutdown cleanup has run in this console process.</span>';
+  }
+  renderSelfCheck(state.lastSelfCheck);
+  const warnings = Array.isArray(data.warnings) ? data.warnings : [];
+  const warnEl = qs('runtimeWarnings');
+  if (warnEl) warnEl.innerHTML = warnings.length ? warnings.map(w => `<div>⚠ ${String(w)}</div>`).join('') : '<span style="color:var(--ok)">No warning reported.</span>';
+}
+function applyCapabilities(data) {
+  const caps = data.capabilities || {};
+  const liveGuarded = Boolean((data.live_actions || {}).guarded);
+  const chopperMoveDisabled = caps.chopper_move === false || liveGuarded;
+  setDisabled('chopperIn', chopperMoveDisabled);
+  setDisabled('chopperOut', chopperMoveDisabled);
+  setDisabled('chopperStatus', caps.chopper_status === false);
+  const maintDisabled = caps.chopper_maintenance === false || liveGuarded;
+  setDisabled('chopperAlarmReset', maintDisabled);
+  setDisabled('chopperHome', maintDisabled);
+  setDisabled('chopperRecover', maintDisabled);
+  setDisabled('startTracking', liveGuarded || caps.target_tracking === false || qs('startTracking').disabled);
+  setDisabled('runRsky', liveGuarded || caps.rsky === false);
+  setDisabled('runSkydip', liveGuarded || caps.skydip === false);
+  if (caps.mount_move === false || liveGuarded) {
+    setDisabled('moveMount', true);
+  }
+  if (caps.mount_move === false) {
+    setDisabled('dryRunMount', true);
+  }
+}
+async function api(action, params={}) {
+  const resp = await fetch('/api/action', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({action, params, session_id: state.sessionId})
+  });
+  const data = await resp.json();
+  await refresh();
+  return data;
+}
+async function refresh() {
+  const resp = await fetch('/api/status');
+  const data = await resp.json();
+  renderStatus(data);
+  renderLog(data.log || []);
+}
+function renderStatus(data) {
+  const heldByMe = data.authority && data.authority.session_id === state.sessionId;
+  state.siteLimits = data.mount_limits || state.siteLimits;
+  state.capabilities = data.capabilities || state.capabilities || {};
+  state.liveActions = data.live_actions || state.liveActions || {guarded: false, enabled: false};
+  const site = data.site || {};
+  const siteName = site.observatory || 'unknown site';
+  const siteSource = site.source || 'unknown source';
+  qs('limitSummary').textContent = `${siteName} ${siteSource}: Az ${state.siteLimits.az_min}..${state.siteLimits.az_max} deg, El ${state.siteLimits.el_min}..${state.siteLimits.el_max} deg`;
+  const authText = data.authority && data.authority.held ? (heldByMe ? 'Authority: held here' : 'Authority: held elsewhere') : 'Authority: auto';
+  const authClass = data.authority && data.authority.held ? (heldByMe ? 'ok' : 'warn') : 'info';
+  const taskClass = data.active_task && data.active_task !== 'none' ? 'ok' : 'info';
+  const motionClass = (data.manual_state === 'moving' || data.manual_state === 'tracking' || data.manual_state === 'calibration' || data.manual_state === 'observing sequence') ? 'ok' : (data.manual_state === 'stopped' ? 'warn' : 'info');
+  const cmd = (finite(Number(data.command_az)) && finite(Number(data.command_el))) ? `${Number(data.command_az).toFixed(3)} / ${Number(data.command_el).toFixed(3)}` : 'none';
+  const progressClass = data.progress && data.progress.running ? 'ok' : 'info';
+  const progressText = data.progress && data.progress.running ? 'Progress: running' : 'Progress: not started';
+  const counts = data.process_counts || {};
+  const runningCount = Number(counts.active ?? counts.running ?? 0);
+  const processClass = runningCount > 0 ? 'ok' : 'info';
+  qs('statusBadges').innerHTML = [
+    `<span class="badge info">${data.telescope}</span>`,
+    `<span class="badge ${data.action_mode === 'dry-run' ? 'warn' : (state.liveActions.guarded ? 'warn' : 'ok')}">Mode: ${data.action_mode || 'unknown'}${state.liveActions.guarded ? ' guarded' : ''}</span>`,
+    `<span class="badge info">Site: ${siteName}</span>`,
+    `<span class="badge ${data.state === 'observing' || data.state === 'calibrating' ? 'ok' : 'info'}">System: ${data.state}</span>`,
+    `<span class="badge ${motionClass}">Motion: ${data.manual_state}</span>`,
+    `<span class="badge ${taskClass}">Active: ${data.active_task || 'none'}</span>`,
+    `<span class="badge ${authClass}">${authText}</span>`,
+    `<span class="badge ${progressClass}">${progressText}</span>`,
+    `<span class="badge ${processClass}">Launchers: ${runningCount} active</span>`,
+    `<span class="badge ${data.warning_count ? 'warn' : 'ok'}">Warnings: ${data.warning_count || 0}</span>`
+  ].join('');
+  qs('authorityButton').textContent = heldByMe ? 'Release authority' : 'Acquire authority';
+  qs('authorityButton').disabled = Boolean(state.liveActions.guarded) && !heldByMe;
+  qs('obsStateBadge').textContent = data.state;
+  qs('obsStateBadge').className = 'badge ' + (data.state === 'observing' ? 'ok' : (data.state === 'calibrating' ? 'warn' : 'info'));
+  qs('abortObs').disabled = data.state !== 'observing';
+  qs('manualBadge').textContent = data.manual_state;
+  qs('manualBadge').className = 'badge ' + motionClass;
+  qs('motionSummary').textContent = data.manual_state;
+  qs('taskSummary').textContent = data.active_task || 'none';
+  qs('posSummary').textContent = `${data.az.toFixed(3)} / ${data.el.toFixed(3)}`;
+  qs('cmdSummary').textContent = cmd;
+  qs('chopperSummary').textContent = `${data.chopper.state} / pos ${data.chopper.position}`;
+  qs('chopperState').textContent = data.chopper.state;
+  qs('chopperPos').textContent = data.chopper.position;
+  qs('chopperAge').textContent = data.chopper.age || 'live demo';
+  qs('stopTracking').disabled = data.manual_state !== 'tracking';
+  qs('calStatusNotice').textContent = `Current active task: ${data.active_task || 'none'}`;
+  qs('calStatusNotice').className = 'notice ' + (data.state === 'calibrating' ? 'ok' : '');
+  renderRuntime(data);
+  applyCapabilities(data);
+}
+function renderLog(items) {
+  qs('log').innerHTML = items.map(item => {
+    const statusClass = item.ok ? 'ok' : 'bad';
+    return `<div class="log-entry"><span class="time">${item.time}</span> <span class="${statusClass}">${item.ok ? 'OK' : 'NG'}</span> ${item.message}</div>`;
+  }).join('') || '<span style="color:var(--faint)">No operation yet.</span>';
+}
+function updateObsRunPath() {
+  const dir = qs('recentDir').value.replace(/\/+$/, '');
+  const name = qs('obsFilename').value.trim().replace(/^\/+/, '');
+  qs('obsPath').value = (dir && name) ? `${dir}/${name}` : '';
+  qs('runBarTitle').textContent = qs('obsPath').value || 'No obs file selected';
+  qs('runBarSub').textContent = qs('obsPath').value ? `${qs('obsMode').value.toUpperCase()} / ${state.obsChecked ? 'checked' : 'unchecked, Start will validate'}` : 'Set the NECST-side directory and filename.';
+}
+function updatePreviewInfo() {
+  const text = qs('obsPreview').value;
+  const lines = text ? text.split(/\r?\n/).length : 0;
+  const bytes = new Blob([text]).size;
+  qs('previewInfo').textContent = text ? `Preview: ${lines} lines, ${bytes} bytes` : 'Preview: empty';
+}
+function validateObs() {
+  updateObsRunPath();
+  updatePreviewInfo();
+  const path = qs('obsPath').value.trim();
+  const hasPreview = qs('obsPreview').value.trim().length > 0;
+  const channel = qs('obsChannel').value.trim();
+  let reasons = [];
+  if (!path) reasons.push('obs file path/name is empty');
+  if (path && !/\.(obs|toml)$/i.test(path)) reasons.push('extension should be .obs or .toml');
+  if (channel) {
+    const ch = Number(channel);
+    if (!Number.isInteger(ch) || ch <= 0) reasons.push('channel override must be a positive integer');
+  }
+  if (reasons.length) {
+    setNotice(qs('obsValidation'), 'bad', 'Cannot start: ' + reasons.join(' / '));
+    qs('checkObs').disabled = !path;
+    qs('dryRunObs').disabled = true;
+    qs('startObs').disabled = true;
+    state.obsChecked = false;
+    updateObsRunPath();
+    return false;
+  }
+  qs('checkObs').disabled = false;
+  qs('dryRunObs').disabled = false;
+  const liveGuarded = Boolean(state.liveActions && state.liveActions.guarded);
+  const startCapable = state.capabilities.observation_start !== false && !liveGuarded;
+  qs('startObs').disabled = !startCapable;
+  const checkText = state.obsChecked ? 'Checked. ' : '';
+  const previewText = hasPreview ? 'Preview loaded. ' : 'No preview loaded. ';
+  const startText = liveGuarded ? 'Live write guard is active; Start is disabled. Use --action-mode dry-run for normal validation, or restart without --guard-live-actions for live operation.' : (startCapable ? 'Start is enabled; Check and Dry run are optional. Start will validate again on the server.' : 'Observation start is disabled by site capability.');
+  setNotice(qs('obsValidation'), startCapable ? (state.obsChecked ? 'ok' : 'warn') : 'bad', checkText + previewText + startText);
+  updateObsRunPath();
+  return true;
+}
+function validateMount() {
+  const az = numberOrNaN(qs('mountAz').value);
+  const el = numberOrNaN(qs('mountEl').value);
+  const azMin = Number(state.siteLimits.az_min);
+  const azMax = Number(state.siteLimits.az_max);
+  const elMin = Number(state.siteLimits.el_min);
+  const elMax = Number(state.siteLimits.el_max);
+  let reasons = [];
+  if (!finite(az)) reasons.push('Az is not a number');
+  if (!finite(el)) reasons.push('El is not a number');
+  if (![azMin, azMax, elMin, elMax].every(finite)) reasons.push('site TOML limits are not available');
+  if (finite(azMin) && finite(azMax) && azMin >= azMax) reasons.push('site TOML Az min/max are invalid');
+  if (finite(elMin) && finite(elMax) && elMin >= elMax) reasons.push('site TOML El min/max are invalid');
+  if (finite(az) && finite(azMin) && finite(azMax) && (az < azMin || az > azMax)) reasons.push(`Az=${az} deg is outside site TOML range ${azMin}..${azMax} deg`);
+  if (finite(el) && finite(elMin) && finite(elMax) && (el < elMin || el > elMax)) reasons.push(`El=${el} deg is outside site TOML range ${elMin}..${elMax} deg`);
+  if (state.capabilities.mount_move === false) reasons.push('mount move is disabled by site capability');
+  markInput(qs('mountAz'), finite(az) && finite(azMin) && finite(azMax) ? (az >= azMin && az <= azMax) : null);
+  markInput(qs('mountEl'), finite(el) && finite(elMin) && finite(elMax) ? (el >= elMin && el <= elMax) : null);
+  const ok = reasons.length === 0;
+  const liveGuarded = Boolean(state.liveActions && state.liveActions.guarded);
+  if (ok && liveGuarded) setNotice(qs('mountValidation'), 'warn', `Dry-run is allowed, but live mount move is guarded by --guard-live-actions.`);
+  else if (ok) setNotice(qs('mountValidation'), 'ok', `Ready to move: command Az=${az.toFixed(6)} deg, El=${el.toFixed(6)} deg`);
+  else setNotice(qs('mountValidation'), 'bad', 'Not movable: ' + reasons.join(' / '));
+  qs('moveMount').disabled = !ok || liveGuarded;
+  qs('dryRunMount').disabled = !ok;
+  return {ok, reasons, az, el};
+}
+function validateTarget() {
+  const kind = qs('targetKind').value;
+  const ox = numberOrNaN(qs('offsetX').value);
+  const oy = numberOrNaN(qs('offsetY').value);
+  let reasons = [];
+  if (!finite(ox) || !finite(oy)) reasons.push('offset must be numeric');
+  if (finite(ox) && Math.abs(ox) > 36000) reasons.push('Offset X is larger than the demo limit of 36000 arcsec');
+  if (finite(oy) && Math.abs(oy) > 36000) reasons.push('Offset Y is larger than the demo limit of 36000 arcsec');
+  if (kind === 'name' && !qs('targetName').value.trim()) reasons.push('object name is empty');
+  if (kind === 'radec') {
+    const ra = parseSexagesimalAngle(qs('coord1').value, true);
+    const dec = parseSexagesimalAngle(qs('coord2').value, false);
+    if (!ra.ok) reasons.push('RA: ' + ra.reason);
+    if (!dec.ok) reasons.push('Dec: ' + dec.reason);
+    if (ra.ok && (ra.deg < 0 || ra.deg >= 360)) reasons.push('RA must satisfy 0 <= value < 360 deg');
+    if (dec.ok && (dec.deg < -90 || dec.deg > 90)) reasons.push('Dec must satisfy -90..90 deg');
+  }
+  if (kind === 'galactic') {
+    const c1 = numberOrNaN(qs('coord1').value);
+    const c2 = numberOrNaN(qs('coord2').value);
+    if (!finite(c1) || !finite(c2)) reasons.push('Galactic coordinates must be decimal degrees');
+    if (finite(c1) && (c1 < 0 || c1 >= 360)) reasons.push('l must satisfy 0 <= value < 360 deg');
+    if (finite(c2) && (c2 < -90 || c2 > 90)) reasons.push('b must satisfy -90..90 deg');
+  }
+  if (state.capabilities.target_tracking === false) reasons.push('target tracking is disabled by site capability');
+  const liveGuarded = Boolean(state.liveActions && state.liveActions.guarded);
+  const ok = reasons.length === 0;
+  if (ok && liveGuarded) setNotice(qs('targetValidation'), 'warn', 'Target is valid, but live tracking is guarded by --guard-live-actions.');
+  else setNotice(qs('targetValidation'), ok ? 'ok' : 'bad', ok ? 'Target tracking can be started. Stop it with STOP.' : 'Cannot track: ' + reasons.join(' / '));
+  qs('startTracking').disabled = !ok || liveGuarded;
+  return {ok, reasons};
+}
+function updateTargetFields() {
+  const kind = qs('targetKind').value;
+  qs('targetNameBlock').style.display = kind === 'name' ? '' : 'none';
+  qs('coordBlock').style.display = (kind === 'radec' || kind === 'galactic') ? '' : 'none';
+  if (kind === 'radec') { qs('coord1Label').textContent = 'RA [deg or HH:MM:SS]'; qs('coord2Label').textContent = 'Dec [deg or ±DD:MM:SS]'; }
+  if (kind === 'galactic') { qs('coord1Label').textContent = 'l [deg]'; qs('coord2Label').textContent = 'b [deg]'; }
+  validateTarget();
+}
+function selectPanel(id) {
+  document.querySelectorAll('.tab').forEach(b => b.classList.toggle('active', b.dataset.panel === id));
+  document.querySelectorAll('.panel').forEach(p => p.classList.toggle('active', p.id === id));
+}
+
+document.querySelectorAll('.tab').forEach(b => b.addEventListener('click', () => selectPanel(b.dataset.panel)));
+['obsFilename','obsPreview','obsChannel','obsMode'].forEach(id => qs(id).addEventListener('input', () => { state.obsChecked = false; validateObs(); }));
+['mountAz','mountEl'].forEach(id => qs(id).addEventListener('input', validateMount));
+['targetKind','targetName','coord1','coord2','offsetFrame','offsetX','offsetY','cosCorrection'].forEach(id => qs(id).addEventListener('input', updateTargetFields));
+qs('obsFile').addEventListener('change', async (ev) => {
+  const file = ev.target.files[0];
+  if (!file) return;
+  qs('obsFilename').value = file.name;
+  qs('obsPreview').value = await file.text();
+  state.obsChecked = false;
+  validateObs();
+});
+qs('recentDir').addEventListener('change', () => { state.obsChecked = false; validateObs(); });
+qs('checkObs').addEventListener('click', async () => {
+  if (!validateObs()) return;
+  const data = await api('check_observation', {mode: qs('obsMode').value, file: qs('obsPath').value, channel: qs('obsChannel').value, preview: qs('obsPreview').value});
+  state.obsChecked = Boolean(data.ok);
+  if (data.ok) {
+    validateObs();
+  } else {
+    state.obsChecked = false;
+    validateObs();
+    setNotice(qs('obsValidation'), 'bad', 'Check failed: ' + (data.reason || 'unknown reason'));
+  }
+});
+qs('dryRunObs').addEventListener('click', async () => {
+  if (!validateObs()) return;
+  const data = await api('dry_run_observation', {mode: qs('obsMode').value, file: qs('obsPath').value, channel: qs('obsChannel').value, preview: qs('obsPreview').value});
+  if (data.ok) {
+    setNotice(qs('obsValidation'), 'ok', data.reason || 'Dry run OK. Start observation remains enabled.');
+  } else {
+    setNotice(qs('obsValidation'), 'bad', 'Dry run failed: ' + (data.reason || 'unknown reason'));
+  }
+});
+qs('startObs').addEventListener('click', async () => {
+  if (!validateObs()) return;
+  await api('start_observation', {mode: qs('obsMode').value, file: qs('obsPath').value, channel: qs('obsChannel').value});
+});
+qs('abortObs').addEventListener('click', async () => {
+  if (confirm('Abort current observation and request recorder/gate/progress cleanup?')) await api('abort_observation');
+});
+qs('authorityButton').addEventListener('click', async () => {
+  const resp = await fetch('/api/status');
+  const data = await resp.json();
+  const heldByMe = data.authority && data.authority.session_id === state.sessionId;
+  await api(heldByMe ? 'release_authority' : 'acquire_authority');
+});
+qs('stopButton').addEventListener('click', async () => { await api('stop'); });
+qs('moveMount').addEventListener('click', async () => {
+  const v = validateMount();
+  if (!v.ok) return;
+  await api('mount_move', {az: qs('mountAz').value, el: qs('mountEl').value});
+});
+qs('dryRunMount').addEventListener('click', async () => {
+  const v = validateMount();
+  if (!v.ok) return;
+  await api('mount_move_dry_run', {az: qs('mountAz').value, el: qs('mountEl').value});
+});
+qs('startTracking').addEventListener('click', async () => {
+  if (!validateTarget().ok) return;
+  await api('start_tracking', {
+    kind: qs('targetKind').value,
+    name: qs('targetName').value,
+    coord1: qs('coord1').value,
+    coord2: qs('coord2').value,
+    offset_frame: qs('offsetFrame').value,
+    offset_x_arcsec: qs('offsetX').value,
+    offset_y_arcsec: qs('offsetY').value,
+    cos_correction: qs('cosCorrection').value
+  });
+});
+qs('stopTracking').addEventListener('click', async () => { await api('stop_tracking'); });
+qs('chopperIn').addEventListener('click', () => api('chopper_in'));
+qs('chopperOut').addEventListener('click', () => api('chopper_out'));
+qs('chopperStatus').addEventListener('click', () => api('chopper_status'));
+qs('chopperAlarmReset').addEventListener('click', () => api('chopper_alarm_reset'));
+qs('chopperHome').addEventListener('click', () => api('chopper_home'));
+qs('chopperRecover').addEventListener('click', () => api('chopper_recover'));
+qs('runRsky').addEventListener('click', () => api('run_rsky', {n: qs('rskyN').value, integ: qs('rskyInteg').value, ch: qs('rskyCh').value}));
+qs('runSkydip').addEventListener('click', () => api('run_skydip', {integ: qs('skydipInteg').value, ch: qs('skydipCh').value, tp_range: qs('skydipTpRange').value}));
+qs('clearLog').addEventListener('click', () => api('clear_log'));
+qs('refreshRuntime').addEventListener('click', refresh);
+qs('loadOperatorLog').addEventListener('click', readOperatorLog);
+qs('runtimeLauncherLogChoices').addEventListener('click', async (ev) => {
+  const btn = ev.target && ev.target.closest ? ev.target.closest('.log-choice') : null;
+  if (!btn) return;
+  await readLogFile(btn.dataset.path);
+});
+qs('runSelfCheck').addEventListener('click', async () => {
+  const resp = await fetch('/api/self-check');
+  const data = await resp.json();
+  state.lastSelfCheck = data;
+  renderSelfCheck(data);
+  await refresh();
+});
+qs('terminateObsLauncher').addEventListener('click', async () => { if (confirm('Terminate local observation launcher subprocess only? Telescope STOP is separate.')) await api('terminate_observation_launcher'); });
+qs('terminateCalLauncher').addEventListener('click', async () => { if (confirm('Terminate local calibration launcher subprocess only? Telescope STOP is separate.')) await api('terminate_calibration_launcher'); });
+qs('terminateAllLaunchers').addEventListener('click', async () => { if (confirm('Terminate all local launcher subprocesses started by this console? Telescope STOP is separate.')) await api('terminate_all_launchers'); });
+qs('runtimeProcesses').addEventListener('click', async (ev) => {
+  const btn = ev.target && ev.target.closest ? ev.target.closest('.process-stop') : null;
+  if (!btn) return;
+  const pid = btn.dataset.pid;
+  if (confirm(`Terminate local launcher pid=${pid}? Telescope STOP is separate.`)) await api('terminate_process', {pid});
+});
+qs('openProgress').addEventListener('click', async () => {
+  const data = await api('launch_progress');
+  const url = data.progress_url || (data.state && data.state.progress_url);
+  if (data.ok && url) window.open(url, '_blank');
+});
+function getStatusRefreshMs() {
+  const cfg = window.NECST_CONSOLE_CONFIG || {};
+  const raw = Number(cfg.statusRefreshMs ?? cfg.status_refresh_ms ?? 1000);
+  if (!Number.isFinite(raw)) return 1000;
+  return Math.max(200, Math.round(raw));
+}
+const statusRefreshMs = getStatusRefreshMs();
+validateObs(); updatePreviewInfo(); validateMount(); updateTargetFields(); refresh(); setInterval(refresh, statusRefreshMs);
+</script>
+</body>
+</html>
+"""
+
+
+PROGRESS_HTML = r"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>NECST Progress Monitor Demo</title>
+<style>
+body { margin:0; background:#08101f; color:#eaf0ff; font:14px/1.45 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; }
+main { max-width:1100px; margin:0 auto; padding:18px; }
+.card { border:1px solid #28324a; border-radius:16px; background:#11182c; padding:14px; margin:12px 0; }
+.badge { display:inline-block; border:1px solid #365076; border-radius:999px; padding:4px 10px; margin:3px; color:#9fd1ff; }
+.grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); gap:12px; }
+.kv { color:#aab6d4; }
+.kv b { color:#eaf0ff; }
+</style>
+</head>
+<body>
+<main>
+  <h1>NECST Progress Monitor Demo</h1>
+  <p>This is a lightweight placeholder launched and owned by the console demo. No ROS or telescope data are used.</p>
+  <div class="card">
+    <span class="badge">Lifecycle: idle/demo</span>
+    <span class="badge">IRIG-B: demo</span>
+    <span class="badge">Recording: demo</span>
+    <span class="badge">Weather: demo</span>
+  </div>
+  <div class="grid">
+    <div class="card"><div class="kv">Current item<br><b>none</b></div></div>
+    <div class="card"><div class="kv">Antenna<br><b>Az/El from console demo</b></div></div>
+    <div class="card"><div class="kv">Spectrometer<br><b>demo status only</b></div></div>
+    <div class="card"><div class="kv">Chopper<br><b>demo status only</b></div></div>
+  </div>
+  <div class="card">
+    <b>Lifecycle policy:</b> because this progress monitor was launched by the console demo, it will stop when the console process exits.
+  </div>
+</main>
+</body>
+</html>
+"""
+
+
+@dataclass
+class LogEntry:
+    time: str
+    ok: bool
+    message: str
+
+
+@dataclass
+class DemoState:
+    telescope: str = "OMU1.85m demo"
+    progress_url: str = "http://127.0.0.1:8091/"
+    progress_running: bool = False
+    progress_owned_by_console: bool = False
+    state: str = "idle"
+    manual_state: str = "idle"
+    active_task: str = "none"
+    az: float = 180.0
+    el: float = 45.0
+    command_az: Optional[float] = None
+    command_el: Optional[float] = None
+    mount_limits: Dict[str, float] = field(default_factory=lambda: {
+        "az_min": 5.0,
+        "az_max": 355.0,
+        "el_min": 5.0,
+        "el_max": 85.0,
+    })
+    warning_count: int = 0
+    authority_held: bool = False
+    authority_session_id: Optional[str] = None
+    chopper_state: str = "OUT"
+    chopper_position: int = 19700
+    log: List[LogEntry] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "telescope": self.telescope,
+            "progress_url": self.progress_url,
+            "progress": {
+                "url": self.progress_url,
+                "running": self.progress_running,
+                "owned_by_console": self.progress_owned_by_console,
+            },
+            "state": self.state,
+            "manual_state": self.manual_state,
+            "active_task": self.active_task,
+            "az": self.az,
+            "el": self.el,
+            "command_az": self.command_az,
+            "command_el": self.command_el,
+            "mount_limits": self.mount_limits,
+            "warning_count": self.warning_count,
+            "authority": {
+                "held": self.authority_held,
+                "session_id": self.authority_session_id,
+            },
+            "chopper": {
+                "state": self.chopper_state,
+                "position": self.chopper_position,
+                "age": "live demo",
+            },
+            "log": [entry.__dict__ for entry in self.log[-80:]],
+        }
+
+
+class ConsoleDemoServer(ThreadingHTTPServer):
+    daemon_threads = True
+
+    def __init__(
+        self,
+        server_address: Tuple[str, int],
+        request_handler_class: type[BaseHTTPRequestHandler],
+        *,
+        telescope: str,
+        progress_url: str,
+        quiet: bool,
+        progress_host: str,
+        progress_port: int,
+    ) -> None:
+        super().__init__(server_address, request_handler_class)
+        self.state = DemoState(telescope=telescope, progress_url=progress_url)
+        self.lock = threading.RLock()
+        self.quiet = quiet
+        self.progress_host = progress_host
+        self.progress_port = int(progress_port)
+        self._progress_server: Optional[ThreadingHTTPServer] = None
+        self._progress_thread: Optional[threading.Thread] = None
+        self.add_log(True, "console demo v7 started; no real telescope command is sent")
+
+    def add_log(self, ok: bool, message: str) -> None:
+        timestamp = time.strftime("%H:%M:%S")
+        self.state.log.append(LogEntry(timestamp, ok, message))
+        if len(self.state.log) > 200:
+            self.state.log = self.state.log[-200:]
+
+    def launch_progress(self) -> Tuple[bool, str, str]:
+        if self._progress_server is not None:
+            return True, "managed progress monitor is already running", self.state.progress_url
+        bind_host = self.progress_host
+        display_host = "127.0.0.1" if bind_host in {"", "0.0.0.0"} else bind_host
+        try:
+            progress_server = ThreadingHTTPServer((bind_host, self.progress_port), ProgressHandler)
+        except OSError as exc:
+            self.state.progress_running = False
+            self.state.progress_owned_by_console = False
+            return False, f"failed to start progress monitor demo: {exc}", self.state.progress_url
+        progress_server.daemon_threads = True
+        thread = threading.Thread(target=progress_server.serve_forever, name="console-demo-progress", daemon=True)
+        thread.start()
+        self._progress_server = progress_server
+        self._progress_thread = thread
+        self.state.progress_url = f"http://{display_host}:{self.progress_port}/"
+        self.state.progress_running = True
+        self.state.progress_owned_by_console = True
+        return True, "managed progress monitor demo started", self.state.progress_url
+
+    def stop_progress(self) -> None:
+        progress_server = self._progress_server
+        progress_thread = self._progress_thread
+        self._progress_server = None
+        self._progress_thread = None
+        if progress_server is not None:
+            progress_server.shutdown()
+            progress_server.server_close()
+        if progress_thread is not None:
+            progress_thread.join(timeout=2.0)
+        self.state.progress_running = False
+        self.state.progress_owned_by_console = False
+
+
+class ProgressHandler(BaseHTTPRequestHandler):
+    def log_message(self, fmt: str, *args: Any) -> None:
+        return
+
+    def do_GET(self) -> None:  # noqa: N802 - stdlib API name
+        if self.path not in {"/", "/index.html", "/health"}:
+            self.send_error(HTTPStatus.NOT_FOUND, "not found")
+            return
+        if self.path == "/health":
+            data = json.dumps({"ok": True}).encode("utf-8")
+            self.send_response(HTTPStatus.OK)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+            return
+        data = PROGRESS_HTML.encode("utf-8")
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(data)))
+        self.send_header("Cache-Control", "no-store")
+        self.end_headers()
+        self.wfile.write(data)
+
+
+class Handler(BaseHTTPRequestHandler):
+    server: ConsoleDemoServer
+
+    def log_message(self, fmt: str, *args: Any) -> None:
+        if not self.server.quiet:
+            super().log_message(fmt, *args)
+
+    def _send_json(self, payload: Dict[str, Any], status: int = 200) -> None:
+        data = json.dumps(payload, ensure_ascii=False, sort_keys=True).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(data)))
+        self.send_header("Cache-Control", "no-store")
+        self.end_headers()
+        self.wfile.write(data)
+
+    def _send_html(self) -> None:
+        data = HTML.encode("utf-8")
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(data)))
+        self.send_header("Cache-Control", "no-store")
+        self.end_headers()
+        self.wfile.write(data)
+
+    def do_GET(self) -> None:  # noqa: N802 - stdlib API name
+        if self.path in {"/", "/index.html"}:
+            self._send_html()
+            return
+        if self.path == "/api/status":
+            with self.server.lock:
+                self._send_json(self.server.state.to_dict())
+            return
+        parsed = urllib.parse.urlparse(self.path)
+        if parsed.path == "/api/operator-log":
+            with self.server.lock:
+                entries = []
+                for idx, entry in enumerate(self.server.state.log[-80:], start=1):
+                    payload = dict(entry.__dict__)
+                    payload["_line"] = idx
+                    payload["time_iso"] = payload.get("time")
+                    entries.append(payload)
+                self._send_json({
+                    "ok": True,
+                    "reason": "demo operator log read",
+                    "path": "demo://operator_console.jsonl",
+                    "entries": entries,
+                    "returned_count": len(entries),
+                })
+            return
+        if parsed.path == "/api/log-file":
+            query = urllib.parse.parse_qs(parsed.query)
+            requested = (query.get("path") or ["demo://launcher.log"])[0]
+            self._send_json({
+                "ok": True,
+                "reason": "demo launcher log read",
+                "path": requested,
+                "size_bytes": 0,
+                "returned_bytes": 0,
+                "truncated_head": False,
+                "text": "This is the standalone console demo. No real launcher log file exists.\n",
+            })
+            return
+        if parsed.path == "/api/self-check":
+            with self.server.lock:
+                self._send_json({
+                    "ok": True,
+                    "status": "warning",
+                    "summary": {
+                        "ok": True,
+                        "status": "warning",
+                        "error_count": 0,
+                        "warning_count": 1,
+                        "check_count": 3,
+                        "telescope": self.server.state.telescope,
+                        "action_mode": "demo",
+                    },
+                    "checks": [
+                        {"name": "demo_mode", "ok": True, "severity": "warning", "message": "standalone demo; no real telescope command is sent", "data": {}},
+                        {"name": "layout", "ok": True, "severity": "info", "message": "v7 layout is available", "data": {}},
+                        {"name": "progress_demo", "ok": True, "severity": "info", "message": "progress demo can be launched from this console", "data": {"url": self.server.state.progress_url}},
+                    ],
+                })
+            return
+        if parsed.path == "/health":
+            self._send_json({"ok": True})
+            return
+        self.send_error(HTTPStatus.NOT_FOUND, "not found")
+
+    def do_POST(self) -> None:  # noqa: N802 - stdlib API name
+        if self.path != "/api/action":
+            self.send_error(HTTPStatus.NOT_FOUND, "not found")
+            return
+        length = int(self.headers.get("Content-Length") or 0)
+        try:
+            body = self.rfile.read(length).decode("utf-8")
+            payload = json.loads(body or "{}")
+        except Exception as exc:
+            self._send_json({"ok": False, "reason": f"invalid JSON: {exc}"}, 400)
+            return
+        action = str(payload.get("action") or "")
+        params = payload.get("params") or {}
+        session_id = str(payload.get("session_id") or "anonymous")
+        if not isinstance(params, dict):
+            self._send_json({"ok": False, "reason": "params must be an object"}, 400)
+            return
+        with self.server.lock:
+            ok, reason = handle_action(self.server, action, params, session_id)
+            self._send_json({"ok": ok, "reason": reason, "state": self.server.state.to_dict()})
+
+
+def _as_float(value: Any, name: str) -> Tuple[Optional[float], Optional[str]]:
+    try:
+        number = float(value)
+    except Exception:
+        return None, f"{name} is not a number"
+    if not math.isfinite(number):
+        return None, f"{name} is not finite"
+    return number, None
+
+
+def _as_optional_int(value: Any, name: str) -> Tuple[Optional[int], Optional[str]]:
+    if value is None or str(value).strip() == "":
+        return None, None
+    try:
+        number = int(str(value).strip())
+    except Exception:
+        return None, f"{name} must be an integer"
+    if number <= 0:
+        return None, f"{name} must be positive"
+    return number, None
+
+
+def _parse_sexagesimal_angle(value: Any, name: str, *, is_ra: bool) -> Tuple[Optional[float], Optional[str]]:
+    text = str(value or "").strip()
+    if not text:
+        return None, f"{name} is empty"
+    try:
+        number = float(text)
+    except Exception:
+        number = None
+    if number is not None and math.isfinite(number):
+        return number, None
+    s = text.replace("−", "-").strip().lower()
+    sign = 1.0
+    if s.startswith("+"):
+        s = s[1:].strip()
+    if s.startswith("-"):
+        sign = -1.0
+        s = s[1:].strip()
+    if is_ra and sign < 0:
+        return None, "RA cannot be negative"
+    for old in ["h", "d", "°"]:
+        s = s.replace(old, ":")
+    for old in ["m", "′", "'"]:
+        s = s.replace(old, ":")
+    for old in ["s", "″", '"']:
+        s = s.replace(old, "")
+    s = ":".join(part for part in s.replace("\t", " ").split(" ") if part)
+    while "::" in s:
+        s = s.replace("::", ":")
+    s = s.strip(":")
+    try:
+        parts = [float(x) for x in s.split(":") if x != ""]
+    except Exception:
+        return None, f"{name} must be decimal degrees or sexagesimal"
+    if len(parts) < 1 or len(parts) > 3 or not all(math.isfinite(x) for x in parts):
+        return None, f"{name} must be decimal degrees or sexagesimal"
+    a0 = abs(parts[0])
+    a1 = parts[1] if len(parts) > 1 else 0.0
+    a2 = parts[2] if len(parts) > 2 else 0.0
+    if not (0 <= a1 < 60) or not (0 <= a2 < 60):
+        return None, "sexagesimal minutes/seconds must be in 0..60"
+    value_abs = a0 + a1 / 60.0 + a2 / 3600.0
+    degrees = value_abs * 15.0 if is_ra else sign * value_abs
+    return degrees, None
+
+
+def _validate_mount(params: Dict[str, Any], limits: Optional[Dict[str, float]] = None) -> Tuple[bool, str, Optional[float], Optional[float]]:
+    az, err = _as_float(params.get("az"), "Az")
+    if err:
+        return False, err, None, None
+    el, err = _as_float(params.get("el"), "El")
+    if err:
+        return False, err, None, None
+    limits = limits or (params.get("limits") if isinstance(params.get("limits"), dict) else {})
+    az_min, err = _as_float(limits.get("az_min", 5), "Az min")
+    if err:
+        return False, err, None, None
+    az_max, err = _as_float(limits.get("az_max", 355), "Az max")
+    if err:
+        return False, err, None, None
+    el_min, err = _as_float(limits.get("el_min", 5), "El min")
+    if err:
+        return False, err, None, None
+    el_max, err = _as_float(limits.get("el_max", 85), "El max")
+    if err:
+        return False, err, None, None
+    assert az is not None and el is not None
+    assert az_min is not None and az_max is not None
+    assert el_min is not None and el_max is not None
+    if az_min >= az_max:
+        return False, "Az min/max are invalid", None, None
+    if el_min >= el_max:
+        return False, "El min/max are invalid", None, None
+    if not (az_min <= az <= az_max):
+        return False, f"Az={az:g} deg is outside allowed range {az_min:g}..{az_max:g} deg", None, None
+    if not (el_min <= el <= el_max):
+        return False, f"El={el:g} deg is outside allowed range {el_min:g}..{el_max:g} deg", None, None
+    return True, "ok", az, el
+
+
+def _validate_observation(params: Dict[str, Any]) -> Tuple[bool, str]:
+    mode = str(params.get("mode") or "")
+    path = str(params.get("file") or "").strip()
+    if mode not in {"otf", "psw", "grid", "radio_pointing"}:
+        return False, f"unsupported observation mode: {mode!r}"
+    if not path:
+        return False, "obs file path/name is empty"
+    if not path.lower().endswith((".obs", ".toml")):
+        return False, "obs file extension should be .obs or .toml"
+    channel, err = _as_optional_int(params.get("channel"), "channel")
+    if err:
+        return False, err
+    if channel is not None and channel > 30:
+        return False, "channel override is too large for this demo"
+    return True, "ok"
+
+
+def _observation_check_summary(params: Dict[str, Any]) -> str:
+    mode = str(params.get("mode") or "")
+    path = str(params.get("file") or "").strip()
+    channel, _err = _as_optional_int(params.get("channel"), "channel")
+    preview = str(params.get("preview") or "")
+    defaults = "defaults: cos_correction=true, use_scan_block=true, sg_preflight_policy=verify_only, sg_preflight_scope=active_lo_chains"
+    ch_text = f", channel override={channel}" if channel is not None else ", channel=obs file/default"
+    preview_text = f", preview={len(preview.splitlines()) if preview else 0} lines"
+    return f"mode={mode}, file={path}{ch_text}{preview_text}, {defaults}"
+
+
+def _observation_dry_run_summary(params: Dict[str, Any]) -> str:
+    mode = str(params.get("mode") or "")
+    path = str(params.get("file") or "").strip()
+    preview = str(params.get("preview") or "")
+    preview_lines = len(preview.splitlines()) if preview else 0
+    if mode == "otf":
+        plan = "plan=OTF sequence: parse obs -> apply defaults -> build scan blocks when available -> verify SG targets"
+    elif mode == "psw":
+        plan = "plan=PSW sequence: parse obs -> apply defaults -> build ON/OFF/HOT cadence -> verify SG targets"
+    elif mode == "grid":
+        plan = "plan=Grid sequence: parse obs -> apply defaults -> build grid point list -> verify SG targets"
+    elif mode == "radio_pointing":
+        plan = "plan=Radio Pointing sequence: parse obs -> apply defaults -> build pointing scans -> verify SG targets"
+    else:
+        plan = "plan=unknown"
+    return f"Dry run OK: file={path}, preview={preview_lines} lines, {plan}. No mount/chopper/recording/gate/SG apply commands were sent."
+
+
+def _validate_tracking(params: Dict[str, Any]) -> Tuple[bool, str]:
+    kind = str(params.get("kind") or "")
+    if kind not in {"sun", "moon", "name", "radec", "galactic"}:
+        return False, f"unsupported target kind: {kind!r}"
+    if kind == "name" and not str(params.get("name") or "").strip():
+        return False, "object name is empty"
+    if kind == "radec":
+        ra_deg, err = _parse_sexagesimal_angle(params.get("coord1"), "RA", is_ra=True)
+        if err:
+            return False, err
+        dec_deg, err = _parse_sexagesimal_angle(params.get("coord2"), "Dec", is_ra=False)
+        if err:
+            return False, err
+        assert ra_deg is not None and dec_deg is not None
+        if not (0.0 <= ra_deg < 360.0):
+            return False, "RA must satisfy 0 <= value < 360 deg"
+        if not (-90.0 <= dec_deg <= 90.0):
+            return False, "Dec must satisfy -90 <= value <= 90 deg"
+    if kind == "galactic":
+        c1, err = _as_float(params.get("coord1"), "Galactic l")
+        if err:
+            return False, err
+        c2, err = _as_float(params.get("coord2"), "Galactic b")
+        if err:
+            return False, err
+        assert c1 is not None and c2 is not None
+        if not (0.0 <= c1 < 360.0):
+            return False, "Galactic l must satisfy 0 <= value < 360 deg"
+        if not (-90.0 <= c2 <= 90.0):
+            return False, "Galactic b must satisfy -90 <= value <= 90 deg"
+    off_x, err = _as_float(params.get("offset_x_arcsec", 0), "offset X")
+    if err:
+        return False, err
+    off_y, err = _as_float(params.get("offset_y_arcsec", 0), "offset Y")
+    if err:
+        return False, err
+    assert off_x is not None and off_y is not None
+    if abs(off_x) > 36000 or abs(off_y) > 36000:
+        return False, "offset is larger than demo limit 36000 arcsec"
+    return True, "ok"
+
+
+def _validate_positive_float(value: Any, name: str) -> Tuple[bool, str, Optional[float]]:
+    number, err = _as_float(value, name)
+    if err:
+        return False, err, None
+    assert number is not None
+    if number <= 0:
+        return False, f"{name} must be positive", None
+    return True, "ok", number
+
+
+def _with_privilege(server: ConsoleDemoServer, session_id: str, action_text: str) -> str:
+    state = server.state
+    if state.authority_held:
+        if state.authority_session_id == session_id:
+            return f"{action_text} using held authority"
+        return f"{action_text} rejected: authority is held by another browser session"
+    return f"{action_text} with temporary authority acquire/release"
+
+
+def handle_action(
+    server: ConsoleDemoServer, action: str, params: Dict[str, Any], session_id: str
+) -> Tuple[bool, str]:
+    state = server.state
+
+    if action == "launch_progress":
+        ok, reason, url = server.launch_progress()
+        server.add_log(ok, f"{reason}: {url}")
+        return ok, reason
+
+    if action == "clear_log":
+        state.log.clear()
+        server.add_log(True, "operation log cleared")
+        return True, "cleared"
+
+    if action == "acquire_authority":
+        if state.authority_held and state.authority_session_id != session_id:
+            reason = "authority is already held by another browser session"
+            server.add_log(False, reason)
+            return False, reason
+        state.authority_held = True
+        state.authority_session_id = session_id
+        server.add_log(True, "authority acquired")
+        return True, "authority acquired"
+
+    if action == "release_authority":
+        if not state.authority_held:
+            server.add_log(True, "authority was already free")
+            return True, "authority already free"
+        if state.authority_session_id != session_id:
+            reason = "cannot release authority held by another browser session"
+            server.add_log(False, reason)
+            return False, reason
+        state.authority_held = False
+        state.authority_session_id = None
+        server.add_log(True, "authority released")
+        return True, "authority released"
+
+    if action == "stop_tracking":
+        if state.manual_state != "tracking":
+            reason = "target tracking is not running"
+            server.add_log(False, reason)
+            return False, reason
+        state.command_az = None
+        state.command_el = None
+        state.manual_state = "stopped"
+        state.active_task = "none"
+        server.add_log(True, "Stop tracking sent: same antenna-stop operation as STOP, limited to tracking context")
+        return True, "tracking stopped"
+
+    if action == "stop":
+        state.command_az = None
+        state.command_el = None
+        state.manual_state = "stopped"
+        if state.state == "observing":
+            state.active_task = "observation; antenna STOP sent"
+            server.add_log(True, "STOP sent: antenna/manual motion stopped; observation cleanup is not performed")
+        elif state.state == "calibrating":
+            state.active_task = "calibration; STOP sent"
+            server.add_log(True, "STOP sent: motion stopped during calibration; procedure cleanup is not simulated")
+        else:
+            state.active_task = "none"
+            server.add_log(True, "STOP sent: manual motion/tracking stopped")
+        return True, "stopped"
+
+    if action == "mount_move" or action == "mount_move_dry_run":
+        ok, reason, az, el = _validate_mount(params, state.mount_limits)
+        if not ok:
+            server.add_log(False, f"mount move not sent: {reason}")
+            return False, reason
+        assert az is not None and el is not None
+        prefix = "dry-run mount move" if action == "mount_move_dry_run" else "mount move"
+        privilege_msg = _with_privilege(server, session_id, prefix)
+        if "rejected" in privilege_msg:
+            server.add_log(False, privilege_msg)
+            return False, privilege_msg
+        if action == "mount_move":
+            state.command_az = az
+            state.command_el = el
+            state.az = az
+            state.el = el
+            state.manual_state = "moving"
+            state.active_task = "manual mount move"
+        server.add_log(True, f"{privilege_msg}: Az={az:.6f} deg, El={el:.6f} deg")
+        return True, "ok"
+
+    if action == "check_observation":
+        ok, reason = _validate_observation(params)
+        if ok:
+            summary = _observation_check_summary(params)
+            server.add_log(True, f"observation Check OK: {summary}")
+            return True, "Check OK: obs file selection and static options are valid"
+        server.add_log(False, f"observation Check failed: {reason}")
+        return False, reason
+
+    if action == "dry_run_observation":
+        ok, reason = _validate_observation(params)
+        if not ok:
+            server.add_log(False, f"observation Dry run failed before planning: {reason}")
+            return False, reason
+        summary = _observation_dry_run_summary(params)
+        server.add_log(True, summary)
+        return True, summary
+
+    if action == "start_observation":
+        ok, reason = _validate_observation(params)
+        if not ok:
+            server.add_log(False, f"observation not started: {reason}")
+            return False, reason
+        privilege_msg = _with_privilege(server, session_id, "start observation")
+        if "rejected" in privilege_msg:
+            server.add_log(False, privilege_msg)
+            return False, privilege_msg
+        state.command_az = None
+        state.command_el = None
+        state.state = "observing"
+        state.manual_state = "observing sequence"
+        state.active_task = "observation"
+        mode = str(params.get("mode") or "")
+        path = str(params.get("file") or "").strip()
+        server.add_log(True, f"{privilege_msg}: mode={mode}, file={path}")
+        return True, "observation started"
+
+    if action == "abort_observation":
+        if state.state != "observing":
+            reason = "no running observation to abort"
+            server.add_log(False, reason)
+            return False, reason
+        state.command_az = None
+        state.command_el = None
+        state.state = "idle"
+        state.manual_state = "idle"
+        state.active_task = "none"
+        server.add_log(True, "ABORT sent: observation cleanup requested")
+        return True, "observation aborted"
+
+    if action == "start_tracking":
+        ok, reason = _validate_tracking(params)
+        if not ok:
+            server.add_log(False, f"tracking not started: {reason}")
+            return False, reason
+        privilege_msg = _with_privilege(server, session_id, "start tracking")
+        if "rejected" in privilege_msg:
+            server.add_log(False, privilege_msg)
+            return False, privilege_msg
+        state.command_az = None
+        state.command_el = None
+        state.manual_state = "tracking"
+        state.active_task = "target tracking"
+        kind = str(params.get("kind") or "")
+        off_x = float(params.get("offset_x_arcsec") or 0)
+        off_y = float(params.get("offset_y_arcsec") or 0)
+        server.add_log(
+            True,
+            f"{privilege_msg}: target={kind}, offset=({off_x:g}, {off_y:g}) arcsec; stop with STOP",
+        )
+        return True, "tracking started"
+
+    if action.startswith("chopper_"):
+        privilege_msg = _with_privilege(server, session_id, action.replace("_", " "))
+        if "rejected" in privilege_msg:
+            server.add_log(False, privilege_msg)
+            return False, privilege_msg
+        if action == "chopper_in":
+            state.chopper_state = "IN"
+            state.chopper_position = 4750
+        elif action == "chopper_out":
+            state.chopper_state = "OUT"
+            state.chopper_position = 19700
+        elif action == "chopper_home":
+            state.chopper_state = "HOME"
+            state.chopper_position = 0
+        elif action == "chopper_recover":
+            state.chopper_state = "HOME"
+            state.chopper_position = 0
+        elif action == "chopper_alarm_reset":
+            pass
+        elif action == "chopper_status":
+            server.add_log(True, f"chopper status: {state.chopper_state}, position={state.chopper_position}")
+            return True, "status"
+        else:
+            return False, f"unknown chopper action: {action}"
+        server.add_log(True, f"{privilege_msg}: state={state.chopper_state}, position={state.chopper_position}")
+        return True, "ok"
+
+    if action == "run_rsky":
+        n, err = _as_optional_int(params.get("n"), "RSky n")
+        if err:
+            server.add_log(False, f"RSky not started: {err}")
+            return False, err
+        ok, reason, integ = _validate_positive_float(params.get("integ", 2), "RSky integ")
+        if not ok:
+            server.add_log(False, f"RSky not started: {reason}")
+            return False, reason
+        _ch, err = _as_optional_int(params.get("ch"), "RSky channel")
+        if err:
+            server.add_log(False, f"RSky not started: {err}")
+            return False, err
+        privilege_msg = _with_privilege(server, session_id, "RSky")
+        if "rejected" in privilege_msg:
+            server.add_log(False, privilege_msg)
+            return False, privilege_msg
+        state.command_az = None
+        state.command_el = None
+        state.state = "calibrating"
+        state.manual_state = "calibration"
+        state.active_task = "RSky"
+        server.add_log(True, f"{privilege_msg}: n={n or 1}, integ={integ:g} s")
+        return True, "RSky started"
+
+    if action == "run_skydip":
+        ok, reason, integ = _validate_positive_float(params.get("integ", 2), "SkyDip integ")
+        if not ok:
+            server.add_log(False, f"SkyDip not started: {reason}")
+            return False, reason
+        _ch, err = _as_optional_int(params.get("ch"), "SkyDip channel")
+        if err:
+            server.add_log(False, f"SkyDip not started: {err}")
+            return False, err
+        tp = str(params.get("tp_range") or "").split()
+        if tp:
+            try:
+                tp_values = [int(x) for x in tp]
+            except Exception:
+                reason = "tp_range must be integers"
+                server.add_log(False, f"SkyDip not started: {reason}")
+                return False, reason
+            if len(tp_values) % 2 != 0:
+                reason = "tp_range must contain START END pairs"
+                server.add_log(False, f"SkyDip not started: {reason}")
+                return False, reason
+        privilege_msg = _with_privilege(server, session_id, "SkyDip")
+        if "rejected" in privilege_msg:
+            server.add_log(False, privilege_msg)
+            return False, privilege_msg
+        state.command_az = None
+        state.command_el = None
+        state.state = "calibrating"
+        state.manual_state = "calibration"
+        state.active_task = "SkyDip"
+        server.add_log(True, f"{privilege_msg}: integ={integ:g} s")
+        return True, "SkyDip started"
+
+    reason = f"unknown action: {action!r}"
+    server.add_log(False, reason)
+    return False, reason
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Preview a standalone NECST operator-console GUI demo"
+    )
+    parser.add_argument("--host", default="127.0.0.1", help="web bind address")
+    parser.add_argument("--port", type=int, default=8090, help="web bind port")
+    parser.add_argument(
+        "--telescope", default="OMU1.85m demo", help="telescope label shown in the UI"
+    )
+    parser.add_argument(
+        "--progress-url",
+        default="http://127.0.0.1:8091/",
+        help="initial Progress monitor URL label before the managed demo progress server is launched",
+    )
+    parser.add_argument("--progress-host", default="127.0.0.1", help="bind address for the managed demo progress-monitor server")
+    parser.add_argument("--progress-port", type=int, default=8091, help="port for the managed demo progress-monitor server")
+    parser.add_argument("--open", action="store_true", help="open the URL in a browser")
+    parser.add_argument("--quiet", action="store_true", help="suppress HTTP request logs")
+    parser.add_argument("--az-min", type=float, default=5.0, help="demo Az lower limit, standing in for site TOML")
+    parser.add_argument("--az-max", type=float, default=355.0, help="demo Az upper limit, standing in for site TOML")
+    parser.add_argument("--el-min", type=float, default=5.0, help="demo El lower limit, standing in for site TOML")
+    parser.add_argument("--el-max", type=float, default=85.0, help="demo El upper limit, standing in for site TOML")
+    args = parser.parse_args(argv)
+
+    server = ConsoleDemoServer(
+        (str(args.host), int(args.port)),
+        Handler,
+        telescope=str(args.telescope),
+        progress_url=str(args.progress_url),
+        quiet=bool(args.quiet),
+        progress_host=str(args.progress_host),
+        progress_port=int(args.progress_port),
+    )
+    server.state.mount_limits = {
+        "az_min": float(args.az_min),
+        "az_max": float(args.az_max),
+        "el_min": float(args.el_min),
+        "el_max": float(args.el_max),
+    }
+    url = f"http://{args.host}:{args.port}/"
+    print("NECST operator console demo v7")
+    print("  standalone: no NECST/neclib/ROS import")
+    print("  real telescope commands: disabled")
+    print(f"  managed progress demo: http://{args.progress_host}:{args.progress_port}/ (launched from the UI)")
+    print(f"  demo site limits: Az {args.az_min}..{args.az_max} deg, El {args.el_min}..{args.el_max} deg")
+    print(f"  URL: {url}")
+    if args.open:
+        try:
+            webbrowser.open(url)
+        except Exception:
+            pass
+
+    stop_event = threading.Event()
+
+    def _signal_handler(_signum: int, _frame: Any) -> None:
+        stop_event.set()
+        server.shutdown()
+
+    old_int = signal.signal(signal.SIGINT, _signal_handler)
+    old_term = signal.signal(signal.SIGTERM, _signal_handler)
+    thread = threading.Thread(target=server.serve_forever, name="console-demo", daemon=True)
+    thread.start()
+    try:
+        while not stop_event.wait(0.2):
+            pass
+    finally:
+        signal.signal(signal.SIGINT, old_int)
+        signal.signal(signal.SIGTERM, old_term)
+        server.stop_progress()
+        server.server_close()
+        thread.join(timeout=2.0)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bin/console-demo.py
+++ b/bin/console-demo.py
@@ -244,6 +244,61 @@ details {
   background: rgba(255,255,255,0.02);
 }
 summary { cursor: pointer; color: var(--muted); }
+
+.file-chooser-card {
+  border: 1px solid rgba(122,162,255,0.24);
+  border-radius: 14px;
+  padding: 10px;
+  margin: 10px 0 12px;
+  background: rgba(255,255,255,0.018);
+}
+.file-chooser-toolbar {
+  display: flex;
+  gap: 7px;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-bottom: 8px;
+}
+.file-chooser-toolbar button { padding: 6px 9px; font-size: 12px; }
+.file-chooser-path {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 8px;
+  align-items: end;
+  margin-bottom: 8px;
+}
+.server-file-browser {
+  height: 210px;
+  overflow: auto;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: #080d1b;
+  padding: 4px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+}
+.file-row {
+  display: grid;
+  grid-template-columns: 28px minmax(0, 1fr) auto;
+  gap: 8px;
+  align-items: center;
+  width: 100%;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text);
+  text-align: left;
+  padding: 6px 8px;
+  cursor: pointer;
+}
+.file-row:hover, .file-row:focus { background: rgba(122,162,255,0.14); outline: none; }
+.file-row.directory .file-name { color: var(--accent2); font-weight: 700; }
+.file-row.file .file-name { color: var(--text); }
+.file-row .file-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.file-row .file-meta { color: var(--faint); font-size: 11px; white-space: nowrap; }
+.file-row.selected { background: rgba(86,211,100,0.12); box-shadow: inset 0 0 0 1px rgba(86,211,100,0.28); }
+.file-empty { color: var(--muted); padding: 12px; }
+
 .callout {
   display: grid;
   gap: 4px;
@@ -327,39 +382,63 @@ summary { cursor: pointer; color: var(--muted); }
             </select>
           </div>
           <div class="field">
-            <label for="obsFile" title="Choose a file from this browser computer only to preview its text. The real NECST-side run path is computed below from directory + filename.">Choose local obs file for preview</label>
-            <input id="obsFile" type="file" accept=".obs,.toml,.txt" title="Preview only. The browser does not expose the real local absolute path.">
-            <small>This reads the local file into the preview box and copies its filename. Browsers do not provide the real local path.</small>
+            <label for="serverObsRoot" title="Browse obs files from the NECST side, meaning the environment where this console server is running. If console is in Docker, this is the Docker/container filesystem.">NECST-side file location</label>
+            <select id="serverObsRoot" title="Starting location for the NECST-side file chooser."></select>
+            <small>This is a file chooser for the side running the console. In Docker it shows container files; outside Docker it shows that PC filesystem.</small>
           </div>
         </div>
         <div class="row">
           <div class="field">
-            <label for="recentDir" title="Directory on the NECST computer. The real implementation should remember recent directories.">Obs directory on NECST computer</label>
-            <select id="recentDir" title="NECST-side directory used to construct the computed run path.">
-              <option>/home/necst/obs</option>
-              <option>/home/necst/obs/commissioning</option>
-              <option>/data/observations/current</option>
-            </select>
-            <small>The real console should remember recently used directories.</small>
+            <label for="recentDir" title="Directory on the NECST-side filesystem. This is editable; selecting a file fills it automatically.">Obs directory on NECST side</label>
+            <input id="recentDir" list="recentDirList" placeholder="/path/on/NECST/side" title="Directory used to construct the run path. This is a NECST-side path, not the browser PC path.">
+            <datalist id="recentDirList"></datalist>
+            <small>NECST-side path. Use the file chooser below to choose and preview the exact file used for execution.</small>
           </div>
           <div class="field">
-            <label for="obsFilename" title="Filename on the NECST computer. Choosing a local preview file copies only its filename here.">Obs filename</label>
-            <input id="obsFilename" placeholder="e.g. orion_otf.obs" title="Filename to combine with the NECST-side directory. Accepts .obs or .toml in this demo.">
-            <small>Filled from the local preview file name, then editable.</small>
+            <label for="obsFilename" title="Filename on the NECST side. Choosing a file fills this automatically.">Obs filename</label>
+            <input id="obsFilename" placeholder="e.g. orion_otf.obs" title="Filename to combine with the NECST-side directory. Accepts .obs or .toml.">
+            <small>Filled from the NECST-side file chooser, then editable.</small>
           </div>
         </div>
         <div class="field">
-          <label for="obsPath" title="Read-only confirmation. This is computed from Obs directory + Obs filename; edit those fields if this path is wrong.">Computed run path on NECST computer</label>
+          <label for="obsPath" title="Read-only confirmation. This is computed from Obs directory + Obs filename; edit those fields if this path is wrong.">Computed run path on NECST side</label>
           <input id="obsPath" readonly placeholder="directory + filename" title="Read-only computed path used by Start observation.">
-          <small>Read-only confirmation. Start uses this computed NECST-side path. The preview text itself is not executed.</small>
+          <small>Read-only confirmation. Check, Dry run, Start, and preview use this same NECST-side path.</small>
+        </div>
+        <div class="file-chooser-card" aria-label="NECST-side file chooser">
+          <div class="file-chooser-toolbar">
+            <button id="serverObsHome" class="secondary compact" type="button" title="Return to the selected location.">Home</button>
+            <button id="serverObsUp" class="secondary compact" type="button" title="Move to the parent directory.">Up</button>
+            <button id="refreshServerObs" class="secondary compact" type="button" title="Refresh the NECST-side directory listing.">Refresh</button>
+            <small id="serverObsInfo">NECST-side file chooser: not loaded</small>
+          </div>
+          <div class="file-chooser-path">
+            <div class="field" style="margin-bottom:0">
+              <label for="serverObsDir" title="Directory to browse on the NECST/console-side filesystem.">Current folder on NECST side</label>
+              <input id="serverObsDir" placeholder="choose a location or type a folder" title="Directory to list on the NECST/console side. This is not the browser PC path.">
+            </div>
+            <button id="goServerObsDir" class="secondary compact" type="button" title="Open the typed NECST-side folder.">Open</button>
+          </div>
+          <div id="serverObsFiles" class="server-file-browser" role="listbox" aria-label="NECST-side files">
+            <div class="file-empty">Choose a location to browse NECST-side files.</div>
+          </div>
+          <small>Folders open in this browser. Clicking an .obs/.toml file previews the exact file used by Check / Dry run / Start.</small>
         </div>
         <div id="obsValidation" class="notice">Set the NECST-side directory and filename.</div>
         <details open>
           <summary>Preview selected obs file</summary>
           <div class="field" style="margin-top:10px">
             <label for="obsPreview">Preview text</label>
-            <textarea id="obsPreview" spellcheck="false" placeholder="Choose a local file above, or paste obs-file text here for visual checking." title="Preview/check copy only. The Start button uses the computed NECST-side run path, not this text."></textarea>
+            <textarea id="obsPreview" spellcheck="false" placeholder="Select a NECST-side obs file above to preview the exact file that Check/Dry run/Start will use." title="NECST-side preview. The Start button uses the same computed run path."></textarea>
             <small id="previewInfo">Preview: empty</small>
+          </div>
+        </details>
+        <details>
+          <summary>Optional local preview only</summary>
+          <div class="field" style="margin-top:10px">
+            <label for="obsFile" title="This reads a file from the browser computer only. It does not provide a server/Docker path and is not used for Start.">Choose local file for visual comparison only</label>
+            <input id="obsFile" type="file" accept=".obs,.toml,.txt" title="Preview only. The browser does not expose the Docker/server absolute path.">
+            <small>Use this only to compare text. Observation execution uses the NECST-side path above, not the browser local file.</small>
           </div>
         </details>
         <details>
@@ -643,7 +722,8 @@ const state = {
   siteLimits: {az_min: 5, az_max: 355, el_min: 5, el_max: 85},
   capabilities: {},
   liveActions: {guarded: false, enabled: false},
-  lastSelfCheck: null
+  lastSelfCheck: null,
+  demoObsBrowser: false
 };
 localStorage.setItem('necstConsoleDemoSession', state.sessionId);
 
@@ -909,6 +989,176 @@ async function refresh() {
   renderStatus(data);
   renderLog(data.log || []);
 }
+async function loadServerObsRoots() {
+  const rootSel = qs('serverObsRoot');
+  const info = qs('serverObsInfo');
+  if (!rootSel) return;
+  try {
+    const resp = await fetch('/api/obs-roots');
+    const data = await resp.json();
+    const roots = Array.isArray(data.roots) ? data.roots : [];
+    state.serverObsRoots = roots;
+    rootSel.innerHTML = roots.map(r => `<option value="${escapeHtml(r.path)}">${escapeHtml(r.label || r.path)}</option>`).join('');
+    setDirectoryDatalist(roots.map(r => r.path));
+    if (roots.length) {
+      qs('serverObsDir').value = roots[0].path;
+      if (!qs('recentDir').value) qs('recentDir').value = roots[0].path;
+      if (info) info.textContent = `NECST-side file chooser: ${roots.length} root(s)`;
+      await browseServerObs(roots[0].path);
+    } else if (info) {
+      info.textContent = 'NECST-side file chooser: no locations are available. Check filesystem permissions or use --obs-root.';
+    }
+  } catch (err) {
+    await useDemoObsBrowser(String(err && err.message ? err.message : err));
+  }
+}
+function formatFileSize(size) {
+  if (size === null || size === undefined || size === '') return '';
+  const n = Number(size);
+  if (!Number.isFinite(n)) return '';
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KiB`;
+  return `${(n / (1024 * 1024)).toFixed(1)} MiB`;
+}
+
+const DEMO_OBS_FILES = {
+  '/root/obs': {type: 'directory'},
+  '/root/obs/commissioning': {type: 'directory'},
+  '/root/obs/commissioning/orion_otf.obs': {type: 'file', text: '# Demo OTF obs file\n[observation]\nmode = "OTF"\nrecord_name = "demo_orion_otf"\n\n[coordinate]\ncoord_sys = "J2000"\n"lambda_on[hms]" = "05:35:17.3"\n"beta_on[dms]" = "-05:23:28"\n'},
+  '/root/obs/commissioning/rsky.toml': {type: 'file', text: '# Demo TOML obs/check file\n[observation]\nmode = "PSW"\nrecord_name = "demo_rsky"\n'},
+  '/data/observations': {type: 'directory'},
+  '/data/observations/current': {type: 'directory'},
+  '/data/observations/current/test_grid.obs': {type: 'file', text: '# Demo Grid obs file\n[observation]\nmode = "Grid"\nrecord_name = "demo_grid"\n'}
+};
+function demoObsRootsPayload() {
+  return [
+    {path: '/root/obs', label: 'Demo obs folder (/root/obs)'},
+    {path: '/data/observations', label: 'Demo observations (/data/observations)'},
+    {path: '/', label: 'Demo filesystem root (/)'}
+  ];
+}
+function demoNormalizePath(path) {
+  let p = String(path || '/root/obs').trim() || '/root/obs';
+  if (!p.startsWith('/')) p = '/root/obs/' + p;
+  p = p.replace(/\/+/g, '/');
+  if (p.length > 1) p = p.replace(/\/+$/, '');
+  return p || '/';
+}
+function demoListDir(dir) {
+  const d = demoNormalizePath(dir);
+  const entries = [];
+  if (d !== '/') entries.push({type: 'directory', name: '..', path: dirnameOf(d), size: null});
+  const seen = new Set();
+  for (const [path, node] of Object.entries(DEMO_OBS_FILES)) {
+    if (path === d) continue;
+    if (!path.startsWith(d === '/' ? '/' : d + '/')) continue;
+    const rest = path.slice(d === '/' ? 1 : d.length + 1);
+    if (!rest || rest.includes('/')) continue;
+    const name = rest;
+    if (seen.has(name)) continue;
+    seen.add(name);
+    entries.push({type: node.type, name, path, size: node.type === 'file' ? (node.text || '').length : null});
+  }
+  entries.sort((a, b) => (a.type === b.type ? a.name.localeCompare(b.name) : (a.type === 'directory' ? -1 : 1)));
+  return {ok: true, directory: d, entries, root_count: 3};
+}
+function demoPreviewFile(path) {
+  const p = demoNormalizePath(path);
+  const node = DEMO_OBS_FILES[p];
+  if (!node || node.type !== 'file') throw new Error('demo file not found: ' + p);
+  const text = node.text || '';
+  return {ok: true, path: p, directory: dirnameOf(p), filename: basenameOf(p), text, size_bytes: text.length, returned_bytes: text.length, line_count: text.split('\n').length, truncated: false};
+}
+async function useDemoObsBrowser(reason) {
+  state.demoObsBrowser = true;
+  const roots = demoObsRootsPayload();
+  const rootSel = qs('serverObsRoot');
+  const info = qs('serverObsInfo');
+  state.serverObsRoots = roots;
+  rootSel.innerHTML = roots.map(r => `<option value="${escapeHtml(r.path)}">${escapeHtml(r.label || r.path)}</option>`).join('');
+  setDirectoryDatalist(roots.map(r => r.path));
+  qs('serverObsDir').value = roots[0].path;
+  if (!qs('recentDir').value) qs('recentDir').value = roots[0].path;
+  if (info) info.textContent = 'Demo NECST-side file chooser shown because the live API is unavailable' + (reason ? ` (${reason})` : '') + '.';
+  await browseServerObs(roots[0].path);
+}
+function renderServerObsEntries(entries, directory) {
+  const list = qs('serverObsFiles');
+  if (!list) return;
+  const safeEntries = Array.isArray(entries) ? entries : [];
+  if (!safeEntries.length) {
+    list.innerHTML = '<div class="file-empty">No .obs/.toml files or subfolders in this folder.</div>';
+    return;
+  }
+  list.innerHTML = safeEntries.map((e, idx) => {
+    const type = e.type === 'directory' ? 'directory' : 'file';
+    const icon = type === 'directory' ? (e.name === '..' ? '↩' : '📁') : '📄';
+    const meta = type === 'directory' ? 'folder' : formatFileSize(e.size);
+    const name = e.name === '..' ? '.. parent folder' : e.name;
+    return `<button type="button" class="file-row ${type}" role="option" data-index="${idx}" data-type="${escapeHtml(type)}" data-path="${escapeHtml(e.path || '')}" title="${escapeHtml(e.path || '')}">` +
+      `<span class="file-icon">${icon}</span>` +
+      `<span class="file-name">${escapeHtml(name || '')}</span>` +
+      `<span class="file-meta">${escapeHtml(meta || '')}</span>` +
+      `</button>`;
+  }).join('');
+}
+async function browseServerObs(dir) {
+  const info = qs('serverObsInfo');
+  const list = qs('serverObsFiles');
+  if (!list) return;
+  const browseDir = String(dir || qs('serverObsDir').value || qs('serverObsRoot').value || '').trim();
+  if (!browseDir) {
+    if (info) info.textContent = 'NECST-side file chooser: choose a root or folder.';
+    list.innerHTML = '<div class="file-empty">No location is available. Check filesystem permissions or use --obs-root.</div>';
+    return;
+  }
+  try {
+    if (info) info.textContent = 'NECST-side file chooser: loading...';
+    let data;
+    if (state.demoObsBrowser) {
+      data = demoListDir(browseDir);
+    } else {
+      const resp = await fetch('/api/obs-list?dir=' + encodeURIComponent(browseDir));
+      data = await resp.json();
+    }
+    if (!data.ok) throw new Error(data.reason || 'obs list failed');
+    const entries = Array.isArray(data.entries) ? data.entries : [];
+    qs('serverObsDir').value = data.directory || browseDir;
+    if (!qs('recentDir').value) qs('recentDir').value = data.directory || browseDir;
+    setDirectoryDatalist([data.directory, ...(state.serverObsRoots || []).map(r => r.path)]);
+    renderServerObsEntries(entries, data.directory || browseDir);
+    if (info) info.textContent = `${state.demoObsBrowser ? 'Demo ' : ''}NECST-side file chooser: ${entries.length} item(s) in ${data.directory || browseDir}`;
+  } catch (err) {
+    if (!state.demoObsBrowser) {
+      await useDemoObsBrowser(String(err && err.message ? err.message : err));
+      return;
+    }
+    list.innerHTML = '<div class="file-empty">Cannot open this folder. Check the path.</div>';
+    if (info) info.textContent = 'NECST-side file chooser error: ' + err;
+  }
+}
+async function previewServerObsFile(path) {
+  const info = qs('previewInfo');
+  try {
+    let data;
+    if (state.demoObsBrowser) {
+      data = demoPreviewFile(path);
+    } else {
+      const resp = await fetch('/api/obs-preview?path=' + encodeURIComponent(path) + '&max_bytes=65536');
+      data = await resp.json();
+    }
+    if (!data.ok) throw new Error(data.reason || 'preview failed');
+    setObsPathFromServerPath(data.path || path);
+    qs('obsPreview').value = data.text || '';
+    updatePreviewInfo();
+    if (info) {
+      const trunc = data.truncated ? ', truncated' : '';
+      info.textContent = `${state.demoObsBrowser ? 'Demo preview' : 'NECST-side preview'}: ${data.line_count || 0} lines, ${data.size_bytes || 0} bytes${trunc}`;
+    }
+  } catch (err) {
+    if (info) info.textContent = 'NECST-side preview failed: ' + err;
+  }
+}
 function renderStatus(data) {
   const heldByMe = data.authority && data.authority.session_id === state.sessionId;
   state.siteLimits = data.mount_limits || state.siteLimits;
@@ -967,10 +1217,41 @@ function renderLog(items) {
     return `<div class="log-entry"><span class="time">${item.time}</span> <span class="${statusClass}">${item.ok ? 'OK' : 'NG'}</span> ${item.message}</div>`;
   }).join('') || '<span style="color:var(--faint)">No operation yet.</span>';
 }
+function dirnameOf(path) {
+  const s = String(path || '').trim();
+  const idx = s.lastIndexOf('/');
+  if (idx <= 0) return idx === 0 ? '/' : '';
+  return s.slice(0, idx);
+}
+function basenameOf(path) {
+  const s = String(path || '').trim();
+  const idx = s.lastIndexOf('/');
+  return idx >= 0 ? s.slice(idx + 1) : s;
+}
+function setDirectoryDatalist(dirs) {
+  const dl = qs('recentDirList');
+  if (!dl) return;
+  const unique = Array.from(new Set((dirs || []).filter(Boolean)));
+  dl.innerHTML = unique.map(d => `<option value="${escapeHtml(d)}"></option>`).join('');
+}
+function setObsPathFromServerPath(path) {
+  const p = String(path || '').trim();
+  if (!p) return;
+  qs('recentDir').value = dirnameOf(p);
+  qs('obsFilename').value = basenameOf(p);
+  if (qs('serverObsDir')) qs('serverObsDir').value = dirnameOf(p);
+  state.obsChecked = false;
+  validateObs();
+}
 function updateObsRunPath() {
-  const dir = qs('recentDir').value.replace(/\/+$/, '');
-  const name = qs('obsFilename').value.trim().replace(/^\/+/, '');
-  qs('obsPath').value = (dir && name) ? `${dir}/${name}` : '';
+  const nameRaw = qs('obsFilename').value.trim();
+  if (nameRaw.startsWith('/')) {
+    qs('obsPath').value = nameRaw;
+  } else {
+    const dir = qs('recentDir').value.trim().replace(/\/+$/, '');
+    const name = nameRaw.replace(/^\/+/, '');
+    qs('obsPath').value = (dir && name) ? `${dir}/${name}` : '';
+  }
   qs('runBarTitle').textContent = qs('obsPath').value || 'No obs file selected';
   qs('runBarSub').textContent = qs('obsPath').value ? `${qs('obsMode').value.toUpperCase()} / ${state.obsChecked ? 'checked' : 'unchecked, Start will validate'}` : 'Set the NECST-side directory and filename.';
 }
@@ -1087,16 +1368,58 @@ function selectPanel(id) {
 }
 
 document.querySelectorAll('.tab').forEach(b => b.addEventListener('click', () => selectPanel(b.dataset.panel)));
-['obsFilename','obsPreview','obsChannel','obsMode'].forEach(id => qs(id).addEventListener('input', () => { state.obsChecked = false; validateObs(); }));
+['recentDir','obsFilename','obsPreview','obsChannel','obsMode'].forEach(id => qs(id).addEventListener('input', () => { state.obsChecked = false; validateObs(); }));
 ['mountAz','mountEl'].forEach(id => qs(id).addEventListener('input', validateMount));
 ['targetKind','targetName','coord1','coord2','offsetFrame','offsetX','offsetY','cosCorrection'].forEach(id => qs(id).addEventListener('input', updateTargetFields));
 qs('obsFile').addEventListener('change', async (ev) => {
   const file = ev.target.files[0];
   if (!file) return;
-  qs('obsFilename').value = file.name;
   qs('obsPreview').value = await file.text();
   state.obsChecked = false;
-  validateObs();
+  updatePreviewInfo();
+  setNotice(qs('obsValidation'), 'warn', 'Local preview loaded for visual comparison only. Start still uses the NECST-side computed run path.');
+});
+qs('serverObsRoot').addEventListener('change', async () => {
+  qs('serverObsDir').value = qs('serverObsRoot').value;
+  await browseServerObs(qs('serverObsRoot').value);
+});
+qs('serverObsHome').addEventListener('click', async () => {
+  const root = qs('serverObsRoot').value;
+  qs('serverObsDir').value = root;
+  await browseServerObs(root);
+});
+qs('serverObsUp').addEventListener('click', async () => {
+  const current = qs('serverObsDir').value.trim();
+  const parent = dirnameOf(current);
+  await browseServerObs(parent || qs('serverObsRoot').value);
+});
+qs('goServerObsDir').addEventListener('click', async () => { await browseServerObs(qs('serverObsDir').value || qs('serverObsRoot').value); });
+qs('serverObsDir').addEventListener('keydown', async (ev) => {
+  if (ev.key === 'Enter') {
+    ev.preventDefault();
+    await browseServerObs(qs('serverObsDir').value || qs('serverObsRoot').value);
+  }
+});
+qs('refreshServerObs').addEventListener('click', async () => { await browseServerObs(qs('serverObsDir').value || qs('serverObsRoot').value); });
+qs('serverObsFiles').addEventListener('click', async (ev) => {
+  const row = ev.target.closest('.file-row');
+  if (!row) return;
+  document.querySelectorAll('.file-row.selected').forEach(el => el.classList.remove('selected'));
+  row.classList.add('selected');
+  const path = row.dataset.path || '';
+  const type = row.dataset.type || '';
+  if (type === 'directory') {
+    qs('serverObsDir').value = path;
+    await browseServerObs(path);
+  } else {
+    await previewServerObsFile(path);
+  }
+});
+qs('serverObsFiles').addEventListener('keydown', async (ev) => {
+  const row = ev.target.closest('.file-row');
+  if (!row || (ev.key !== 'Enter' && ev.key !== ' ')) return;
+  ev.preventDefault();
+  row.click();
 });
 qs('recentDir').addEventListener('change', () => { state.obsChecked = false; validateObs(); });
 qs('checkObs').addEventListener('click', async () => {
@@ -1202,7 +1525,7 @@ function getStatusRefreshMs() {
   return Math.max(200, Math.round(raw));
 }
 const statusRefreshMs = getStatusRefreshMs();
-validateObs(); updatePreviewInfo(); validateMount(); updateTargetFields(); refresh(); setInterval(refresh, statusRefreshMs);
+loadServerObsRoots(); validateObs(); updatePreviewInfo(); validateMount(); updateTargetFields(); refresh(); setInterval(refresh, statusRefreshMs);
 </script>
 </body>
 </html>

--- a/bin/console-demo.py
+++ b/bin/console-demo.py
@@ -24,6 +24,7 @@ import urllib.parse
 from dataclasses import dataclass, field
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 
@@ -288,6 +289,12 @@ button.selected:not(:disabled) { border-color: rgba(86,211,100,0.70); box-shadow
   color: var(--text);
 }
 .obs-output-dir .output-meta { color: var(--muted); font-size: 12px; margin-top: 6px; }
+.obs-output-dir .output-meta b { color: var(--text); }
+.obs-output-dir .output-meta code { display:inline; padding:0; border:0; background:transparent; color:var(--text); white-space:normal; }
+.progress-status-line { margin-top: 6px; color: var(--muted); font-size: 12px; }
+.progress-status-line.ok { color: var(--ok); }
+.progress-status-line.warn { color: var(--warn); }
+.progress-status-line.bad { color: var(--bad); }
 .log-browser-text { max-height:220px; overflow:auto; white-space:pre-wrap; word-break:break-word; background:#080d1b; border:1px solid var(--line); border-radius:10px; padding:8px; font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace; font-size:11px; color:var(--muted); }
 .log-choice { display:block; width:100%; text-align:left; margin-top:4px; padding:5px 7px; font-size:12px; }
 .warning-list { color:var(--warn); }
@@ -512,8 +519,8 @@ summary { cursor: pointer; color: var(--muted); }
         <div id="obsOutputDirBox" class="obs-output-dir" aria-live="polite">
           <div class="output-title">Latest observation data directory</div>
           <div class="output-path-row">
-            <code id="obsOutputDirPath">not available yet</code>
-            <button id="copyObsOutputDir" class="secondary compact" type="button" title="Copy the observation data directory path for analysis notebooks.">Copy</button>
+            <code id="obsOutputDirName">not available yet</code>
+            <button id="copyObsOutputDir" class="secondary compact" type="button" title="Copy the record directory name for analysis notebooks.">Copy</button>
           </div>
           <div class="output-meta" id="obsOutputDirMeta">Shown when the console knows the latest record name.</div>
         </div>
@@ -758,8 +765,8 @@ summary { cursor: pointer; color: var(--muted); }
               <div class="card-head"><h2>RSky</h2><span class="hint">runtime parameters</span></div>
               <div class="card-body">
                 <div class="row">
-                  <div class="field"><label for="rskyN">n</label><input id="rskyN" value="1" inputmode="numeric"></div>
-                  <div class="field"><label for="rskyInteg">integ [s]</label><input id="rskyInteg" value="2" inputmode="decimal"></div>
+                  <div class="field"><label for="rskyN">n</label><input id="rskyN" type="number" min="1" step="1" value="1" inputmode="numeric"></div>
+                  <div class="field"><label for="rskyInteg">integ [s]</label><input id="rskyInteg" type="number" min="0.1" step="0.5" value="5" inputmode="decimal"></div>
                 </div>
                 <details><summary>Advanced</summary><div class="field" style="margin-top:10px"><label for="rskyCh">channel</label><input id="rskyCh" placeholder="empty = default"></div></details>
                 <button id="runRsky" class="primary">Run RSky</button>
@@ -768,7 +775,7 @@ summary { cursor: pointer; color: var(--muted); }
             <div class="card operation-subcard" id="skydipCard" style="box-shadow:none">
               <div class="card-head"><h2>SkyDip</h2><span class="hint">runtime parameters</span></div>
               <div class="card-body">
-                <div class="field"><label for="skydipInteg">integ [s]</label><input id="skydipInteg" value="2" inputmode="decimal"></div>
+                <div class="field"><label for="skydipInteg">integ [s]</label><input id="skydipInteg" type="number" min="0.1" step="0.5" value="10" inputmode="decimal"></div>
                 <details><summary>Advanced</summary>
                   <div class="field" style="margin-top:10px"><label for="skydipCh">channel</label><input id="skydipCh" placeholder="empty = default"></div>
                   <div class="field"><label for="skydipTpRange">tp_range</label><input id="skydipTpRange" placeholder="e.g. 5000 6000 17000 18000"></div>
@@ -834,7 +841,8 @@ summary { cursor: pointer; color: var(--muted); }
           <h3>Current observation data</h3>
           <div class="runtime-list">
             <div>Record: <b id="runtimeRecordName">loading</b></div>
-            <div class="path-text" title="Expected NECST recorder output directory">Data directory: <b id="runtimeRecordingDir">loading</b></div>
+            <div class="path-text" title="Local PC path if the Docker/container data root is mapped; otherwise the container path is shown.">Local/data path: <b id="runtimeLocalRecordingDir">loading</b></div>
+            <div class="path-text" title="Expected NECST recorder output directory inside the console/container environment">Container data directory: <b id="runtimeRecordingDir">loading</b></div>
             <div class="path-text" title="Progress sidecar directory">Progress directory: <b id="runtimeProgressRecordDir">loading</b></div>
           </div>
         </div>
@@ -898,9 +906,41 @@ const state = {
   currentOperation: {phase: 'ready', kind: 'idle', label: 'READY'},
   lastActionResponse: null,
   demoObsBrowser: false,
-  selectedObsPath: ""
+  selectedObsPath: "",
+  progressLaunch: {active: false, openedUrl: "", message: ""}
 };
 localStorage.setItem('necstConsoleDemoSession', state.sessionId);
+
+const FORM_STORAGE_PREFIX = 'necstConsole.form.';
+const PERSISTED_FORM_FIELDS = [
+  'obsMode', 'recentDir', 'obsFilename', 'obsChannel',
+  'mountAz', 'mountEl',
+  'targetKind', 'targetName', 'coord1', 'coord2', 'offsetFrame', 'offsetX', 'offsetY', 'cosCorrection',
+  'rskyN', 'rskyInteg', 'rskyCh',
+  'skydipInteg', 'skydipCh', 'skydipTpRange'
+];
+function storageKeyForField(id) { return FORM_STORAGE_PREFIX + id; }
+function saveFormField(id) {
+  const el = qs(id);
+  if (!el) return;
+  try { localStorage.setItem(storageKeyForField(id), el.value); } catch (_) {}
+}
+function restoreFormField(id) {
+  const el = qs(id);
+  if (!el) return;
+  try {
+    const saved = localStorage.getItem(storageKeyForField(id));
+    if (saved !== null && saved !== undefined) el.value = saved;
+  } catch (_) {}
+}
+function setupFormPersistence() {
+  PERSISTED_FORM_FIELDS.forEach(id => {
+    restoreFormField(id);
+    const el = qs(id);
+    if (!el) return;
+    ['input', 'change'].forEach(ev => el.addEventListener(ev, () => saveFormField(id)));
+  });
+}
 
 function numberOrNaN(value) {
   if (String(value).trim() === '') return NaN;
@@ -1250,43 +1290,59 @@ function updateChopperButtons(chopper) {
   if (inButton) inButton.title = isIn ? 'Current chopper state is IN.' : 'Move chopper to IN.';
   if (outButton) outButton.title = isOut ? 'Current chopper state is OUT.' : 'Move chopper to OUT.';
 }
+
+function basenameFromPath(path) {
+  const s = String(path || '').trim().replace(/\/+$/, '');
+  if (!s) return '';
+  const idx = s.lastIndexOf('/');
+  return idx >= 0 ? s.slice(idx + 1) : s;
+}
 function observationOutputInfo(data) {
   const obs = (data && data.observation) || {};
-  const dir = String(obs.recording_dir || '').trim();
   const record = String(obs.record_name || '').trim();
+  const containerDir = String(obs.recording_dir || '').trim();
+  const localDir = String(obs.local_recording_dir || obs.local_data_dir || '').trim();
   const progressDir = String(obs.progress_record_dir || '').trim();
-  return {dir, record, progressDir};
+  const mode = String(obs.record_path_display_mode || 'local').trim().toLowerCase();
+  const preferContainer = mode === 'container' || mode === 'docker' || mode === 'internal';
+  const directoryName = record || basenameFromPath(localDir) || basenameFromPath(containerDir);
+  const displayPath = preferContainer ? (containerDir || localDir) : (localDir || containerDir);
+  const displayKind = preferContainer ? 'container' : 'local';
+  return {directoryName, record, containerDir, localDir, progressDir, displayPath, displayKind};
 }
 function updateObservationOutputBox(data) {
   const box = qs('obsOutputDirBox');
-  const pathEl = qs('obsOutputDirPath');
+  const nameEl = qs('obsOutputDirName');
   const metaEl = qs('obsOutputDirMeta');
   const copyBtn = qs('copyObsOutputDir');
-  if (!box || !pathEl || !metaEl) return;
+  if (!box || !nameEl || !metaEl) return;
   const info = observationOutputInfo(data || {});
-  const hasDir = Boolean(info.dir);
-  box.classList.toggle('visible', hasDir);
-  pathEl.textContent = hasDir ? info.dir : 'not available yet';
-  pathEl.title = hasDir ? info.dir : 'Observation data directory is not available yet.';
-  const pieces = [];
-  if (info.record) pieces.push(`record: ${info.record}`);
-  if (info.progressDir) pieces.push(`progress: ${info.progressDir}`);
-  metaEl.textContent = hasDir ? (pieces.join(' / ') || 'Copy this path into the analysis notebook.') : 'Shown when the console knows the latest record name.';
+  const hasName = Boolean(info.directoryName);
+  box.classList.toggle('visible', hasName);
+  nameEl.textContent = hasName ? info.directoryName : 'not available yet';
+  nameEl.title = hasName ? 'Directory name copied by the Copy button.' : 'Observation data directory is not available yet.';
+  if (hasName) {
+    const label = info.displayKind === 'container' ? 'record (container)' : 'record';
+    metaEl.innerHTML = info.displayPath ? `${escapeHtml(label)}: <code>${escapeHtml(info.displayPath)}</code>` : 'record: path not available yet';
+  } else {
+    metaEl.textContent = 'Shown when the console knows the latest record name.';
+  }
   if (copyBtn) {
-    copyBtn.disabled = !hasDir;
-    copyBtn.title = hasDir ? 'Copy the observation data directory path for analysis notebooks.' : 'No observation data directory is available yet.';
+    copyBtn.disabled = !hasName;
+    copyBtn.title = hasName ? 'Copy the directory name for analysis notebooks.' : 'No observation data directory is available yet.';
   }
 }
 async function copyObservationOutputDir() {
   const info = observationOutputInfo(state.lastStatus || {});
-  if (!info.dir) {
-    log(false, 'No observation data directory is available to copy.');
+  const value = info.directoryName;
+  if (!value) {
+    log(false, 'No observation data directory name is available to copy.');
     return;
   }
   try {
     if (navigator.clipboard && navigator.clipboard.writeText) {
-      await navigator.clipboard.writeText(info.dir);
-      log(true, `Copied observation data directory: ${info.dir}`);
+      await navigator.clipboard.writeText(value);
+      log(true, `Copied observation directory name: ${value}`);
       const btn = qs('copyObsOutputDir');
       if (btn) {
         const old = btn.textContent;
@@ -1295,10 +1351,103 @@ async function copyObservationOutputDir() {
       }
       return;
     }
-  } catch (err) {
-    // Fall through to the manual copy prompt below.
+  } catch (err) {}
+  window.prompt('Copy observation data directory name', value);
+}
+function progressMonitorSnapshot(data) {
+  const progress = (data && data.progress) || {};
+  const monitor = progress.monitor || progress;
+  const status = String(monitor.status || progress.monitor_status || '').trim().toLowerCase();
+  const url = String(monitor.progress_url || monitor.url || progress.url || data.progress_url || '').trim();
+  const running = Boolean(monitor.running || progress.running);
+  const readyStatus = !status || ['managed', 'external', 'running', 'ready', 'ok'].includes(status);
+  const starting = ['managed_starting', 'starting', 'pending'].includes(status);
+  const failed = ['exited', 'failed', 'error'].includes(status) || (monitor.returncode !== null && monitor.returncode !== undefined && monitor.returncode !== 0);
+  return {running, ready: running && readyStatus, starting, failed, status, url, message: monitor.message || progress.message || ''};
+}
+function updateProgressLaunchButton(data) {
+  const btn = qs('openProgress');
+  if (!btn) return;
+  const snap = progressMonitorSnapshot(data || state.lastStatus || {});
+  if (state.progressLaunch.active) {
+    btn.textContent = 'Starting progress...';
+    btn.disabled = true;
+    btn.classList.add('selected');
+    btn.title = 'Waiting for the progress monitor server to become reachable.';
+    return;
   }
-  window.prompt('Copy observation data directory', info.dir);
+  btn.disabled = false;
+  btn.classList.remove('selected');
+  if (snap.ready) {
+    btn.textContent = 'Open progress monitor';
+    btn.title = `Progress monitor is reachable: ${snap.url || 'URL unknown'}`;
+  } else if (snap.starting) {
+    btn.textContent = 'Progress starting...';
+    btn.title = snap.message || 'Progress monitor process is starting; click to retry opening when ready.';
+  } else if (snap.failed) {
+    btn.textContent = 'Retry progress monitor';
+    btn.title = snap.message || 'Progress monitor failed or exited; click to retry launch.';
+  } else {
+    btn.textContent = 'Launch progress monitor';
+    btn.title = 'Start or open the progress-monitor server managed by this console. If this console exits, only a console-owned progress server stops.';
+  }
+}
+function setProgressLaunchMessage(kind, text) {
+  const el = qs('runtimeProgressMonitor');
+  if (el) el.textContent = text;
+  const btn = qs('openProgress');
+  if (btn) btn.title = text;
+  if (kind === 'bad') log(false, text);
+  else if (kind === 'ok') log(true, text);
+}
+async function waitForProgressReady(initialUrl) {
+  const timeoutMs = 12000;
+  const started = Date.now();
+  let lastUrl = initialUrl || '';
+  let lastMessage = 'Waiting for progress server...';
+  state.progressLaunch.active = true;
+  updateProgressLaunchButton(state.lastStatus || {});
+  try {
+    while (Date.now() - started < timeoutMs) {
+      await new Promise(resolve => setTimeout(resolve, 350));
+      try { await refresh(); } catch (_) {}
+      const snap = progressMonitorSnapshot(state.lastStatus || {});
+      if (snap.url) lastUrl = snap.url;
+      if (snap.message) lastMessage = snap.message;
+      if (snap.ready && lastUrl) {
+        state.progressLaunch.active = false;
+        updateProgressLaunchButton(state.lastStatus || {});
+        setProgressLaunchMessage('ok', 'Progress monitor is ready. Opening it now.');
+        window.open(lastUrl, '_blank');
+        return true;
+      }
+      if (snap.failed && !snap.starting) break;
+    }
+  } finally {
+    state.progressLaunch.active = false;
+    updateProgressLaunchButton(state.lastStatus || {});
+  }
+  setProgressLaunchMessage('bad', `Progress monitor is not reachable yet. ${lastMessage}. Try Open/Retry or inspect progress logs.`);
+  if (lastUrl) window.open(lastUrl, '_blank');
+  return false;
+}
+async function launchOrOpenProgress() {
+  const existing = progressMonitorSnapshot(state.lastStatus || {});
+  if (existing.ready && existing.url) {
+    window.open(existing.url, '_blank');
+    return;
+  }
+  state.progressLaunch.active = true;
+  updateProgressLaunchButton(state.lastStatus || {});
+  const data = await api('launch_progress');
+  const url = data.progress_url || data.url || (data.state && data.state.progress_url) || existing.url;
+  if (!data.ok) {
+    state.progressLaunch.active = false;
+    updateProgressLaunchButton(state.lastStatus || {});
+    setProgressLaunchMessage('bad', data.reason || data.message || 'Failed to launch progress monitor.');
+    return;
+  }
+  await waitForProgressReady(url);
 }
 function operationLocksActive(op) {
   return Boolean(op && ['starting', 'running', 'attention'].includes(op.phase));
@@ -1494,10 +1643,12 @@ function renderRuntime(data) {
   if (processEl) processEl.innerHTML = renderProcessRows(processes);
   const obs = data.observation || {};
   setText('runtimeRecordName', obs.record_name || '(none)');
+  setText('runtimeLocalRecordingDir', obs.local_recording_dir || obs.local_data_dir || obs.recording_dir || '(not available yet)');
   setText('runtimeRecordingDir', obs.recording_dir || '(not available yet)');
   setText('runtimeProgressRecordDir', obs.progress_record_dir || '(not available yet)');
   renderLauncherLogChoices(processes);
   setText('runtimeProgressMonitor', progressMonitorText(progress));
+  updateProgressLaunchButton(data);
   setText('runtimeOperatorLog', data.operator_log_path || '(not configured)');
   setText('runtimeLauncherLogDir', data.launcher_log_dir || '(not configured)');
   const shutdown = data.shutdown || {};
@@ -1886,6 +2037,8 @@ function setObsPathFromServerPath(path) {
   if (!p) return;
   qs('recentDir').value = dirnameOf(p);
   qs('obsFilename').value = basenameOf(p);
+  saveFormField('recentDir');
+  saveFormField('obsFilename');
   if (qs('serverObsDir')) qs('serverObsDir').value = dirnameOf(p);
   state.obsChecked = false;
   validateObs();
@@ -2189,11 +2342,7 @@ qs('runtimeProcesses').addEventListener('click', async (ev) => {
   const pid = btn.dataset.pid;
   if (confirm(`Terminate local launcher pid=${pid}? Telescope STOP is separate.`)) await api('terminate_process', {pid});
 });
-qs('openProgress').addEventListener('click', async () => {
-  const data = await api('launch_progress');
-  const url = data.progress_url || (data.state && data.state.progress_url);
-  if (data.ok && url) window.open(url, '_blank');
-});
+qs('openProgress').addEventListener('click', launchOrOpenProgress);
 function getStatusRefreshMs() {
   const cfg = window.NECST_CONSOLE_CONFIG || {};
   const raw = Number(cfg.statusRefreshMs ?? cfg.status_refresh_ms ?? 1000);
@@ -2201,7 +2350,7 @@ function getStatusRefreshMs() {
   return Math.max(200, Math.round(raw));
 }
 const statusRefreshMs = getStatusRefreshMs();
-loadServerObsRoots(); validateObs(); updatePreviewInfo(); validateMount(); updateTargetFields(); refresh(); setInterval(refresh, statusRefreshMs);
+setupFormPersistence(); loadServerObsRoots(); validateObs(); updatePreviewInfo(); validateMount(); updateTargetFields(); refresh(); setInterval(refresh, statusRefreshMs);
 </script>
 </body>
 </html>
@@ -2283,6 +2432,10 @@ class DemoState:
     exclusive_start_action: Optional[str] = None
     exclusive_start_started_at: Optional[float] = None
     exclusive_start_message: str = ""
+    record_name: Optional[str] = None
+    recording_dir: Optional[str] = None
+    local_recording_dir: Optional[str] = None
+    progress_record_dir: Optional[str] = None
     log: List[LogEntry] = field(default_factory=list)
 
     def prune_exclusive_start_guard(self) -> None:
@@ -2308,6 +2461,12 @@ class DemoState:
                 "owned_by_console": self.progress_owned_by_console,
             },
             "state": self.state,
+            "observation": {
+                "record_name": self.record_name,
+                "recording_dir": self.recording_dir,
+                "local_recording_dir": self.local_recording_dir,
+                "progress_record_dir": self.progress_record_dir,
+            },
             "manual_state": self.manual_state,
             "active_task": self.active_task,
             "az": self.az,
@@ -2768,6 +2927,14 @@ def _demo_clear_exclusive_start_guard(state: DemoState) -> None:
     state.exclusive_start_message = ""
 
 
+
+def _demo_set_record(state: DemoState, record_name: str) -> None:
+    record = str(record_name or '').strip() or 'demo_record'
+    state.record_name = record
+    state.recording_dir = f"/root/data/{record}"
+    state.local_recording_dir = f"/local/necst/data/{record}"
+    state.progress_record_dir = f"/tmp/necst_progress/{record}"
+
 def _demo_mark_exclusive_start_guard(state: DemoState, action: str, message: str) -> None:
     if action not in EXCLUSIVE_START_ACTIONS:
         return
@@ -2935,6 +3102,8 @@ def handle_action(
         state.active_task = "observation"
         mode = str(params.get("mode") or "")
         path = str(params.get("file") or "").strip()
+        stem = Path(path).name.rsplit('.', 1)[0] if path else 'demo_observation'
+        _demo_set_record(state, f"{stem}_{int(time.time())}")
         server.add_log(True, f"{authority_msg}: mode={mode}, file={path}")
         return True, "observation started"
 
@@ -3007,7 +3176,7 @@ def handle_action(
         if err:
             server.add_log(False, f"RSky not started: {err}")
             return False, err
-        ok, reason, integ = _validate_positive_float(params.get("integ", 2), "RSky integ")
+        ok, reason, integ = _validate_positive_float(params.get("integ", 5), "RSky integ")
         if not ok:
             server.add_log(False, f"RSky not started: {reason}")
             return False, reason
@@ -3025,11 +3194,12 @@ def handle_action(
         state.state = "calibrating"
         state.manual_state = "calibration"
         state.active_task = "RSky"
+        _demo_set_record(state, f"necst_rsky_{time.strftime('%Y%m%d_%H%M%S')}")
         server.add_log(True, f"{authority_msg}: n={n or 1}, integ={integ:g} s")
         return True, "RSky started"
 
     if action == "run_skydip":
-        ok, reason, integ = _validate_positive_float(params.get("integ", 2), "SkyDip integ")
+        ok, reason, integ = _validate_positive_float(params.get("integ", 10), "SkyDip integ")
         if not ok:
             server.add_log(False, f"SkyDip not started: {reason}")
             return False, reason
@@ -3059,6 +3229,7 @@ def handle_action(
         state.state = "calibrating"
         state.manual_state = "calibration"
         state.active_task = "SkyDip"
+        _demo_set_record(state, f"necst_skydip_{time.strftime('%Y%m%d_%H%M%S')}")
         server.add_log(True, f"{authority_msg}: integ={integ:g} s")
         return True, "SkyDip started"
 

--- a/bin/console-demo.py
+++ b/bin/console-demo.py
@@ -514,6 +514,8 @@ summary { cursor: pointer; color: var(--muted); }
           <div class="run-actions">
             <button id="startObs" class="primary large" disabled title="Start the selected observation sequence. Check and Dry run are optional; Start always performs server-side validation before launching.">Start observation</button>
             <button id="abortObs" class="danger large" title="Abort a running observation sequence and request recorder/gate/progress cleanup. Safety action: kept clickable even if status has not yet detected observing.">ABORT observation</button>
+            <button id="terminateObsLauncherQuick" class="secondary compact" type="button" disabled title="Terminate the local observation launcher subprocess only. This does not send telescope STOP and should be used only after confirming the hardware is safe.">Terminate launcher</button>
+            <button id="clearStaleObs" class="secondary compact" type="button" disabled title="Recover the console from stale progress state after confirming the telescope/recorder are safe. This archives only current progress pointer files; it does not send hardware commands or delete data.">Clear stale state</button>
           </div>
         </div>
         <div id="obsOutputDirBox" class="obs-output-dir" aria-live="polite">
@@ -1130,13 +1132,44 @@ function safetyReleaseLooksIdle(data, ageSec) {
 }
 function actualOperationFromStatus(data) {
   data = data || {};
+  const stale = data.stale_observation || {};
+  if (stale.launcher_stuck || stale.running_stale) {
+    const age = Number(stale.age_sec);
+    const ageText = Number.isFinite(age) ? `${age.toFixed(1)} s` : 'unknown age';
+    const record = stale.record_name || 'unknown record';
+    if (stale.launcher_stuck) {
+      const safetyAge = Number(stale.safety_release_age_sec);
+      const safetyText = Number.isFinite(safetyAge) ? `${safetyAge.toFixed(1)} s since STOP/ABORT` : 'launcher still active';
+      return {
+        phase: 'attention',
+        kind: 'observation',
+        label: 'ATTENTION: OBSERVATION LAUNCHER STUCK',
+        detail: `Observation launcher still appears active for ${record} while the system is error/abort-stalled (${safetyText}). Confirm hardware is safe, then terminate the local launcher. Clear stale state may be needed after that.`
+      };
+    }
+    return {
+      phase: 'attention',
+      kind: 'observation',
+      label: 'ATTENTION: STALE OBSERVATION STATE',
+      detail: `Progress still says observation is running for ${record}, but no active launcher/fresh progress update is confirmed (${ageText}). Confirm the hardware is safe, then use Clear stale state.`
+    };
+  }
   const sys = lowerText(data.state || 'idle');
   const manual = lowerText(data.manual_state || 'idle');
   const task = lowerText(data.active_task || 'none');
   const progress = data.progress || {};
-  const finalOrIdle = ['idle', 'finished', 'aborted', 'error', 'failed'].includes(sys);
-  const obsActive = sys === 'observing' || (!finalOrIdle && task.includes('observation')) || (!finalOrIdle && Boolean(progress.observation_running)) || processCategoryActive(data, 'observation');
-  const calActive = sys === 'calibrating' || (!finalOrIdle && manual === 'calibration') || (!finalOrIdle && (task.includes('rsky') || task.includes('skydip'))) || processCategoryActive(data, 'calibration');
+  const errorLike = ['error', 'failed', 'stale_observation'].includes(sys);
+  const finalOrIdle = ['idle', 'finished', 'aborted', 'error', 'failed', 'stale_observation'].includes(sys);
+  if (errorLike && (processCategoryActive(data, 'observation') || Boolean(progress.observation_running))) {
+    return {
+      phase: 'attention',
+      kind: 'observation',
+      label: 'ATTENTION: OBSERVATION STATE ERROR',
+      detail: 'Observation-related state remains while the system lifecycle is error/failed. Use ABORT first; if it does not clear, terminate the local launcher and clear stale state after confirming hardware safety.'
+    };
+  }
+  const obsActive = sys === 'observing' || (!finalOrIdle && task.includes('observation')) || (!finalOrIdle && Boolean(progress.observation_running)) || (!finalOrIdle && processCategoryActive(data, 'observation'));
+  const calActive = sys === 'calibrating' || (!finalOrIdle && manual === 'calibration') || (!finalOrIdle && (task.includes('rsky') || task.includes('skydip'))) || (!finalOrIdle && processCategoryActive(data, 'calibration'));
   const explicitTrackingActive = task.includes('target tracking');
   const atTargetIdle = Boolean((data.mount_target_reached || data.mount_hold_at_target) && data.motion_live_active === false);
   const mountActive = !atTargetIdle && (manual === 'moving' || (manual === 'tracking' && !explicitTrackingActive) || task.includes('mount move') || task.includes('manual mount'));
@@ -1980,6 +2013,26 @@ function renderStatus(data) {
   // ABORT is a safety action.  It must stay clickable even when the
   // observation state cannot be inferred from status/progress yet.
   qs('abortObs').disabled = false;
+  const staleObs = data.stale_observation || {};
+  const terminateQuick = qs('terminateObsLauncherQuick');
+  if (terminateQuick) {
+    const canTerminate = Boolean(staleObs.can_terminate_launcher || staleObs.launcher_stuck || operation.label === 'ATTENTION: OBSERVATION LAUNCHER STUCK');
+    terminateQuick.disabled = !canTerminate;
+    terminateQuick.style.display = canTerminate ? '' : 'none';
+    if (canTerminate) {
+      terminateQuick.title = 'Terminate the local observation launcher subprocess only. Confirm hardware is safe first; this does not send telescope STOP.';
+    }
+  }
+  const staleButton = qs('clearStaleObs');
+  if (staleButton) {
+    const canClearStale = Boolean(staleObs.can_clear || staleObs.running_stale || operation.label === 'ATTENTION: STALE OBSERVATION STATE');
+    staleButton.disabled = !canClearStale;
+    staleButton.style.display = canClearStale ? '' : 'none';
+    if (canClearStale) {
+      const record = staleObs.record_name || 'unknown record';
+      staleButton.title = `Clear stale console/progress state for ${record}. Confirm hardware is safe first. This does not send hardware commands or delete data.`;
+    }
+  }
   qs('manualBadge').textContent = ['mount', 'tracking', 'rsky', 'skydip', 'calibration'].includes(operation.kind) ? operation.label : data.manual_state;
   qs('manualBadge').className = 'badge ' + (operation.phase === 'attention' ? 'bad' : (operation.phase === 'running' ? 'warn' : motionClass));
   qs('motionSummary').textContent = data.manual_state;
@@ -2278,6 +2331,20 @@ qs('startObs').addEventListener('click', async () => {
 qs('abortObs').addEventListener('click', async () => {
   if (confirm('Abort current observation and request recorder/gate/progress cleanup?')) await api('abort_observation', {}, 'abort');
 });
+qs('terminateObsLauncherQuick').addEventListener('click', async () => {
+  if (!confirm('Terminate the local observation launcher subprocess only?\n\nUse this only after confirming the telescope/recorder/XFFTS are safe. This does not send telescope STOP.')) return;
+  clearPendingOperation();
+  const resp = await api('terminate_observation_launcher');
+  if (!resp.ok) alert('Terminate observation launcher failed: ' + (resp.reason || 'unknown reason'));
+});
+qs('clearStaleObs').addEventListener('click', async () => {
+  const stale = (state.lastStatus || {}).stale_observation || {};
+  const record = stale.record_name || 'unknown record';
+  if (!confirm(`Clear stale observation/progress state for ${record}?\n\nOnly use this after confirming the telescope, recorder, and XFFTS are safe. This does not send hardware commands and does not delete observation data.`)) return;
+  clearPendingOperation();
+  const resp = await api('clear_stale_observation_state');
+  if (!resp.ok) alert('Clear stale state failed: ' + (resp.reason || 'unknown reason'));
+});
 qs('copyObsOutputDir').addEventListener('click', copyObservationOutputDir);
 qs('authorityButton').addEventListener('click', async () => {
   const resp = await fetch('/api/status');
@@ -2459,6 +2526,11 @@ class DemoState:
                 "url": self.progress_url,
                 "running": self.progress_running,
                 "owned_by_console": self.progress_owned_by_console,
+            },
+            "stale_observation": {
+                "running_stale": False,
+                "can_clear": False,
+                "record_name": self.record_name,
             },
             "state": self.state,
             "observation": {
@@ -2992,6 +3064,16 @@ def handle_action(
         state.log.clear()
         server.add_log(True, "operation log cleared")
         return True, "cleared"
+
+    if action == "clear_stale_observation_state":
+        _demo_clear_exclusive_start_guard(state)
+        state.state = "idle"
+        state.manual_state = "idle"
+        state.active_task = "none"
+        state.command_az = None
+        state.command_el = None
+        server.add_log(True, "stale observation state cleared in demo")
+        return True, "stale observation state cleared"
 
     if action == "acquire_authority":
         if state.authority_held and state.authority_session_id != session_id:

--- a/bin/console-demo.py
+++ b/bin/console-demo.py
@@ -12,8 +12,10 @@ commands.
 from __future__ import annotations
 
 import argparse
+import csv
 import json
 import math
+import os
 import signal
 import sys
 import threading
@@ -21,10 +23,11 @@ import time
 import uuid
 import webbrowser
 import urllib.parse
+from datetime import datetime, timezone
 from dataclasses import dataclass, field
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Any, Dict, List, Optional, Tuple
 
 
@@ -170,6 +173,11 @@ button.pending:not(:disabled) { border-color: rgba(122,162,255,0.75); background
 .main-grid {
   display: grid;
   grid-template-columns: minmax(520px, 1.05fr) minmax(430px, 0.95fr);
+  gap: 14px;
+  align-items: start;
+}
+.side-stack {
+  display: grid;
   gap: 14px;
   align-items: start;
 }
@@ -481,6 +489,138 @@ summary { cursor: pointer; color: var(--muted); }
 .callout b { color: var(--text); }
 .invalid { border-color: var(--bad) !important; }
 .valid { border-color: rgba(86,211,100,0.8) !important; }
+
+.obslog-card {
+  margin: 12px 0 0;
+  border-radius: 14px;
+  background: rgba(9, 15, 30, 0.58);
+  box-shadow: none;
+}
+.obslog-card .card-head { padding: 8px 10px 6px; }
+.obslog-card .card-body { padding: 8px 10px 10px; }
+.obslog-card h2 { font-size: 15px; }
+.obslog-card .compact-hint { font-size: 11px; color: var(--muted); }
+.obslog-head { align-items: center; }
+.obslog-card .mini-label {
+  color: var(--muted);
+  font-size: 11px;
+  white-space: nowrap;
+}
+.obslog-card .obslog-current-row {
+  display: grid;
+  grid-template-columns: auto minmax(280px, 1fr) auto auto;
+  gap: 7px;
+  align-items: center;
+  min-width: 0;
+  margin-bottom: 3px;
+}
+.obslog-card .obslog-current-row code {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding: 5px 7px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(0,0,0,0.18);
+  font-size: 12px;
+}
+.obslog-card .obslog-file-meta-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 7px;
+  align-items: center;
+  margin: 0 0 7px;
+  padding-left: 0;
+}
+.obslog-card .obslog-created {
+  color: var(--muted);
+  font-size: 11px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.obslog-card .obslog-settings-row,
+.obslog-card .obslog-custom-row,
+.obslog-card .obslog-comment-row {
+  display: grid;
+  gap: 7px;
+  align-items: end;
+  margin-bottom: 7px;
+}
+.obslog-card .obslog-settings-row {
+  grid-template-columns: 130px 180px minmax(190px, auto);
+  justify-content: start;
+}
+.obslog-card .obslog-custom-row {
+  grid-template-columns: auto minmax(220px, 1fr) auto;
+  align-items: center;
+}
+.obslog-card .obslog-comment-row {
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+}
+.obslog-card .mini-field {
+  display: grid;
+  gap: 3px;
+  color: var(--muted);
+  font-size: 11px;
+}
+.obslog-card label { color: var(--muted); font-size: 11px; }
+.obslog-card input { padding: 6px 8px; font-size: 12px; }
+.obslog-card .obslog-last {
+  margin-top: 5px;
+  color: var(--muted);
+  font-size: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.obslog-card .obslog-recent-details {
+  margin: 6px 0 0;
+  color: var(--muted);
+  font-size: 12px;
+}
+.obslog-card .obslog-recent {
+  max-height: 180px;
+  overflow: auto;
+  margin-top: 7px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  max-width: 100%;
+}
+.obslog-card table { width: max-content; min-width: 100%; border-collapse: collapse; font-size: 12px; }
+.obslog-card th, .obslog-card td { padding: 5px 7px; border-bottom: 1px solid rgba(40,50,74,0.6); text-align: left; vertical-align: top; white-space: nowrap; }
+.obslog-card th { color: var(--muted); font-weight: 600; background: rgba(255,255,255,0.025); position: sticky; top: 0; }
+.obslog-card td:nth-child(4), .obslog-card td:nth-child(7) { max-width: 260px; overflow: hidden; text-overflow: ellipsis; }
+.obslog-card .obslog-warning { color: var(--warn); font-size: 11px; margin-top: 5px; }
+.obslog-card .obslog-help-button {
+  width: 32px;
+  min-width: 32px;
+  height: 32px;
+  border-radius: 999px;
+  padding: 0;
+  justify-content: center;
+}
+.obslog-card .obslog-help-text {
+  margin: 3px 0 7px;
+  padding: 7px 9px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: rgba(122,162,255,0.07);
+  color: var(--muted);
+  font-size: 11px;
+  white-space: pre-line;
+}
+@media (max-width: 1050px) {
+  .obslog-card .obslog-current-row,
+  .obslog-card .obslog-file-meta-row,
+  .obslog-card .obslog-settings-row,
+  .obslog-card .obslog-custom-row,
+  .obslog-card .obslog-comment-row { grid-template-columns: 1fr; }
+}
+
 @media (max-width: 1050px) {
   .header-inner { grid-template-columns: 1fr; }
   .main-grid { grid-template-columns: 1fr; }
@@ -652,11 +792,12 @@ summary { cursor: pointer; color: var(--muted); }
       </div>
     </section>
 
-    <section class="card sticky" id="manualCard">
+    <div class="side-stack">
+    <section class="card" id="manualCard">
       <div class="card-head">
         <div>
           <h2>Manual telescope control</h2>
-          <div class="hint">Right-side control area aligned with the always-visible STOP button.</div>
+          <div class="hint">Manual mount, tracking, chopper, and calibration controls. STOP remains available in the top bar.</div>
         </div>
         <span class="badge" id="manualBadge">Ready</span>
       </div>
@@ -811,7 +952,56 @@ summary { cursor: pointer; color: var(--muted); }
         </div>
       </div>
     </section>
+    <section class="card obslog-card" id="observationLogCard">
+      <div class="card-head obslog-head">
+        <div>
+          <h2>Observation Log</h2>
+          <div class="compact-hint">Append-only CSV log for observers. Browser reload keeps the same file.</div>
+        </div>
+        <span class="badge info" id="obsLogBadge">loading</span>
+      </div>
+      <div class="card-body">
+        <div class="obslog-current-row">
+          <span class="mini-label">Current CSV</span>
+          <code id="obsLogFile" title="Current observation CSV log file. This display is read-only. Use 'New timestamped CSV' or 'Use / Append CSV' to change the write target.">loading</code>
+          <button id="copyObsLogPath" class="secondary compact" type="button" title="Copy the full container path of the active CSV log.">Copy path</button>
+          <button id="obsLogDirHelp" class="secondary compact obslog-help-button" type="button" aria-expanded="false" title="Log directory selection:\n1. NECST_OBSLOG_DIR, if set.\n2. <record root>/obslogs, if available.\n3. ~/.necst/observation_logs as fallback.\nThis path is inside the console container. Use a bind-mounted path if you need the log on the host.">?</button>
+        </div>
+        <div class="obslog-file-meta-row">
+          <span class="mini-label">Started</span>
+          <span id="obsLogCreated" class="obslog-created"></span>
+        </div>
+        <div id="obsLogHelpText" class="obslog-help-text" hidden></div>
+
+        <div class="obslog-settings-row">
+          <label class="mini-field" for="obsLogUser"><span>User</span><input id="obsLogUser" value="User" maxlength="128" title="Observer name written to subsequent CSV rows."></label>
+          <label class="mini-field" for="obsLogPrefix"><span>Prefix</span><input id="obsLogPrefix" value="obslog" maxlength="64" title="Filename prefix used by 'New timestamped CSV'."></label>
+          <button id="newObsLog" class="secondary compact" type="button" title="Create a new CSV using the prefix and current UTC time, e.g. obslog_20260609T134032Z.csv. This does not rename the old file.">New timestamped CSV</button>
+        </div>
+
+        <div class="obslog-custom-row">
+          <label for="obsLogOpenPath">Use specific CSV</label>
+          <input id="obsLogOpenPath" placeholder="night1 or night1.csv, or /container/path/night1.csv" title="Switch writing to this CSV. If it exists, append to it. If it does not exist, create it. Relative names are resolved inside the current log directory; .csv is added automatically when omitted.">
+          <button id="openObsLog" class="secondary compact" type="button" title="Switch writing to the specified CSV. Existing files are appended; missing files are created.">Use / Append CSV</button>
+        </div>
+
+        <div class="obslog-comment-row">
+          <input id="obsLogComment" placeholder="Add a manual observation comment" title="Append a comment row to the active observation CSV log.">
+          <button id="addObsLogComment" class="primary compact" type="button">Add comment</button>
+        </div>
+        <div id="obsLogLast" class="obslog-last">No observation-log row yet.</div>
+        <div id="obsLogWarning" class="obslog-warning"></div>
+        <details class="obslog-recent-details">
+          <summary>Recent CSV rows</summary>
+          <div id="obsLogRecent" class="obslog-recent">No rows.</div>
+        </details>
+      </div>
+    </section>
+    </div>
   </div>
+
+
+
 
   <section class="card" style="margin-top:14px">
     <div class="card-head">
@@ -873,21 +1063,10 @@ summary { cursor: pointer; color: var(--muted); }
           <p class="card-hint">Console-side warnings only; this does not decide observation OK/NG yet.</p>
           <div id="runtimeWarnings" class="runtime-list warning-list">loading</div>
         </div>
-        <div class="runtime-card logs history wide">
-          <h3>Observation/action history log</h3>
-          <p class="card-hint">Persistent operator_console.jsonl: observation starts, obs-file names, record/output directories when available, and accepted/rejected console actions.</p>
-          <div class="runtime-list">
-            <div class="runtime-path" title="operator log path">Path: <b id="runtimeOperatorLog">loading</b></div>
-            <div class="mini-actions">
-              <button id="loadOperatorLog" class="secondary" title="Show the persistent observation/action history log tail here">Show latest history</button>
-            </div>
-            <div id="runtimeOperatorLogText" class="log-browser-text">Click “Show latest history” to display recent observation and console actions.</div>
-          </div>
-        </div>
       </div>
 
       <details class="runtime-advanced">
-        <summary>Advanced recovery tools and launcher logs</summary>
+        <summary>Advanced recovery tools, launcher logs, and internal action log</summary>
         <div class="runtime-grid advanced" style="margin-top:10px">
           <div class="runtime-card recovery wide">
             <h3>Stuck local launchers (recovery only)</h3>
@@ -906,11 +1085,22 @@ summary { cursor: pointer; color: var(--muted); }
           </div>
           <div class="runtime-card logs wide">
             <h3>Launcher stdout/stderr files</h3>
-            <p class="card-hint">Debug logs for local launcher subprocesses. Latest logs are listed first; observation history is shown above.</p>
+            <p class="card-hint">Debug logs for local launcher subprocesses. Latest logs are listed first. Observer-facing history is in the Observation Log CSV above; internal action history is below.</p>
             <div class="runtime-list">
               <div id="runtimeLogBrowserSummary">Select a launcher log below. Latest first.</div>
               <div id="runtimeLauncherLogChoices"><span style="color:var(--faint)">No launcher log recorded.</span></div>
               <div id="runtimeLogBrowserText" class="log-browser-text">Select a launcher stdout/stderr log to display its tail.</div>
+            </div>
+          </div>
+          <div class="runtime-card logs history wide">
+            <h3>Internal operator/action log</h3>
+            <p class="card-hint">Persistent operator_console.jsonl for internal console actions, API results, recovery/debug traces, and CSV write warnings. Use the Observation Log CSV above for observer-facing notes.</p>
+            <div class="runtime-list">
+              <div class="runtime-path" title="internal operator/action JSONL path">Path: <b id="runtimeOperatorLog">loading</b></div>
+              <div class="mini-actions">
+                <button id="loadOperatorLog" class="secondary" title="Show the persistent internal operator/action JSONL tail here">Show latest internal log</button>
+              </div>
+              <div id="runtimeOperatorLogText" class="log-browser-text">Click “Show latest internal log” to display recent internal console actions and debug traces.</div>
             </div>
           </div>
           <div class="runtime-card">
@@ -964,7 +1154,8 @@ const PERSISTED_FORM_FIELDS = [
   'mountAz', 'mountEl',
   'targetKind', 'targetName', 'coord1', 'coord2', 'offsetFrame', 'offsetX', 'offsetY', 'cosCorrection',
   'rskyN', 'rskyInteg', 'rskyCh',
-  'skydipInteg', 'skydipCh', 'skydipTpRange'
+  'skydipInteg', 'skydipCh', 'skydipTpRange',
+  'obsLogUser', 'obsLogPrefix', 'obsLogOpenPath'
 ];
 function storageKeyForField(id) { return FORM_STORAGE_PREFIX + id; }
 function saveFormField(id) {
@@ -1695,7 +1886,7 @@ function renderOperatorLog(payload) {
   const body = qs('runtimeOperatorLogText');
   if (!body) return;
   if (!payload) {
-    body.textContent = 'Click “Show latest history” to display recent observation and console actions.';
+    body.textContent = 'Click “Show latest internal log” to display recent internal console actions and debug traces.';
     return;
   }
   if (Array.isArray(payload.entries)) {
@@ -1722,10 +1913,10 @@ function renderOperatorLog(payload) {
       if (pid) details.push(`pid=${pid}`);
       const detailText = details.length ? `\n    ${details.join('\n    ')}` : '';
       return `${when} ${mark}${action}: ${msg}${detailText}`;
-    }).join('\n\n') || '(observation/action history log is empty)';
+    }).join('\n\n') || '(internal operator/action log is empty)';
     return;
   }
-  body.textContent = payload.text || payload.reason || '(observation/action history log is empty)';
+  body.textContent = payload.text || payload.reason || '(internal operator/action log is empty)';
 }
 async function readOperatorLog() {
   const resp = await fetch('/api/operator-log?limit=80');
@@ -1861,7 +2052,7 @@ async function api(action, params={}, pendingKind=null) {
     const resp = await fetch('/api/action', {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({action, params, session_id: state.sessionId})
+      body: JSON.stringify({action, params, session_id: state.sessionId, obslog_user: (qs('obsLogUser') ? qs('obsLogUser').value : '')})
     });
     data = await resp.json();
   } catch (err) {
@@ -1894,6 +2085,7 @@ async function refresh() {
     const data = await resp.json();
     state.lastStatus = data;
     renderStatus(data);
+    renderObservationLog(data.observation_log || {});
     renderLog(data.log || []);
   } catch (err) {
     renderStatusRefreshError(err);
@@ -2189,6 +2381,79 @@ function renderStatus(data) {
   validateTarget();
   applyOperationUi(operation);
 }
+
+function basenameFromPath(path) {
+  const text = String(path || '');
+  if (!text) return '';
+  const normalized = text.replace(/\\/g, '/');
+  return normalized.split('/').filter(Boolean).pop() || text;
+}
+function compactUtc(value) {
+  const text = String(value || '');
+  const m = text.match(/^(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2})/);
+  return m ? `${m[1]} ${m[2]}Z` : text;
+}
+function renderObservationLog(log) {
+  if (log && log.observation_log && !log.csv_path) log = log.observation_log;
+  const badge = qs('obsLogBadge');
+  if (!log || log.ok === false) {
+    if (badge) { badge.textContent = 'not configured'; badge.className = 'badge warn'; }
+    if (qs('obsLogFile')) { qs('obsLogFile').textContent = 'not configured'; qs('obsLogFile').title = ''; }
+    if (qs('obsLogCreated')) qs('obsLogCreated').textContent = '';
+    return;
+  }
+  const csvPath = String(log.csv_path || '');
+  const csvName = log.csv_name || basenameFromPath(csvPath) || 'initializing...';
+  const writing = Boolean(log.writing) || (Boolean(csvPath) && log.writing !== false);
+  if (badge) {
+    badge.textContent = writing ? 'writing' : 'closed';
+    badge.className = 'badge ' + (writing ? 'ok' : 'warn');
+  }
+  if (qs('obsLogUser') && document.activeElement !== qs('obsLogUser')) qs('obsLogUser').value = log.observer || qs('obsLogUser').value || 'User';
+  if (qs('obsLogPrefix') && document.activeElement !== qs('obsLogPrefix')) qs('obsLogPrefix').value = log.prefix || qs('obsLogPrefix').value || 'obslog';
+  if (qs('obsLogFile')) {
+    qs('obsLogFile').textContent = csvName;
+    const parts = [];
+    if (csvPath) parts.push('CSV: ' + csvPath);
+    if (log.meta_path) parts.push('Meta JSON: ' + log.meta_path);
+    if (log.log_dir) parts.push('Log dir: ' + log.log_dir);
+    qs('obsLogFile').title = parts.join('\n');
+  }
+  if (qs('obsLogCreated')) {
+    const created = compactUtc(log.created_utc || '');
+    qs('obsLogCreated').textContent = created || '';
+    qs('obsLogCreated').title = log.created_utc || '';
+  }
+  const tooltip = log.tooltips || {};
+  if (qs('obsLogDirHelp') && tooltip.directory) qs('obsLogDirHelp').title = tooltip.directory;
+  if (qs('obsLogHelpText') && tooltip.directory) qs('obsLogHelpText').textContent = tooltip.directory;
+  const rows = Array.isArray(log.last_rows) ? log.last_rows : [];
+  const last = rows[0];
+  if (qs('obsLogLast')) {
+    if (last) {
+      const comment = last.comment ? ` comment=${last.comment}` : '';
+      qs('obsLogLast').textContent = `Last ${compactUtc(last.utc_iso || '')} ${last.mode || ''} ${last.event || ''} ${last.action_or_obsfile || ''}${comment}`;
+    } else {
+      qs('obsLogLast').textContent = 'No observation-log row yet.';
+    }
+  }
+  const warnings = [];
+  if (log.last_error) warnings.push(log.last_error);
+  if (Array.isArray(log.directory_warnings)) warnings.push(...log.directory_warnings);
+  if (!csvPath) warnings.push('active CSV path is not available yet');
+  if (qs('obsLogWarning')) qs('obsLogWarning').textContent = warnings.join(' / ');
+  if (qs('obsLogRecent')) {
+    if (!rows.length) {
+      qs('obsLogRecent').innerHTML = '<div class="file-empty">No rows.</div>';
+    } else {
+      const head = '<tr><th>UTC</th><th>Az</th><th>El</th><th>Comment</th><th>Mode</th><th>Event</th><th>Action/file</th><th>Result</th><th>User</th><th>Record dir</th><th>Session</th><th>Row</th><th>Temp C</th><th>Hum %</th><th>Pressure hPa</th><th>Weather</th></tr>';
+      const body = rows.map(r => `<tr><td>${escapeHtml(r.utc_iso)}</td><td>${escapeHtml(r.enc_az_deg)}</td><td>${escapeHtml(r.enc_el_deg)}</td><td>${escapeHtml(r.comment)}</td><td>${escapeHtml(r.mode)}</td><td>${escapeHtml(r.event)}</td><td>${escapeHtml(r.action_or_obsfile)}</td><td>${escapeHtml(r.result)}</td><td>${escapeHtml(r.user)}</td><td>${escapeHtml(r.record_dir)}</td><td>${escapeHtml(r.session_id)}</td><td>${escapeHtml(r.row_id)}</td><td>${escapeHtml(r.temp_C)}</td><td>${escapeHtml(r.humidity_pct)}</td><td>${escapeHtml(r.pressure_hPa)}</td><td>${escapeHtml(r.weather_source)}</td></tr>`).join('');
+      qs('obsLogRecent').innerHTML = `<table>${head}${body}</table>`;
+    }
+  }
+}
+
+
 function renderLog(items) {
   qs('log').innerHTML = items.map(item => {
     const statusClass = item.ok ? 'ok' : 'bad';
@@ -2512,6 +2777,38 @@ qs('chopperHome').addEventListener('click', () => api('chopper_home'));
 qs('chopperRecover').addEventListener('click', () => api('chopper_recover'));
 qs('runRsky').addEventListener('click', () => api('run_rsky', {n: qs('rskyN').value, integ: qs('rskyInteg').value, ch: qs('rskyCh').value}, 'rsky'));
 qs('runSkydip').addEventListener('click', () => api('run_skydip', {integ: qs('skydipInteg').value, ch: qs('skydipCh').value, tp_range: qs('skydipTpRange').value}, 'skydip'));
+qs('addObsLogComment').addEventListener('click', async () => {
+  const comment = qs('obsLogComment').value;
+  const data = await api('obslog_comment', {comment});
+  if (data.ok) qs('obsLogComment').value = '';
+});
+qs('obsLogComment').addEventListener('keydown', async (ev) => {
+  if (ev.key === 'Enter' && !ev.shiftKey) {
+    ev.preventDefault();
+    qs('addObsLogComment').click();
+  }
+});
+qs('newObsLog').addEventListener('click', async () => {
+  await api('obslog_new', {prefix: qs('obsLogPrefix').value, user: qs('obsLogUser').value});
+});
+qs('openObsLog').addEventListener('click', async () => {
+  const path = qs('obsLogOpenPath').value.trim();
+  if (!path) { alert('Enter a CSV filename or a full container path. Existing files are appended; missing files are created.'); return; }
+  await api('obslog_open_existing', {path, user: qs('obsLogUser').value});
+});
+qs('copyObsLogPath').addEventListener('click', async () => {
+  const log = (state.lastStatus || {}).observation_log || {};
+  const text = String(log.csv_path || qs('obsLogFile').title || '').split('\n')[0].replace(/^CSV:\s*/, '').trim();
+  if (!text || text === 'loading' || text === 'not configured' || text === 'initializing...') return;
+  try { await navigator.clipboard.writeText(text); qs('copyObsLogPath').textContent = 'Copied'; setTimeout(() => qs('copyObsLogPath').textContent = 'Copy path', 900); } catch (_) {}
+});
+qs('obsLogDirHelp').addEventListener('click', () => {
+  const box = qs('obsLogHelpText');
+  const btn = qs('obsLogDirHelp');
+  const willShow = box.hidden;
+  box.hidden = !willShow;
+  btn.setAttribute('aria-expanded', String(willShow));
+});
 qs('clearLog').addEventListener('click', () => api('clear_log'));
 qs('refreshRuntime').addEventListener('click', refresh);
 qs('loadOperatorLog').addEventListener('click', readOperatorLog);
@@ -2591,6 +2888,394 @@ main { max-width:1100px; margin:0 auto; padding:18px; }
 </html>
 """
 
+
+
+DEMO_CSV_HEADER = [
+    "utc_iso",
+    "enc_az_deg",
+    "enc_el_deg",
+    "comment",
+    "mode",
+    "event",
+    "action_or_obsfile",
+    "result",
+    "user",
+    "record_dir",
+    "session_id",
+    "row_id",
+    "temp_C",
+    "humidity_pct",
+    "pressure_hPa",
+    "weather_source",
+]
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _utc_iso(dt: Optional[datetime] = None) -> str:
+    return (dt or _utc_now()).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def _utc_stamp(dt: Optional[datetime] = None) -> str:
+    return (dt or _utc_now()).strftime("%Y%m%dT%H%M%SZ")
+
+
+
+
+def _demo_last_path_component(value: Any) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    trimmed = text.rstrip("/\\")
+    if not trimmed:
+        return text
+    if "\\" in trimmed and "/" not in trimmed:
+        name = PureWindowsPath(trimmed).name
+    else:
+        name = Path(trimmed).name
+    return name or trimmed
+
+
+def _safe_prefix(text: Any) -> str:
+    raw = str(text or "obslog").strip() or "obslog"
+    out = "".join(ch if ch.isalnum() or ch in "_.-" else "_" for ch in raw).strip("._-")
+    return (out or "obslog")[:64]
+
+
+class DemoObservationLog:
+    """Small real CSV writer for the standalone demo.
+
+    The real console uses necst.web.observation_log.  The demo intentionally
+    stays independent from ROS/NECST imports, but it should still behave like an
+    observer-facing append-only CSV logger so the UI can be tested honestly.
+    """
+
+    def __init__(self, *, prefix: str = "obslog", observer: str = "User") -> None:
+        self.log_dir = Path(os.environ.get("NECST_OBSLOG_DIR", "")).expanduser() if os.environ.get("NECST_OBSLOG_DIR") else Path.home() / ".necst" / "demo_observation_logs"
+        self.log_dir.mkdir(parents=True, exist_ok=True)
+        self.prefix = _safe_prefix(prefix)
+        self.observer = str(observer or "User").strip() or "User"
+        created = _utc_now()
+        self.created_utc = _utc_iso(created)
+        self.session_id = f"{_utc_stamp(created)}-{uuid.uuid4().hex[:4]}"
+        self.row_id = 0
+        self.last_rows: List[Dict[str, Any]] = []
+        self.last_error = ""
+        self.closed_utc: Optional[str] = None
+        self.csv_path = self._default_path(self.prefix, created)
+        self.meta_path = self.csv_path.with_suffix(self.csv_path.suffix + ".meta.json")
+        self._fh: Any = None
+        self._writer: Optional[csv.writer] = None
+        self._lock = threading.RLock()
+        self._open(self.csv_path)
+        self.write_event(mode="Console", event="console_start", action_or_obsfile="demo console started", result="success")
+
+    def _default_path(self, prefix: str, created: Optional[datetime] = None) -> Path:
+        stamp = _utc_stamp(created)
+        path = self.log_dir / f"{_safe_prefix(prefix)}_{stamp}.csv"
+        if not path.exists():
+            return path
+        for idx in range(2, 1000):
+            candidate = self.log_dir / f"{_safe_prefix(prefix)}_{stamp}_{idx}.csv"
+            if not candidate.exists():
+                return candidate
+        return self.log_dir / f"{_safe_prefix(prefix)}_{stamp}_{uuid.uuid4().hex[:6]}.csv"
+
+    def _sync(self) -> None:
+        if self._fh is None:
+            return
+        self._fh.flush()
+        os.fsync(self._fh.fileno())
+
+    def _write_meta(self) -> None:
+        payload = {
+            "schema_version": "demo-1.0",
+            "session_id": self.session_id,
+            "created_utc": self.created_utc,
+            "closed_utc": self.closed_utc,
+            "observer": self.observer,
+            "prefix": self.prefix,
+            "csv_path": str(self.csv_path),
+            "meta_path": str(self.meta_path),
+            "log_dir": str(self.log_dir),
+            "log_dir_source": "NECST_OBSLOG_DIR" if os.environ.get("NECST_OBSLOG_DIR") else "demo_home_fallback",
+            "notes": "Standalone demo observation log. Paths are inside the console container/process environment.",
+        }
+        tmp = self.meta_path.with_suffix(self.meta_path.suffix + ".tmp")
+        with tmp.open("w", encoding="utf-8") as fh:
+            json.dump(payload, fh, ensure_ascii=False, indent=2, sort_keys=True)
+            fh.write("\n")
+            fh.flush()
+            try:
+                os.fsync(fh.fileno())
+            except Exception:
+                pass
+        tmp.replace(self.meta_path)
+
+    def _open(self, path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        existed = path.exists()
+        size = path.stat().st_size if existed else 0
+        self.csv_path = path
+        self.meta_path = path.with_suffix(path.suffix + ".meta.json")
+        self.last_rows = []
+        self._fh = path.open("a", encoding="utf-8", newline="")
+        self._writer = csv.writer(self._fh)
+        if size == 0:
+            self.row_id = 0
+            self._writer.writerow(DEMO_CSV_HEADER)
+            self._sync()
+        else:
+            try:
+                with path.open("r", encoding="utf-8", newline="") as fh:
+                    reader = csv.reader(fh)
+                    header = next(reader, [])
+                    row_count = 0
+                    max_existing_row_id = 0
+                    recent: List[Dict[str, Any]] = []
+                    for row in reader:
+                        if not row or not any(str(cell).strip() for cell in row):
+                            continue
+                        row_count += 1
+                        if header == DEMO_CSV_HEADER:
+                            values = list(row)[: len(DEMO_CSV_HEADER)]
+                            if len(values) < len(DEMO_CSV_HEADER):
+                                values.extend([""] * (len(DEMO_CSV_HEADER) - len(values)))
+                            row_dict = dict(zip(DEMO_CSV_HEADER, values))
+                            try:
+                                max_existing_row_id = max(max_existing_row_id, int(str(row_dict.get("row_id") or "0")))
+                            except Exception:
+                                pass
+                            recent.append(row_dict)
+                            if len(recent) > 20:
+                                del recent[0]
+                self.row_id = max_existing_row_id if header == DEMO_CSV_HEADER and max_existing_row_id > 0 else row_count
+                if header == DEMO_CSV_HEADER:
+                    self.last_rows = list(reversed(recent))
+                else:
+                    self.last_error = "CSV header differs from the demo observation-log schema; appending anyway"
+            except Exception as exc:
+                self.row_id = 0
+                self.last_error = f"failed to inspect existing CSV header; appending anyway: {exc}"
+        self._write_meta()
+
+    def _resolve_user_csv_path(self, path_text: Any) -> Path:
+        raw = str(path_text or "").strip()
+        if not raw:
+            raise ValueError("CSV path is empty")
+        path = Path(raw).expanduser()
+        if not path.is_absolute():
+            if any(part == ".." for part in path.parts):
+                raise ValueError("relative observation log path must not contain '..'")
+            path = self.log_dir / path
+        if raw.endswith(("/", "\\")):
+            raise ValueError("observation log path must include a CSV filename")
+        if path.suffix == "":
+            path = path.with_suffix(".csv")
+        elif path.suffix.lower() != ".csv":
+            raise ValueError("observation log path must end with .csv")
+        return path
+
+    def _preflight_csv_path(self, path: Path) -> None:
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with path.open("a", encoding="utf-8", newline="") as fh:
+                fh.flush()
+                try:
+                    os.fsync(fh.fileno())
+                except Exception:
+                    pass
+        except Exception as exc:
+            raise OSError(f"observation log path is not writable: {path}: {exc}") from exc
+
+    def _record_open_failure(self, path: Path, exc: BaseException) -> None:
+        self.write_event(comment=str(exc), mode="Console", event="log_open_failed", action_or_obsfile=str(path), result="failed")
+
+    def _restore_previous_after_switch_failure(self, previous: Optional[Path], target: Path, exc: BaseException) -> None:
+        try:
+            if self._fh is not None:
+                self._fh.close()
+        except Exception:
+            pass
+        self._fh = None
+        self._writer = None
+        if previous is None:
+            self.last_error = str(exc)
+            return
+        try:
+            self.closed_utc = None
+            self._open(previous)
+            self.write_event(comment=str(exc), mode="Console", event="log_open_failed", action_or_obsfile=str(target), result="failed")
+        except Exception as restore_exc:
+            self.last_error = f"failed to open {target}: {exc}; failed to restore {previous}: {restore_exc}"
+
+    def update_observer(self, observer: Any) -> None:
+        with self._lock:
+            self._update_observer_unlocked(observer)
+
+    def _update_observer_unlocked(self, observer: Any) -> None:
+        new = str(observer or "").strip()
+        if new and new != self.observer:
+            old = self.observer
+            self.observer = new[:128]
+            self.write_event(mode="Console", event="observer_changed", action_or_obsfile=f"{old} -> {self.observer}", result="success")
+            self._write_meta()
+
+    def open_new(self, *, prefix: Any = None, observer: Any = None) -> None:
+        with self._lock:
+            self._open_new_unlocked(prefix=prefix, observer=observer)
+
+    def _open_new_unlocked(self, *, prefix: Any = None, observer: Any = None) -> None:
+        old_observer = self.observer
+        old_prefix = self.prefix
+        if observer:
+            self.observer = str(observer).strip()[:128] or "User"
+        if prefix:
+            self.prefix = _safe_prefix(prefix)
+        new_path = self._default_path(self.prefix)
+        previous = getattr(self, "csv_path", None)
+        try:
+            self._preflight_csv_path(new_path)
+        except Exception as exc:
+            self.observer = old_observer
+            self.prefix = old_prefix
+            self._record_open_failure(new_path, exc)
+            raise
+        self.write_event(mode="Console", event="log_closed", action_or_obsfile=str(new_path), result="success")
+        self.close(write_log_closed=False)
+        self.closed_utc = None
+        self.created_utc = _utc_iso()
+        try:
+            self._open(new_path)
+        except Exception as exc:
+            self._restore_previous_after_switch_failure(previous, new_path, exc)
+            raise
+        self.write_event(mode="Console", event="log_opened", action_or_obsfile=f"from {previous}", result="success")
+
+    def open_existing(self, path_text: Any, *, observer: Any = None) -> None:
+        with self._lock:
+            self._open_existing_unlocked(path_text, observer=observer)
+
+    def _open_existing_unlocked(self, path_text: Any, *, observer: Any = None) -> None:
+        try:
+            path = self._resolve_user_csv_path(path_text)
+        except Exception as exc:
+            fallback = self.log_dir / str(path_text or "")
+            self._record_open_failure(fallback, exc)
+            raise
+        old_observer = self.observer
+        if observer:
+            self.observer = str(observer).strip()[:128] or "User"
+        previous = getattr(self, "csv_path", None)
+        try:
+            self._preflight_csv_path(path)
+        except Exception as exc:
+            self.observer = old_observer
+            self._record_open_failure(path, exc)
+            raise
+        self.write_event(mode="Console", event="log_closed", action_or_obsfile=str(path), result="success")
+        self.close(write_log_closed=False)
+        self.closed_utc = None
+        self.created_utc = _utc_iso()
+        try:
+            self._open(path)
+        except Exception as exc:
+            self._restore_previous_after_switch_failure(previous, path, exc)
+            raise
+        self.write_event(mode="Console", event="log_opened", action_or_obsfile=f"from {previous}", result="success")
+
+    def write_event(self, *, state: Optional["DemoState"] = None, comment: str = "", mode: str = "Console", event: str = "event", action_or_obsfile: str = "", result: str = "unknown", record_dir: str = "") -> bool:
+        with self._lock:
+            return self._write_event_unlocked(state=state, comment=comment, mode=mode, event=event, action_or_obsfile=action_or_obsfile, result=result, record_dir=record_dir)
+
+    def _write_event_unlocked(self, *, state: Optional["DemoState"] = None, comment: str = "", mode: str = "Console", event: str = "event", action_or_obsfile: str = "", result: str = "unknown", record_dir: str = "") -> bool:
+        if self._writer is None:
+            return False
+        try:
+            az = f"{float(state.az):.4f}" if state is not None else ""
+            el = f"{float(state.el):.4f}" if state is not None else ""
+            if not record_dir and state is not None:
+                record_dir = state.local_recording_dir or state.recording_dir or state.progress_record_dir or ""
+            record_dir = _demo_last_path_component(record_dir)
+            next_row_id = self.row_id + 1
+            row = [
+                _utc_iso(), az, el, str(comment or ""), str(mode or ""), str(event or ""), str(action_or_obsfile or ""), str(result or ""),
+                self.observer, str(record_dir or ""), self.session_id, next_row_id, "", "", "", "",
+            ]
+            self._writer.writerow(row)
+            self._fh.flush()
+            fsync_error = ""
+            try:
+                os.fsync(self._fh.fileno())
+            except Exception as exc:
+                fsync_error = str(exc)
+            self.row_id = next_row_id
+            row_dict = dict(zip(DEMO_CSV_HEADER, row))
+            self.last_rows.insert(0, row_dict)
+            del self.last_rows[20:]
+            self.last_error = fsync_error
+            return not bool(fsync_error)
+        except Exception as exc:
+            self.last_error = str(exc)
+            return False
+
+    def close(self, *, write_log_closed: bool = True) -> None:
+        with self._lock:
+            self._close_unlocked(write_log_closed=write_log_closed)
+
+    def _close_unlocked(self, *, write_log_closed: bool = True) -> None:
+        if self._fh is None:
+            return
+        if write_log_closed:
+            self.write_event(mode="Console", event="log_closed", action_or_obsfile="demo console stopping", result="success")
+        self.closed_utc = _utc_iso()
+        try:
+            self._write_meta()
+        except Exception as exc:
+            self.last_error = str(exc)
+        try:
+            self._sync()
+        finally:
+            try:
+                self._fh.close()
+            finally:
+                self._fh = None
+                self._writer = None
+
+    def status(self) -> Dict[str, Any]:
+        with self._lock:
+            return self._status_unlocked()
+
+    def _status_unlocked(self) -> Dict[str, Any]:
+        return {
+            "ok": self._writer is not None,
+            "writing": self._writer is not None,
+            "csv_path": str(self.csv_path),
+            "csv_name": self.csv_path.name,
+            "meta_path": str(self.meta_path),
+            "meta_name": self.meta_path.name,
+            "created_utc": self.created_utc,
+            "closed_utc": self.closed_utc,
+            "log_dir": str(self.log_dir),
+            "log_dir_source": "NECST_OBSLOG_DIR" if os.environ.get("NECST_OBSLOG_DIR") else "demo_home_fallback",
+            "record_root": None,
+            "prefix": self.prefix,
+            "observer": self.observer,
+            "session_id": self.session_id,
+            "row_id": self.row_id,
+            "schema_version": "demo-1.0",
+            "columns": list(DEMO_CSV_HEADER),
+            "last_rows": list(self.last_rows),
+            "last_error": self.last_error,
+            "directory_warnings": [],
+            "tooltips": {
+                "directory": "Log directory selection:\n1. NECST_OBSLOG_DIR, if set.\n2. <record root>/obslogs, if available.\n3. ~/.necst/observation_logs as fallback.\nThis path is inside the console container. Use a bind-mounted path if you need the log on the host.",
+                "file": "A new log file is created when the console server starts. Reloading the web page does not change the log file.",
+                "switch": "Close the current log file and continue writing to a new or selected CSV file. This does not rename the existing file.",
+            },
+        }
 
 @dataclass
 class LogEntry:
@@ -2721,6 +3406,7 @@ class ConsoleDemoServer(ThreadingHTTPServer):
         self.progress_port = int(progress_port)
         self._progress_server: Optional[ThreadingHTTPServer] = None
         self._progress_thread: Optional[threading.Thread] = None
+        self.observation_log = DemoObservationLog(prefix=os.environ.get("NECST_OBSLOG_PREFIX", "obslog"), observer=os.environ.get("NECST_OBSLOG_USER", "User"))
         self.add_log(True, "console demo v7 started; no real telescope command is sent")
 
     def add_log(self, ok: bool, message: str) -> None:
@@ -2820,7 +3506,9 @@ class Handler(BaseHTTPRequestHandler):
             return
         if self.path == "/api/status":
             with self.server.lock:
-                self._send_json(self.server.state.to_dict())
+                payload = self.server.state.to_dict()
+                payload["observation_log"] = self.server.observation_log.status()
+                self._send_json(payload)
             return
         parsed = urllib.parse.urlparse(self.path)
         if parsed.path == "/api/operator-log":
@@ -2895,9 +3583,16 @@ class Handler(BaseHTTPRequestHandler):
         if not isinstance(params, dict):
             self._send_json({"ok": False, "reason": "params must be an object"}, 400)
             return
+        obslog_user = str(payload.get("obslog_user") or "").strip()
         with self.server.lock:
+            if obslog_user:
+                self.server.observation_log.update_observer(obslog_user)
             ok, reason = handle_action(self.server, action, params, session_id)
-            self._send_json({"ok": ok, "reason": reason, "state": self.server.state.to_dict()})
+            if not action.startswith("obslog_"):
+                _demo_write_observation_log_for_action(self.server, action, params, ok, reason)
+            state_payload = self.server.state.to_dict()
+            state_payload["observation_log"] = self.server.observation_log.status()
+            self._send_json({"ok": ok, "reason": reason, "state": state_payload, "observation_log": self.server.observation_log.status()})
 
 
 def _as_float(value: Any, name: str) -> Tuple[Optional[float], Optional[str]]:
@@ -3172,6 +3867,92 @@ def _demo_active_operation_reason(state: DemoState, requested_action: str) -> Op
         return f"cannot start {requested_action}: active task is {state.active_task}; use STOP/ABORT or wait until READY"
     return None
 
+
+def _demo_obslog_mode_for_action(action: str, params: Dict[str, Any]) -> str:
+    if action in {"start_observation", "check_observation", "dry_run_observation", "abort_observation"}:
+        mode = str(params.get("mode") or "Observation")
+        return mode.upper() if mode else "Observation"
+    if action.startswith("chopper_"):
+        return "Chopper"
+    if action in {"mount_move", "mount_move_dry_run"}:
+        return "Mount"
+    if action in {"start_tracking", "stop_tracking"}:
+        return "Tracking"
+    if action == "run_rsky":
+        return "RSky"
+    if action == "run_skydip":
+        return "SkyDip"
+    if action.startswith("terminate_") or action in {"kill_process"}:
+        return "Recovery"
+    return "Console"
+
+
+def _demo_obslog_event_for_action(action: str) -> Optional[str]:
+    mapping = {
+        "check_observation": "check_clicked",
+        "dry_run_observation": "dry_run_clicked",
+        "start_observation": "observation_start_clicked",
+        "abort_observation": "abort_clicked",
+        "stop": "stop_clicked",
+        "mount_move": "mount_move_clicked",
+        "mount_move_dry_run": "mount_move_dry_run_clicked",
+        "start_tracking": "tracking_start_clicked",
+        "stop_tracking": "tracking_stop_clicked",
+        "chopper_in": "chopper_in_clicked",
+        "chopper_out": "chopper_out_clicked",
+        "chopper_status": "chopper_status_clicked",
+        "chopper_alarm_reset": "chopper_alarm_reset_clicked",
+        "chopper_home": "chopper_home_clicked",
+        "chopper_recover": "chopper_recover_clicked",
+        "run_rsky": "rsky_clicked",
+        "run_skydip": "skydip_clicked",
+        "terminate_process": "local_launcher_force_kill_clicked",
+        "kill_process": "local_launcher_force_kill_clicked",
+        "terminate_observation_launcher": "local_observation_launcher_force_kill_clicked",
+        "terminate_calibration_launcher": "local_calibration_launcher_force_kill_clicked",
+        "terminate_all_launchers": "local_launchers_force_kill_clicked",
+    }
+    return mapping.get(action)
+
+
+def _demo_obslog_action_text(action: str, params: Dict[str, Any]) -> str:
+    if action in {"start_observation", "check_observation", "dry_run_observation"}:
+        return _demo_last_path_component(params.get("file") or "")
+    if action in {"mount_move", "mount_move_dry_run"}:
+        return f"Az={params.get('az', '')}, El={params.get('el', '')}"
+    if action == "start_tracking":
+        return str(params.get("kind") or "target")
+    if action in {"run_rsky", "run_skydip"}:
+        bits = []
+        for key in ("n", "integ", "ch", "tp_range"):
+            if params.get(key) not in (None, ""):
+                bits.append(f"{key}={params.get(key)}")
+        return ", ".join(bits)
+    if action.startswith("terminate_") or action in {"kill_process"}:
+        pid = params.get("pid")
+        return f"{action}" + (f" pid={pid}" if pid not in (None, "") else "")
+    return action
+
+
+def _demo_write_observation_log_for_action(server: ConsoleDemoServer, action: str, params: Dict[str, Any], ok: bool, reason: str) -> None:
+    event = _demo_obslog_event_for_action(action)
+    if event is None:
+        return
+    result = "success" if ok else "failed"
+    if action == "start_observation" and ok:
+        result = "running"
+    if action == "abort_observation" and ok:
+        result = "aborted"
+    if action == "stop" and ok:
+        result = "stopped"
+    server.observation_log.write_event(
+        state=server.state,
+        mode=_demo_obslog_mode_for_action(action, params),
+        event=event,
+        action_or_obsfile=_demo_obslog_action_text(action, params),
+        result=result,
+    )
+
 def handle_action(
     server: ConsoleDemoServer, action: str, params: Dict[str, Any], session_id: str
 ) -> Tuple[bool, str]:
@@ -3181,6 +3962,33 @@ def handle_action(
     if active_reason is not None:
         server.add_log(False, active_reason)
         return False, active_reason
+
+    if action == "obslog_comment":
+        comment = str(params.get("comment") or "").strip()
+        if not comment:
+            server.add_log(False, "observation-log comment not written: empty comment")
+            return False, "comment is empty; no observation-log row was written"
+        written = server.observation_log.write_event(state=state, comment=comment, mode="Comment", event="comment", action_or_obsfile="manual comment", result="success")
+        if not written:
+            reason = f"failed to append observation CSV log comment: {server.observation_log.last_error or 'unknown error'}"
+            server.add_log(False, reason)
+            return False, reason
+        server.add_log(True, "observation-log comment appended")
+        return True, "comment appended to observation CSV log"
+
+    if action == "obslog_new":
+        server.observation_log.open_new(prefix=params.get("prefix") or server.observation_log.prefix, observer=params.get("user") or server.observation_log.observer)
+        server.add_log(True, f"new observation CSV log opened: {server.observation_log.csv_path.name}")
+        return True, "new observation CSV log opened"
+
+    if action == "obslog_open_existing":
+        try:
+            server.observation_log.open_existing(params.get("path"), observer=params.get("user") or server.observation_log.observer)
+        except Exception as exc:
+            server.add_log(False, f"observation CSV open/append failed: {exc}")
+            return False, str(exc)
+        server.add_log(True, f"observation CSV log opened for append: {server.observation_log.csv_path.name}")
+        return True, "existing observation CSV log opened for append"
 
     if action == "launch_progress":
         ok, reason, url = server.launch_progress()
@@ -3515,6 +4323,10 @@ def main(argv: Optional[List[str]] = None) -> int:
     finally:
         signal.signal(signal.SIGINT, old_int)
         signal.signal(signal.SIGTERM, old_term)
+        try:
+            server.observation_log.close(write_log_closed=True)
+        except Exception:
+            pass
         server.stop_progress()
         server.server_close()
         thread.join(timeout=2.0)

--- a/bin/console-demo.py
+++ b/bin/console-demo.py
@@ -202,6 +202,8 @@ button.pending:not(:disabled) { border-color: rgba(122,162,255,0.75); background
 .secondary { background: #18213b; }
 .ghost { background: transparent; }
 button.selected:not(:disabled) { border-color: rgba(86,211,100,0.70); box-shadow: 0 0 0 2px rgba(86,211,100,0.12); }
+button.recovery-danger:not(:disabled) { background:#4d2730; border-color:rgba(255,107,107,0.72); color:#ffd9dd; font-weight:800; }
+button.recovery-danger:hover:not(:disabled) { background:#6b2b36; border-color:rgba(255,137,145,0.90); }
 .run-bar {
   position: sticky;
   top: 78px;
@@ -256,16 +258,33 @@ button.selected:not(:disabled) { border-color: rgba(86,211,100,0.70); box-shadow
 .log-entry .time { color: var(--faint); }
 .log-entry .ok { color: var(--ok); }
 .log-entry .bad { color: var(--bad); }
-.runtime-grid { display:grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap:10px; }
-.runtime-card { border:1px solid var(--line); border-radius:12px; padding:10px; background:rgba(255,255,255,0.025); }
-.runtime-card h3 { margin:0 0 8px; font-size:13px; color:var(--accent2); }
-.runtime-list { display:grid; gap:6px; font-size:12px; color:var(--muted); }
+.runtime-grid { display:grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap:12px; align-items:start; }
+.runtime-grid.advanced { grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); }
+.runtime-card { border:1px solid var(--line); border-radius:12px; padding:12px; background:rgba(255,255,255,0.025); min-width:0; }
+.runtime-card h3 { margin:0 0 5px; font-size:13px; color:var(--accent2); }
+.runtime-card .card-hint { margin:0 0 9px; color:var(--faint); font-size:12px; line-height:1.35; }
+.runtime-card.wide { grid-column: span 2; }
+.runtime-card.history { border-color:rgba(86,211,100,0.28); }
+.runtime-card.recovery { border-color:rgba(242,204,96,0.32); }
+.recovery-warning { border:1px solid rgba(242,204,96,0.46); border-radius:10px; padding:9px 10px; background:rgba(242,204,96,0.075); color:var(--warn); line-height:1.38; }
+.recovery-warning b { color:var(--warn); }
+.recovery-muted { color:var(--faint); font-size:11px; line-height:1.35; }
+.runtime-card.logs { border-color:rgba(122,162,255,0.25); }
+.runtime-list { display:grid; gap:6px; font-size:12px; color:var(--muted); min-width:0; }
 .runtime-list b { color:var(--text); font-weight:600; }
-.process-row { border-top:1px dashed rgba(255,255,255,0.10); padding-top:6px; margin-top:6px; color:var(--muted); }
+.runtime-subtitle { margin: 10px 0 4px; color:var(--faint); font-size:11px; font-weight:700; letter-spacing:.04em; text-transform:uppercase; }
+.process-row { border-top:1px dashed rgba(255,255,255,0.10); padding-top:7px; margin-top:7px; color:var(--muted); }
 .process-row:first-child { border-top:0; margin-top:0; padding-top:0; }
+.process-row .process-title { display:flex; flex-wrap:wrap; gap:6px; align-items:center; color:var(--text); font-weight:700; }
+.process-row .process-meta { margin-top:2px; color:var(--faint); font-size:11px; }
+.process-row .process-log-paths { margin-top:4px; color:var(--muted); font-size:11px; overflow-wrap:anywhere; word-break:break-word; white-space:normal; }
+.process-row button { margin-top:6px; padding:5px 8px; font-size:12px; }
 .mini-actions { display:flex; flex-wrap:wrap; gap:6px; margin-top:8px; }
-.process-row button { margin-top:5px; padding:5px 8px; font-size:12px; }
 .path-text { overflow:hidden; text-overflow:ellipsis; white-space:nowrap; direction:rtl; text-align:left; }
+.path-text.ltr { direction:ltr; }
+.path-text.wrap, .runtime-path { direction:ltr; text-align:left; white-space:normal; overflow:visible; text-overflow:clip; overflow-wrap:anywhere; word-break:break-word; line-height:1.35; }
+.runtime-path b, .path-text.wrap b { overflow-wrap:anywhere; word-break:break-word; }
+@media (max-width: 980px) { .runtime-card.wide { grid-column: auto; } .runtime-grid.advanced { grid-template-columns: 1fr; } }
 .copy-path-text { direction:ltr; text-align:left; user-select:text; }
 .obs-output-dir {
   display: none;
@@ -295,8 +314,11 @@ button.selected:not(:disabled) { border-color: rgba(86,211,100,0.70); box-shadow
 .progress-status-line.ok { color: var(--ok); }
 .progress-status-line.warn { color: var(--warn); }
 .progress-status-line.bad { color: var(--bad); }
-.log-browser-text { max-height:220px; overflow:auto; white-space:pre-wrap; word-break:break-word; background:#080d1b; border:1px solid var(--line); border-radius:10px; padding:8px; font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace; font-size:11px; color:var(--muted); }
-.log-choice { display:block; width:100%; text-align:left; margin-top:4px; padding:5px 7px; font-size:12px; }
+.log-browser-text { max-height:260px; overflow:auto; white-space:pre-wrap; word-break:break-word; background:#080d1b; border:1px solid var(--line); border-radius:10px; padding:8px; font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace; font-size:11px; color:var(--muted); }
+.log-choice { display:block; width:100%; text-align:left; margin-top:5px; padding:6px 8px; font-size:12px; }
+.log-choice.latest { border-color:rgba(86,211,100,0.45); }
+.log-choice .log-choice-title { display:block; color:var(--text); font-weight:700; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.log-choice .log-choice-sub { display:block; color:var(--faint); font-size:11px; overflow-wrap:anywhere; word-break:break-word; white-space:normal; margin-top:2px; }
 .warning-list { color:var(--warn); }
 details {
   margin-top: 10px;
@@ -514,7 +536,7 @@ summary { cursor: pointer; color: var(--muted); }
           <div class="run-actions">
             <button id="startObs" class="primary large" disabled title="Start the selected observation sequence. Check and Dry run are optional; Start always performs server-side validation before launching.">Start observation</button>
             <button id="abortObs" class="danger large" title="Abort a running observation sequence and request recorder/gate/progress cleanup. Safety action: kept clickable even if status has not yet detected observing.">ABORT observation</button>
-            <button id="terminateObsLauncherQuick" class="secondary compact" type="button" disabled title="Terminate the local observation launcher subprocess only. This does not send telescope STOP and should be used only after confirming the hardware is safe.">Terminate launcher</button>
+            <button id="terminateObsLauncherQuick" class="recovery-danger compact" type="button" disabled title="Force-kill only the local observation launcher started by this console. Use only after Abort does not return and hardware is already confirmed safe.">Force-kill local launcher</button>
             <button id="clearStaleObs" class="secondary compact" type="button" disabled title="Recover the console from stale progress state after confirming the telescope/recorder are safe. This archives only current progress pointer files; it does not send hardware commands or delete data.">Clear stale state</button>
           </div>
         </div>
@@ -808,7 +830,7 @@ summary { cursor: pointer; color: var(--muted); }
     <div class="card-head">
       <div>
         <h2>Runtime status</h2>
-        <div class="hint">Site config, process lifecycle, progress monitor ownership, and persistent log paths.</div>
+        <div class="hint">Observation data, operation history, progress status, and advanced recovery tools.</div>
       </div>
       <button id="refreshRuntime" class="secondary">Refresh</button>
     </div>
@@ -816,6 +838,7 @@ summary { cursor: pointer; color: var(--muted); }
       <div class="runtime-grid">
         <div class="runtime-card">
           <h3>Site and action mode</h3>
+          <p class="card-hint">Current console mode and live telemetry source.</p>
           <div class="runtime-list">
             <div>Action mode: <b id="runtimeActionMode">loading</b></div>
             <div>Live writes: <b id="runtimeLiveWrites">loading</b></div>
@@ -823,74 +846,96 @@ summary { cursor: pointer; color: var(--muted); }
             <div>Live telemetry: <b id="runtimeLiveTelemetry">loading</b></div>
             <div>Observatory: <b id="runtimeObservatory">loading</b></div>
             <div>Config source: <b id="runtimeConfigSource">loading</b></div>
-            <div class="path-text" title="site config path">Path: <b id="runtimeConfigPath">loading</b></div>
+            <div class="path-text wrap" title="site config path">Path: <b id="runtimeConfigPath">loading</b></div>
             <div>Capabilities: <b id="runtimeCapabilities">loading</b></div>
           </div>
         </div>
         <div class="runtime-card">
-          <h3>Process lifecycle</h3>
-          <div class="runtime-list">
-            <div>Counts: <b id="runtimeProcessCounts">loading</b></div>
-            <div id="runtimeProcesses">loading</div>
-            <div class="mini-actions">
-              <button id="terminateObsLauncher" class="secondary" title="Terminate local observation launcher subprocess only; does not send telescope STOP">Terminate obs launcher</button>
-              <button id="terminateCalLauncher" class="secondary" title="Terminate local calibration launcher subprocess only; does not send telescope STOP">Terminate cal launcher</button>
-              <button id="terminateAllLaunchers" class="secondary" title="Terminate all local launcher subprocesses started by this console">Terminate all launchers</button>
-            </div>
-          </div>
-        </div>
-        <div class="runtime-card">
           <h3>Current observation data</h3>
+          <p class="card-hint">Record and data paths from the most recent observation state.</p>
           <div class="runtime-list">
             <div>Record: <b id="runtimeRecordName">loading</b></div>
-            <div class="path-text" title="Local PC path if the Docker/container data root is mapped; otherwise the container path is shown.">Local/data path: <b id="runtimeLocalRecordingDir">loading</b></div>
-            <div class="path-text" title="Expected NECST recorder output directory inside the console/container environment">Container data directory: <b id="runtimeRecordingDir">loading</b></div>
-            <div class="path-text" title="Progress sidecar directory">Progress directory: <b id="runtimeProgressRecordDir">loading</b></div>
+            <div class="runtime-path" title="Local PC path if configured; otherwise the data path visible to this console is shown.">record path: <b id="runtimeLocalRecordingDir">loading</b></div>
+            <div class="runtime-path" title="Expected NECST recorder output directory inside the console/container environment">container data: <b id="runtimeRecordingDir">loading</b></div>
+            <div class="runtime-path" title="Progress sidecar directory">progress sidecar: <b id="runtimeProgressRecordDir">loading</b></div>
           </div>
         </div>
         <div class="runtime-card">
-          <h3>Progress monitor and logs</h3>
+          <h3>Progress monitor</h3>
+          <p class="card-hint">Progress server state. Operator and launcher logs are separated below.</p>
           <div class="runtime-list">
             <div>Progress: <b id="runtimeProgressMonitor">loading</b></div>
-            <div class="path-text" title="operator log path">Operator log: <b id="runtimeOperatorLog">loading</b></div>
-            <div class="path-text" title="launcher log directory">Launcher logs: <b id="runtimeLauncherLogDir">loading</b></div>
-            <div class="mini-actions">
-              <button id="loadOperatorLog" class="secondary" title="Read the persistent operator_console.jsonl tail">Read operator log</button>
-            </div>
-          </div>
-        </div>
-        <div class="runtime-card">
-          <h3>Log browser</h3>
-          <div class="runtime-list">
-            <div id="runtimeLogBrowserSummary">Operator and launcher logs are read-only.</div>
-            <div id="runtimeLauncherLogChoices"><span style="color:var(--faint)">No launcher log recorded.</span></div>
-            <div id="runtimeLogBrowserText" class="log-browser-text">Select a log to display its tail.</div>
-          </div>
-        </div>
-        <div class="runtime-card">
-          <h3>Shutdown cleanup</h3>
-          <div class="runtime-list">
-            <div>Status: <b id="runtimeShutdownStatus">loading</b></div>
-            <div>Terminate launchers: <b id="runtimeShutdownTerminate">loading</b></div>
-            <div>Last cleanup: <b id="runtimeShutdownLast">loading</b></div>
-            <div id="runtimeShutdownSummary" class="path-text">loading</div>
-          </div>
-        </div>
-        <div class="runtime-card">
-          <h3>Self-check</h3>
-          <div class="runtime-list">
-            <div>Status: <b id="runtimeSelfCheckStatus">not run</b></div>
-            <div id="runtimeSelfCheckSummary" class="path-text">Run self-check before live operation.</div>
-            <div class="mini-actions">
-              <button id="runSelfCheck" class="secondary" title="Run read-only console self-checks; no telescope command is sent">Run self-check</button>
-            </div>
+            <div class="runtime-path" title="launcher log directory">Progress/launcher log dir: <b id="runtimeLauncherLogDir">loading</b></div>
           </div>
         </div>
         <div class="runtime-card">
           <h3>Warnings</h3>
+          <p class="card-hint">Console-side warnings only; this does not decide observation OK/NG yet.</p>
           <div id="runtimeWarnings" class="runtime-list warning-list">loading</div>
         </div>
+        <div class="runtime-card logs history wide">
+          <h3>Observation/action history log</h3>
+          <p class="card-hint">Persistent operator_console.jsonl: observation starts, obs-file names, record/output directories when available, and accepted/rejected console actions.</p>
+          <div class="runtime-list">
+            <div class="runtime-path" title="operator log path">Path: <b id="runtimeOperatorLog">loading</b></div>
+            <div class="mini-actions">
+              <button id="loadOperatorLog" class="secondary" title="Show the persistent observation/action history log tail here">Show latest history</button>
+            </div>
+            <div id="runtimeOperatorLogText" class="log-browser-text">Click “Show latest history” to display recent observation and console actions.</div>
+          </div>
+        </div>
       </div>
+
+      <details class="runtime-advanced">
+        <summary>Advanced recovery tools and launcher logs</summary>
+        <div class="runtime-grid advanced" style="margin-top:10px">
+          <div class="runtime-card recovery wide">
+            <h3>Stuck local launchers (recovery only)</h3>
+            <p class="card-hint">Local child processes started by this console. These are not telescope, recorder, or XFFTS nodes.</p>
+            <div class="recovery-warning"><b>Use only when ABORT does not return.</b><br>First press STOP/ABORT and confirm the telescope, recorder, and XFFTS are safe. These buttons only kill local launcher processes started by this console; they do not send any hardware STOP command.</div>
+            <div class="runtime-list">
+              <div>Counts: <b id="runtimeProcessCounts">loading</b></div>
+              <div id="runtimeProcesses">loading</div>
+              <div class="mini-actions">
+                <button id="terminateObsLauncher" class="recovery-danger" title="Force-kill only the local observation launcher subprocess. This does not send telescope STOP, recorder STOP, or XFFTS STOP.">Force-kill local observation launcher</button>
+                <button id="terminateCalLauncher" class="recovery-danger" title="Force-kill only the local calibration launcher subprocess. This does not send telescope STOP, recorder STOP, or XFFTS STOP.">Force-kill local calibration launcher</button>
+                <button id="terminateAllLaunchers" class="recovery-danger" title="Force-kill all local launcher subprocesses started by this console. This does not send telescope STOP, recorder STOP, or XFFTS STOP.">Force-kill all local launchers</button>
+                <div class="recovery-muted">Normal operation: use STOP and ABORT. Use force-kill only for a stuck local launcher after hardware safety is confirmed.</div>
+              </div>
+            </div>
+          </div>
+          <div class="runtime-card logs wide">
+            <h3>Launcher stdout/stderr files</h3>
+            <p class="card-hint">Debug logs for local launcher subprocesses. Latest logs are listed first; observation history is shown above.</p>
+            <div class="runtime-list">
+              <div id="runtimeLogBrowserSummary">Select a launcher log below. Latest first.</div>
+              <div id="runtimeLauncherLogChoices"><span style="color:var(--faint)">No launcher log recorded.</span></div>
+              <div id="runtimeLogBrowserText" class="log-browser-text">Select a launcher stdout/stderr log to display its tail.</div>
+            </div>
+          </div>
+          <div class="runtime-card">
+            <h3>Self-check</h3>
+            <p class="card-hint">Read-only console self-check. It does not move hardware.</p>
+            <div class="runtime-list">
+              <div>Status: <b id="runtimeSelfCheckStatus">not run</b></div>
+              <div id="runtimeSelfCheckSummary" class="runtime-path">Run self-check before live operation.</div>
+              <div class="mini-actions">
+                <button id="runSelfCheck" class="secondary" title="Run read-only console self-checks; no telescope command is sent">Run self-check</button>
+              </div>
+            </div>
+          </div>
+          <div class="runtime-card">
+            <h3>Shutdown cleanup</h3>
+            <p class="card-hint">What this console would clean up on shutdown. No automatic hardware command is sent from here.</p>
+            <div class="runtime-list">
+              <div>Status: <b id="runtimeShutdownStatus">loading</b></div>
+              <div>Stop local launchers on console shutdown: <b id="runtimeShutdownTerminate">loading</b></div>
+              <div>Last cleanup: <b id="runtimeShutdownLast">loading</b></div>
+              <div id="runtimeShutdownSummary" class="runtime-path">loading</div>
+            </div>
+          </div>
+        </div>
+      </details>
     </div>
   </section>
 </main>
@@ -1144,7 +1189,7 @@ function actualOperationFromStatus(data) {
         phase: 'attention',
         kind: 'observation',
         label: 'ATTENTION: OBSERVATION LAUNCHER STUCK',
-        detail: `Observation launcher still appears active for ${record} while the system is error/abort-stalled (${safetyText}). Confirm hardware is safe, then terminate the local launcher. Clear stale state may be needed after that.`
+        detail: `Observation launcher still appears active for ${record} while the system is error/abort-stalled (${safetyText}). Confirm hardware is safe, then force-kill the local launcher. Clear stale state may be needed after that.`
       };
     }
     return {
@@ -1165,7 +1210,7 @@ function actualOperationFromStatus(data) {
       phase: 'attention',
       kind: 'observation',
       label: 'ATTENTION: OBSERVATION STATE ERROR',
-      detail: 'Observation-related state remains while the system lifecycle is error/failed. Use ABORT first; if it does not clear, terminate the local launcher and clear stale state after confirming hardware safety.'
+      detail: 'Observation-related state remains while the system lifecycle is error/failed. Use ABORT first; if it does not clear, force-kill the local launcher and clear stale state after confirming hardware safety.'
     };
   }
   const obsActive = sys === 'observing' || (!finalOrIdle && task.includes('observation')) || (!finalOrIdle && Boolean(progress.observation_running)) || (!finalOrIdle && processCategoryActive(data, 'observation'));
@@ -1552,69 +1597,145 @@ function processSummary(counts) {
 function escapeHtml(value) {
   return String(value ?? '').replace(/[&<>"']/g, ch => ({'&':'&amp;', '<':'&lt;', '>':'&gt;', '"':'&quot;', "'":'&#39;'}[ch]));
 }
+function parseProcessTime(p) {
+  const raw = Number(p && p.started_at);
+  if (Number.isFinite(raw)) return raw;
+  const parsed = Date.parse((p && p.started_at_iso) || '');
+  return Number.isFinite(parsed) ? parsed / 1000 : 0;
+}
+function sortedProcesses(processes) {
+  if (!Array.isArray(processes)) return [];
+  return processes.slice().sort((a, b) => parseProcessTime(b) - parseProcessTime(a));
+}
+function processIsActive(p) {
+  return ['running', 'terminating', 'killing'].includes(String((p && p.status) || '')) || Boolean(p && p.can_terminate);
+}
+function processMatchesCategory(p, category) {
+  const haystack = [p && p.category, p && p.action, p && p.label, p && p.command].flat().join(' ').toLowerCase();
+  if (category === 'observation') return haystack.includes('observation') || haystack.includes('obs') || haystack.includes('psw') || haystack.includes('otf');
+  if (category === 'calibration') return haystack.includes('calibration') || haystack.includes('rsky') || haystack.includes('skydip');
+  return false;
+}
 function renderProcessRows(processes) {
-  if (!Array.isArray(processes) || processes.length === 0) return '<span style="color:var(--faint)">No launcher process recorded.</span>';
-  return processes.slice(0, 8).map(p => {
-    const rc = (p.returncode === null || p.returncode === undefined) ? '' : `, rc=${p.returncode}`;
+  const rows = sortedProcesses(processes);
+  if (rows.length === 0) return '<span style="color:var(--faint)">No local launcher process recorded.</span>';
+  return rows.slice(0, 8).map((p, index) => {
+    const rc = (p.returncode === null || p.returncode === undefined) ? '' : ` rc=${escapeHtml(p.returncode)}`;
     const pidValue = p.pid;
-    const pid = pidValue === undefined ? 'pid=?' : `pid=${pidValue}`;
-    const started = escapeHtml(p.started_at_iso || '');
+    const pid = pidValue === undefined ? 'pid=?' : `pid=${escapeHtml(pidValue)}`;
+    const started = escapeHtml(p.started_at_iso || 'time unknown');
+    const ended = p.ended_at_iso ? ` → ${escapeHtml(p.ended_at_iso)}` : '';
     const label = escapeHtml(p.label || p.action || 'launcher');
     const status = escapeHtml(p.status || 'unknown');
-    const logs = [p.stdout_path ? `stdout: ${escapeHtml(p.stdout_path)}` : '', p.stderr_path ? `stderr: ${escapeHtml(p.stderr_path)}` : ''].filter(Boolean).join('<br>');
-    const canTerminate = p.can_terminate || ['running', 'terminating', 'killing'].includes(String(p.status || ''));
-    const button = canTerminate && pidValue !== undefined ? `<br><button class="secondary process-stop" data-pid="${escapeHtml(pidValue)}">Terminate local launcher</button>` : '';
-    return `<div class="process-row"><b>${label}</b> ${pid}, ${status}${rc}<br><small>${started}</small>${logs ? '<br><small>' + logs + '</small>' : ''}${button}</div>`;
+    const active = processIsActive(p);
+    const latest = index === 0 ? ' <span class="badge ok">latest</span>' : '';
+    const stdout = p.stdout_path ? `<div title="${escapeHtml(p.stdout_path)}">stdout: ${escapeHtml(p.stdout_path)}</div>` : '';
+    const stderr = p.stderr_path ? `<div title="${escapeHtml(p.stderr_path)}">stderr: ${escapeHtml(p.stderr_path)}</div>` : '';
+    const canTerminate = active && pidValue !== undefined;
+    const button = canTerminate ? `<button class="recovery-danger process-stop" data-pid="${escapeHtml(pidValue)}">Force-kill this local launcher</button>` : '';
+    return `<div class="process-row"><div class="process-title">${label}${latest}</div><div class="process-meta">${pid} · ${status}${rc} · ${started}${ended}</div>${stdout || stderr ? '<div class="process-log-paths">' + stdout + stderr + '</div>' : ''}${button}</div>`;
   }).join('');
+}
+function shortFileName(path) {
+  const text = String(path || '');
+  const parts = text.split('/').filter(Boolean);
+  return parts.length ? parts[parts.length - 1] : text;
 }
 function renderLauncherLogChoices(processes) {
   const el = qs('runtimeLauncherLogChoices');
   if (!el) return;
   const choices = [];
-  if (Array.isArray(processes)) {
-    processes.slice(0, 8).forEach(p => {
-      const label = p.label || p.action || 'launcher';
-      if (p.stdout_path) choices.push({label, stream:'stdout', path:p.stdout_path, pid:p.pid});
-      if (p.stderr_path) choices.push({label, stream:'stderr', path:p.stderr_path, pid:p.pid});
-    });
-  }
+  sortedProcesses(processes).forEach((p, pIndex) => {
+    const label = p.label || p.action || 'launcher';
+    const started = p.started_at_iso || '';
+    const status = p.status || 'unknown';
+    const rc = (p.returncode === null || p.returncode === undefined) ? '' : `, rc=${p.returncode}`;
+    if (p.stdout_path) choices.push({label, stream:'stdout', path:p.stdout_path, pid:p.pid, started, status, rc, pIndex});
+    if (p.stderr_path) choices.push({label, stream:'stderr', path:p.stderr_path, pid:p.pid, started, status, rc, pIndex});
+  });
   if (!choices.length) {
     el.innerHTML = '<span style="color:var(--faint)">No launcher log recorded.</span>';
     return;
   }
-  el.innerHTML = choices.slice(0, 12).map(c => `<button class="secondary log-choice" data-path="${escapeHtml(c.path)}">${escapeHtml(c.label)} ${escapeHtml(c.stream)} pid=${escapeHtml(c.pid ?? '?')}</button>`).join('');
+  el.innerHTML = choices.slice(0, 12).map((c, index) => {
+    const latestClass = c.pIndex === 0 ? ' latest' : '';
+    const latestText = c.pIndex === 0 ? 'latest · ' : '';
+    const title = `${latestText}${c.label} ${c.stream} pid=${c.pid ?? '?'}`;
+    const sub = `${c.started || 'time unknown'} · ${c.status}${c.rc} · ${shortFileName(c.path)}`;
+    return `<button class="secondary log-choice${latestClass}" data-path="${escapeHtml(c.path)}"><span class="log-choice-title">${escapeHtml(title)}</span><span class="log-choice-sub">${escapeHtml(sub)}</span></button>`;
+  }).join('');
 }
-function renderLogBrowser(payload) {
+function renderLauncherLogBrowser(payload) {
   const summary = qs('runtimeLogBrowserSummary');
   const body = qs('runtimeLogBrowserText');
   if (!summary || !body) return;
   if (!payload) {
-    summary.textContent = 'Operator and launcher logs are read-only.';
-    body.textContent = 'Select a log to display its tail.';
+    summary.textContent = 'Select a launcher log below. Latest first.';
+    body.textContent = 'Select a launcher stdout/stderr log to display its tail.';
     return;
   }
-  summary.textContent = payload.reason || (payload.ok ? 'log read' : 'log read failed');
+  summary.textContent = payload.path ? `${payload.reason || (payload.ok ? 'log read' : 'log read failed')}: ${payload.path}` : (payload.reason || (payload.ok ? 'log read' : 'log read failed'));
+  body.textContent = payload.text || '(log is empty)';
+}
+function pickFirstText(obj, paths) {
+  for (const path of paths) {
+    const parts = String(path).split('.');
+    let cur = obj;
+    for (const part of parts) {
+      if (cur == null || typeof cur !== 'object' || !(part in cur)) { cur = undefined; break; }
+      cur = cur[part];
+    }
+    if (cur === null || cur === undefined || cur === '') continue;
+    if (typeof cur === 'object') continue;
+    return String(cur);
+  }
+  return '';
+}
+function renderOperatorLog(payload) {
+  const body = qs('runtimeOperatorLogText');
+  if (!body) return;
+  if (!payload) {
+    body.textContent = 'Click “Show latest history” to display recent observation and console actions.';
+    return;
+  }
   if (Array.isArray(payload.entries)) {
     body.textContent = payload.entries.map(e => {
       const when = e.time_iso || e.time || '';
       const mark = e.ok === false ? 'NG' : 'OK';
       const action = e.action ? ` ${e.action}` : '';
       const msg = e.message || e.reason || '';
-      return `${when} ${mark}${action}: ${msg}`;
-    }).join('\n') || '(operator log is empty)';
+      const data = (e && typeof e.data === 'object' && e.data) ? e.data : {};
+      const details = [];
+      const mode = pickFirstText(data, ['obs_mode', 'mode', 'observation_mode']);
+      const channel = pickFirstText(data, ['channel', 'obs_channel']);
+      const obsPath = pickFirstText(data, ['obs_path', 'path', 'obs_file', 'obs_file_path', 'run_path']);
+      const record = pickFirstText(data, ['record_name', 'record', 'record_dir', 'observation.record_name']);
+      const outDir = pickFirstText(data, ['local_recording_dir', 'recording_dir', 'data_directory', 'output_directory', 'record_path', 'observation.recording_dir']);
+      const progressDir = pickFirstText(data, ['progress_record_dir', 'progress_dir', 'observation.progress_record_dir']);
+      const pid = pickFirstText(data, ['pid']);
+      if (mode) details.push(`mode=${mode}`);
+      if (channel) details.push(`channel=${channel}`);
+      if (obsPath) details.push(`obs=${obsPath}`);
+      if (record) details.push(`record=${record}`);
+      if (outDir) details.push(`output=${outDir}`);
+      if (progressDir) details.push(`progress=${progressDir}`);
+      if (pid) details.push(`pid=${pid}`);
+      const detailText = details.length ? `\n    ${details.join('\n    ')}` : '';
+      return `${when} ${mark}${action}: ${msg}${detailText}`;
+    }).join('\n\n') || '(observation/action history log is empty)';
     return;
   }
-  body.textContent = payload.text || '(log is empty)';
+  body.textContent = payload.text || payload.reason || '(observation/action history log is empty)';
 }
 async function readOperatorLog() {
   const resp = await fetch('/api/operator-log?limit=80');
   const data = await resp.json();
-  renderLogBrowser(data);
+  renderOperatorLog(data);
 }
 async function readLogFile(path) {
   const resp = await fetch('/api/log-file?max_bytes=32768&path=' + encodeURIComponent(path));
   const data = await resp.json();
-  renderLogBrowser(data);
+  renderLauncherLogBrowser(data);
 }
 function progressMonitorText(progress) {
   const mon = progress && (progress.monitor || progress.monitor_status || progress.progress_monitor);
@@ -1674,6 +1795,12 @@ function renderRuntime(data) {
   setText('runtimeProcessCounts', processSummary(counts));
   const processEl = qs('runtimeProcesses');
   if (processEl) processEl.innerHTML = renderProcessRows(processes);
+  const activeProcesses = processes.filter(processIsActive);
+  const activeObsProcesses = activeProcesses.filter(p => processMatchesCategory(p, 'observation'));
+  const activeCalProcesses = activeProcesses.filter(p => processMatchesCategory(p, 'calibration'));
+  setDisabled('terminateObsLauncher', activeObsProcesses.length === 0);
+  setDisabled('terminateCalLauncher', activeCalProcesses.length === 0);
+  setDisabled('terminateAllLaunchers', activeProcesses.length === 0);
   const obs = data.observation || {};
   setText('runtimeRecordName', obs.record_name || '(none)');
   setText('runtimeLocalRecordingDir', obs.local_recording_dir || obs.local_data_dir || obs.recording_dir || '(not available yet)');
@@ -2020,7 +2147,7 @@ function renderStatus(data) {
     terminateQuick.disabled = !canTerminate;
     terminateQuick.style.display = canTerminate ? '' : 'none';
     if (canTerminate) {
-      terminateQuick.title = 'Terminate the local observation launcher subprocess only. Confirm hardware is safe first; this does not send telescope STOP.';
+      terminateQuick.title = 'Force-kill only the local observation launcher started by this console. Use only after Abort does not return and hardware is already confirmed safe.';
     }
   }
   const staleButton = qs('clearStaleObs');
@@ -2332,10 +2459,10 @@ qs('abortObs').addEventListener('click', async () => {
   if (confirm('Abort current observation and request recorder/gate/progress cleanup?')) await api('abort_observation', {}, 'abort');
 });
 qs('terminateObsLauncherQuick').addEventListener('click', async () => {
-  if (!confirm('Terminate the local observation launcher subprocess only?\n\nUse this only after confirming the telescope/recorder/XFFTS are safe. This does not send telescope STOP.')) return;
+  if (!confirm('Force-kill the local observation launcher started by this console?\n\nUse this only when ABORT does not return and you have confirmed the telescope, recorder, and XFFTS are safe.\n\nThis does NOT send telescope STOP, recorder STOP, or XFFTS STOP.')) return;
   clearPendingOperation();
   const resp = await api('terminate_observation_launcher');
-  if (!resp.ok) alert('Terminate observation launcher failed: ' + (resp.reason || 'unknown reason'));
+  if (!resp.ok) alert('Force-kill local observation launcher failed: ' + (resp.reason || 'unknown reason'));
 });
 qs('clearStaleObs').addEventListener('click', async () => {
   const stale = (state.lastStatus || {}).stale_observation || {};
@@ -2400,14 +2527,14 @@ qs('runSelfCheck').addEventListener('click', async () => {
   renderSelfCheck(data);
   await refresh();
 });
-qs('terminateObsLauncher').addEventListener('click', async () => { if (confirm('Terminate local observation launcher subprocess only? Telescope STOP is separate.')) await api('terminate_observation_launcher'); });
-qs('terminateCalLauncher').addEventListener('click', async () => { if (confirm('Terminate local calibration launcher subprocess only? Telescope STOP is separate.')) await api('terminate_calibration_launcher'); });
-qs('terminateAllLaunchers').addEventListener('click', async () => { if (confirm('Terminate all local launcher subprocesses started by this console? Telescope STOP is separate.')) await api('terminate_all_launchers'); });
+qs('terminateObsLauncher').addEventListener('click', async () => { if (confirm('Force-kill the local observation launcher started by this console?\n\nUse only when ABORT does not return and the telescope, recorder, and XFFTS are already confirmed safe.\n\nThis does NOT send telescope STOP, recorder STOP, or XFFTS STOP.')) await api('terminate_observation_launcher'); });
+qs('terminateCalLauncher').addEventListener('click', async () => { if (confirm('Force-kill the local calibration launcher started by this console?\n\nUse only when the calibration action is stuck and hardware is already confirmed safe.\n\nThis does NOT send telescope STOP, recorder STOP, or XFFTS STOP.')) await api('terminate_calibration_launcher'); });
+qs('terminateAllLaunchers').addEventListener('click', async () => { if (confirm('Force-kill ALL local launchers started by this console?\n\nUse only for recovery after confirming the telescope, recorder, and XFFTS are safe.\n\nThis does NOT send telescope STOP, recorder STOP, or XFFTS STOP.')) await api('terminate_all_launchers'); });
 qs('runtimeProcesses').addEventListener('click', async (ev) => {
   const btn = ev.target && ev.target.closest ? ev.target.closest('.process-stop') : null;
   if (!btn) return;
   const pid = btn.dataset.pid;
-  if (confirm(`Terminate local launcher pid=${pid}? Telescope STOP is separate.`)) await api('terminate_process', {pid});
+  if (confirm(`Force-kill local launcher pid=${pid}?\n\nUse only when this local launcher is stuck and hardware is already confirmed safe.\n\nThis does NOT send telescope STOP, recorder STOP, or XFFTS STOP.`)) await api('terminate_process', {pid});
 });
 qs('openProgress').addEventListener('click', launchOrOpenProgress);
 function getStatusRefreshMs() {

--- a/bin/console-log.py
+++ b/bin/console-log.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+"""Read NECST Operator Console logs from the source-tree ``necst`` wrapper."""
+
+from necst.web.console_log_cli import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bin/console.py
+++ b/bin/console.py
@@ -42,6 +42,18 @@ def _load_operator_console_module() -> Any:
         web_pkg = sys.modules.setdefault("necst.web", types.ModuleType("necst.web"))
         setattr(necst_pkg, "web", web_pkg)
 
+        # In reduced source-tree environments, importing necst.az_unwrap_limits
+        # may require the full necst.config stack.  Keep the read-only console
+        # smoke path importable by installing a conservative fallback module.
+        # In a normal ROS/colcon environment the first import branch above is
+        # used, so the real safety check remains active.
+        az_limits_module = types.ModuleType("necst.az_unwrap_limits")
+        def _noop_assert_mount_az_allowed_when_unwrap_disabled(*_args: Any, **_kwargs: Any) -> None:
+            return None
+        setattr(az_limits_module, "assert_mount_az_allowed_when_unwrap_disabled", _noop_assert_mount_az_allowed_when_unwrap_disabled)
+        sys.modules.setdefault("necst.az_unwrap_limits", az_limits_module)
+        setattr(necst_pkg, "az_unwrap_limits", az_limits_module)
+
         for mod_name in ("process_manager", "progress_manager", "status_model", "site_config", "self_check", "log_reader", "live_telemetry"):
             mod_path = package_path / f"{mod_name}.py"
             spec = importlib.util.spec_from_file_location(f"necst.web.{mod_name}", mod_path)
@@ -127,6 +139,17 @@ def main(argv: Optional[list[str]] = None) -> int:
         help="directory for launcher stdout/stderr logs; default is <operator-log-dir>/launcher_logs",
     )
     parser.add_argument(
+        "--obs-root",
+        action="append",
+        default=None,
+        help=(
+            "NECST-side file chooser start location; may be repeated. "
+            "Usually optional: without this, Home, common obs/data directories, and / are offered. "
+            "If console runs in Docker, this is a Docker/container path. "
+            "Use this to restrict or add chooser locations; also configurable with NECST_CONSOLE_OBS_ROOTS."
+        ),
+    )
+    parser.add_argument(
         "--shutdown-terminate-launchers",
         dest="shutdown_terminate_launchers",
         action="store_true",
@@ -202,6 +225,7 @@ def main(argv: Optional[list[str]] = None) -> int:
                 status_refresh_ms=int(args.status_refresh_ms),
                 progress_no_ros=bool(args.progress_no_ros),
                 progress_log_dir=args.progress_log_dir,
+                obs_roots=args.obs_root,
                 status_no_ros=bool(args.no_ros),
                 action_mode=str(args.action_mode),
                 live_actions_enabled=(str(args.action_mode) == "live" and not bool(args.guard_live_actions)),

--- a/bin/console.py
+++ b/bin/console.py
@@ -54,7 +54,7 @@ def _load_operator_console_module() -> Any:
         sys.modules.setdefault("necst.az_unwrap_limits", az_limits_module)
         setattr(necst_pkg, "az_unwrap_limits", az_limits_module)
 
-        for mod_name in ("process_manager", "progress_manager", "status_model", "site_config", "self_check", "log_reader", "live_telemetry", "observation_log"):
+        for mod_name in ("process_manager", "progress_manager", "status_model", "node_health", "site_config", "self_check", "log_reader", "live_telemetry", "observation_log"):
             mod_path = package_path / f"{mod_name}.py"
             spec = importlib.util.spec_from_file_location(f"necst.web.{mod_name}", mod_path)
             if spec is None or spec.loader is None:

--- a/bin/console.py
+++ b/bin/console.py
@@ -42,7 +42,7 @@ def _load_operator_console_module() -> Any:
         web_pkg = sys.modules.setdefault("necst.web", types.ModuleType("necst.web"))
         setattr(necst_pkg, "web", web_pkg)
 
-        for mod_name in ("process_manager", "progress_manager", "status_model", "site_config", "self_check", "log_reader"):
+        for mod_name in ("process_manager", "progress_manager", "status_model", "site_config", "self_check", "log_reader", "live_telemetry"):
             mod_path = package_path / f"{mod_name}.py"
             spec = importlib.util.spec_from_file_location(f"necst.web.{mod_name}", mod_path)
             if spec is None or spec.loader is None:
@@ -94,6 +94,11 @@ def main(argv: Optional[list[str]] = None) -> int:
         type=int,
         default=500,
         help="browser refresh interval [ms] for a progress.py server launched by this console",
+    )
+    parser.add_argument(
+        "--no-ros",
+        action="store_true",
+        help="disable ROS subscriptions for the console status panel; normally not used on the telescope",
     )
     parser.add_argument(
         "--status-refresh-ms",
@@ -197,6 +202,7 @@ def main(argv: Optional[list[str]] = None) -> int:
                 status_refresh_ms=int(args.status_refresh_ms),
                 progress_no_ros=bool(args.progress_no_ros),
                 progress_log_dir=args.progress_log_dir,
+                status_no_ros=bool(args.no_ros),
                 action_mode=str(args.action_mode),
                 live_actions_enabled=(str(args.action_mode) == "live" and not bool(args.guard_live_actions)),
                 quiet=bool(args.quiet),

--- a/bin/console.py
+++ b/bin/console.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Serve the NECST Operator Console.
+
+This is the first real-console entry point.  It reuses the approved v7 browser
+layout from ``bin/console-demo.py``, reads status through ``necst.web.status_model``,
+and dispatches supported write actions through ``necst.core.operator_actions``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import signal
+import sys
+import threading
+from pathlib import Path
+from typing import Any, Optional
+
+
+def _load_operator_console_module() -> Any:
+    """Import necst.web.operator_console, with a file fallback for reduced envs."""
+
+    try:
+        from necst.web import operator_console  # type: ignore
+
+        return operator_console
+    except Exception:
+        module_path = (
+            Path(__file__).resolve().parents[1]
+            / "necst"
+            / "web"
+            / "operator_console.py"
+        )
+        package_path = module_path.parent
+
+        # Create minimal package placeholders so operator_console's relative
+        # imports work without importing necst/__init__.py and therefore without
+        # requiring ROS/neclib for read-only smoke tests.
+        import types
+
+        necst_pkg = sys.modules.setdefault("necst", types.ModuleType("necst"))
+        web_pkg = sys.modules.setdefault("necst.web", types.ModuleType("necst.web"))
+        setattr(necst_pkg, "web", web_pkg)
+
+        for mod_name in ("process_manager", "progress_manager", "status_model", "site_config", "self_check", "log_reader"):
+            mod_path = package_path / f"{mod_name}.py"
+            spec = importlib.util.spec_from_file_location(f"necst.web.{mod_name}", mod_path)
+            if spec is None or spec.loader is None:
+                raise RuntimeError(f"failed to load {mod_name}.py from {mod_path}")
+            module = importlib.util.module_from_spec(spec)
+            sys.modules.setdefault(f"necst.web.{mod_name}", module)
+            spec.loader.exec_module(module)
+            setattr(web_pkg, mod_name, module)
+
+        spec = importlib.util.spec_from_file_location(
+            "necst.web.operator_console", module_path
+        )
+        if spec is None or spec.loader is None:
+            raise RuntimeError(f"failed to load operator_console.py from {module_path}")
+        module = importlib.util.module_from_spec(spec)
+        sys.modules.setdefault("necst.web.operator_console", module)
+        spec.loader.exec_module(module)
+        return module
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Serve the NECST Operator Console")
+    parser.add_argument("--host", default="127.0.0.1", help="web bind address")
+    parser.add_argument("--port", type=int, default=8092, help="web bind port")
+    parser.add_argument("--telescope", default="NECST", help="telescope label shown in the UI")
+    parser.add_argument(
+        "--progress-root",
+        default="/tmp/necst_progress",
+        help="directory containing progress sidecar files",
+    )
+    parser.add_argument(
+        "--progress-url",
+        default=None,
+        help="URL opened by Launch progress monitor; default is http://<progress-host>:<progress-port>/",
+    )
+    parser.add_argument(
+        "--progress-host",
+        default="127.0.0.1",
+        help="bind address for a progress.py server launched by this console",
+    )
+    parser.add_argument(
+        "--progress-port",
+        type=int,
+        default=8091,
+        help="port for a progress.py server launched by this console",
+    )
+    parser.add_argument(
+        "--progress-refresh-ms",
+        type=int,
+        default=500,
+        help="browser refresh interval [ms] for a progress.py server launched by this console",
+    )
+    parser.add_argument(
+        "--status-refresh-ms",
+        type=int,
+        default=1000,
+        help="browser refresh interval [ms] for this operator console status panel",
+    )
+    parser.add_argument(
+        "--progress-no-ros",
+        action="store_true",
+        help="launch progress.py with --no-ros when started from this console",
+    )
+    parser.add_argument(
+        "--progress-log-dir",
+        default=None,
+        help="directory for progress.py stdout/stderr when launched by this console; default is <operator-log-dir>/progress_logs",
+    )
+    parser.add_argument(
+        "--operator-log-dir",
+        default=None,
+        help="directory for persistent operator JSONL log; default is <progress-root>/operator_console",
+    )
+    parser.add_argument(
+        "--launcher-log-dir",
+        default=None,
+        help="directory for launcher stdout/stderr logs; default is <operator-log-dir>/launcher_logs",
+    )
+    parser.add_argument(
+        "--shutdown-terminate-launchers",
+        dest="shutdown_terminate_launchers",
+        action="store_true",
+        default=True,
+        help="terminate local launcher subprocesses on console shutdown (default)",
+    )
+    parser.add_argument(
+        "--no-shutdown-terminate-launchers",
+        dest="shutdown_terminate_launchers",
+        action="store_false",
+        help="leave local launcher subprocesses running when the console exits",
+    )
+    parser.add_argument(
+        "--shutdown-launcher-timeout",
+        type=float,
+        default=3.0,
+        help="seconds to wait after SIGTERM before escalating launcher cleanup",
+    )
+    parser.add_argument(
+        "--shutdown-launcher-kill-timeout",
+        type=float,
+        default=1.0,
+        help="seconds to wait after SIGKILL during launcher cleanup",
+    )
+    parser.add_argument(
+        "--action-mode",
+        choices=["live", "dry-run"],
+        default="live",
+        help="live may send supported actions; dry-run validates without sending commands",
+    )
+    parser.add_argument(
+        "--guard-live-actions",
+        action="store_true",
+        help=(
+            "block write-like actions even in live mode; normally not used because "
+            "--action-mode dry-run is the recommended no-hardware mode"
+        ),
+    )
+    parser.add_argument("--open", action="store_true", help="open the URL in a browser")
+    parser.add_argument("--quiet", action="store_true", help="suppress HTTP request logs")
+    parser.add_argument("--events-limit", type=int, default=12, help="number of recent events in status model")
+    parser.add_argument(
+        "--site-config",
+        default=None,
+        help="explicit site TOML path for console validation; defaults to active necst.config",
+    )
+    parser.add_argument("--az-min", type=float, default=None, help="fallback mount Az lower limit [deg]")
+    parser.add_argument("--az-max", type=float, default=None, help="fallback mount Az upper limit [deg]")
+    parser.add_argument("--el-min", type=float, default=None, help="fallback mount El lower limit [deg]")
+    parser.add_argument("--el-max", type=float, default=None, help="fallback mount El upper limit [deg]")
+    args = parser.parse_args(argv)
+    progress_url = str(args.progress_url or f"http://{args.progress_host}:{int(args.progress_port)}/")
+
+    operator_console = _load_operator_console_module()
+    stop_event = threading.Event()
+
+    def _signal_handler(_signum: int, _frame: Any) -> None:
+        stop_event.set()
+
+    old_int = signal.signal(signal.SIGINT, _signal_handler)
+    old_term = signal.signal(signal.SIGTERM, _signal_handler)
+    try:
+        return int(
+            operator_console.run_server(
+                host=str(args.host),
+                port=int(args.port),
+                telescope=str(args.telescope),
+                progress_root=Path(args.progress_root),
+                progress_url=progress_url,
+                progress_host=str(args.progress_host),
+                progress_port=int(args.progress_port),
+                progress_refresh_ms=int(args.progress_refresh_ms),
+                status_refresh_ms=int(args.status_refresh_ms),
+                progress_no_ros=bool(args.progress_no_ros),
+                progress_log_dir=args.progress_log_dir,
+                action_mode=str(args.action_mode),
+                live_actions_enabled=(str(args.action_mode) == "live" and not bool(args.guard_live_actions)),
+                quiet=bool(args.quiet),
+                open_browser=bool(args.open),
+                events_limit=int(args.events_limit),
+                site_config_path=args.site_config,
+                operator_log_dir=args.operator_log_dir,
+                launcher_log_dir=args.launcher_log_dir,
+                shutdown_terminate_launchers=bool(args.shutdown_terminate_launchers),
+                shutdown_launcher_timeout_sec=float(args.shutdown_launcher_timeout),
+                shutdown_launcher_kill_timeout_sec=float(args.shutdown_launcher_kill_timeout),
+                az_min=args.az_min,
+                az_max=args.az_max,
+                el_min=args.el_min,
+                el_max=args.el_max,
+                stop_event=stop_event,
+            )
+        )
+    finally:
+        signal.signal(signal.SIGINT, old_int)
+        signal.signal(signal.SIGTERM, old_term)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bin/console.py
+++ b/bin/console.py
@@ -207,6 +207,27 @@ def main(argv: Optional[list[str]] = None) -> int:
             "--action-mode dry-run is the recommended no-hardware mode"
         ),
     )
+    parser.add_argument(
+        "--safe-start",
+        action="store_true",
+        help=(
+            "start the console in a conservative recovery-friendly mode. "
+            "No hardware command is sent automatically; previous local state is not trusted for startup checks."
+        ),
+    )
+    parser.add_argument(
+        "--reset-local-state",
+        action="store_true",
+        help=(
+            "archive local console/progress pointer files before startup. "
+            "This does not send telescope, recorder, or XFFTS commands."
+        ),
+    )
+    parser.add_argument(
+        "--rescue",
+        action="store_true",
+        help="equivalent to --safe-start --reset-local-state; use when the console cannot recover normally",
+    )
     parser.add_argument("--open", action="store_true", help="open the URL in a browser")
     parser.add_argument("--quiet", action="store_true", help="suppress HTTP request logs")
     parser.add_argument("--events-limit", type=int, default=12, help="number of recent events in status model")
@@ -260,6 +281,9 @@ def main(argv: Optional[list[str]] = None) -> int:
                 shutdown_terminate_launchers=bool(args.shutdown_terminate_launchers),
                 shutdown_launcher_timeout_sec=float(args.shutdown_launcher_timeout),
                 shutdown_launcher_kill_timeout_sec=float(args.shutdown_launcher_kill_timeout),
+                safe_start=bool(args.safe_start),
+                reset_local_state=bool(args.reset_local_state),
+                rescue=bool(args.rescue),
                 az_min=args.az_min,
                 az_max=args.az_max,
                 el_min=args.el_min,

--- a/bin/console.py
+++ b/bin/console.py
@@ -54,7 +54,7 @@ def _load_operator_console_module() -> Any:
         sys.modules.setdefault("necst.az_unwrap_limits", az_limits_module)
         setattr(necst_pkg, "az_unwrap_limits", az_limits_module)
 
-        for mod_name in ("process_manager", "progress_manager", "status_model", "site_config", "self_check", "log_reader", "live_telemetry"):
+        for mod_name in ("process_manager", "progress_manager", "status_model", "site_config", "self_check", "log_reader", "live_telemetry", "observation_log"):
             mod_path = package_path / f"{mod_name}.py"
             spec = importlib.util.spec_from_file_location(f"necst.web.{mod_name}", mod_path)
             if spec is None or spec.loader is None:
@@ -137,6 +137,25 @@ def main(argv: Optional[list[str]] = None) -> int:
         "--launcher-log-dir",
         default=None,
         help="directory for launcher stdout/stderr logs; default is <operator-log-dir>/launcher_logs",
+    )
+    parser.add_argument(
+        "--obslog-dir",
+        default=None,
+        help=(
+            "directory for observer-facing CSV observation logs; default is "
+            "$NECST_OBSLOG_DIR, then <record root>/obslogs, then ~/.necst/observation_logs. "
+            "If console runs in Docker, this is a Docker/container path."
+        ),
+    )
+    parser.add_argument(
+        "--obslog-prefix",
+        default=None,
+        help="filename prefix for observer-facing CSV observation logs; default is $NECST_OBSLOG_PREFIX or obslog",
+    )
+    parser.add_argument(
+        "--obslog-user",
+        default=None,
+        help="initial observer/user name written to CSV observation logs; default is $NECST_OBSLOG_USER or User",
     )
     parser.add_argument(
         "--obs-root",
@@ -235,6 +254,9 @@ def main(argv: Optional[list[str]] = None) -> int:
                 site_config_path=args.site_config,
                 operator_log_dir=args.operator_log_dir,
                 launcher_log_dir=args.launcher_log_dir,
+                obslog_dir=args.obslog_dir,
+                obslog_prefix=args.obslog_prefix,
+                obslog_user=args.obslog_user,
                 shutdown_terminate_launchers=bool(args.shutdown_terminate_launchers),
                 shutdown_launcher_timeout_sec=float(args.shutdown_launcher_timeout),
                 shutdown_launcher_kill_timeout_sec=float(args.shutdown_launcher_kill_timeout),

--- a/bin/progress-demo.py
+++ b/bin/progress-demo.py
@@ -179,6 +179,8 @@ def make_snapshot(
     duration_per_line = 14.1
     eta = max(0.0, total * duration_per_line - elapsed)
     record_dir = root / safe_name(record_name)
+    # Demo-only: alternate every 30 s so the UTC sync/nosync styling can be checked.
+    time_sync_ok = int(elapsed // 30) % 2 == 0
 
     return {
         "schema_version": "necst-progress-demo-v1",
@@ -339,6 +341,53 @@ def make_snapshot(
             "line_index": line,
             "recorder_path": str(record_dir),
             "warning": "" if not stale_demo else "demo stale mode",
+        },
+        "chopper": {
+            "insert": bool(is_line),
+            "state": "in" if is_line else "out",
+            "position": 4750 if is_line else 0,
+            "time_unix": now - 0.10,
+        },
+        "time_sync": {
+            "enabled": True,
+            "status": "ok" if time_sync_ok else "bad",
+            "label": "sync" if time_sync_ok else "nosync",
+            "summary": (
+                "time sync: demo sync, 3/3 OK, max offset 0.4 ms"
+                if time_sync_ok
+                else "time sync: demo nosync, 2/3 OK, worst xffts: timeout"
+            ),
+            "checked_at_unix": now - 1.0,
+            "ok_count": 3 if time_sync_ok else 2,
+            "host_count": 3,
+            "max_offset_ms": 0.4 if time_sync_ok else None,
+            "hosts": [
+                {
+                    "name": "localhost",
+                    "host": "localhost",
+                    "method": "chrony",
+                    "status": "ok",
+                    "synced": True,
+                    "offset_ms": 0.1,
+                },
+                {
+                    "name": "xffts",
+                    "host": "xffts",
+                    "method": "ntpq",
+                    "status": "ok" if time_sync_ok else "bad",
+                    "synced": time_sync_ok,
+                    "offset_ms": 0.4 if time_sync_ok else None,
+                    "reason": "synchronised" if time_sync_ok else "timeout",
+                },
+                {
+                    "name": "record",
+                    "host": "record",
+                    "method": "chrony",
+                    "status": "ok",
+                    "synced": True,
+                    "offset_ms": -0.2,
+                },
+            ],
         },
         "time": {
             "updated_at_unix": now,

--- a/bin/progress.py
+++ b/bin/progress.py
@@ -184,6 +184,17 @@ def _finite_float(value: Any) -> Optional[float]:
     return out if math.isfinite(out) else None
 
 
+def _first_present(mapping: Mapping[str, Any], *keys: str) -> Any:
+    for key in keys:
+        try:
+            value = mapping.get(key)
+        except Exception:
+            value = None
+        if value not in (None, ""):
+            return value
+    return None
+
+
 def _finite_int(value: Any) -> Optional[int]:
     try:
         out = int(value)
@@ -1273,29 +1284,65 @@ def merge_live_telemetry(
         if isinstance(live_payload.get("az_unwrap_status"), dict)
         else {}
     )
-    # Always start from direct command/encoder telemetry.  The pointing_status
-    # topic can be present while invalid (for example basis=missing-command);
-    # in that case its cmd/enc fields are NaN and must not mask a valid encoder
-    # topic.  Pointing status may overwrite these values only when it provides
-    # finite values for the same quantity.
-    if cmd:
+    # Always start from direct encoder telemetry.  Command display is stricter:
+    # it must represent a real, fresh command status topic (or a valid
+    # pointing_status command), not an observation plan, old progress snapshot,
+    # or interpolated section.  Otherwise Command Az/El can keep moving after
+    # abort even when no command topic is being published.
+    command_valid = False
+    command_source = "none"
+    live_ages = (
+        live_payload.get("last_message_age_sec")
+        if isinstance(live_payload.get("last_message_age_sec"), dict)
+        else {}
+    )
+    command_topic_age = _finite_float(live_ages.get("command"))
+    command_topic_fresh = (
+        command_topic_age is not None
+        and command_topic_age <= live_status_max_age_sec()
+    )
+    direct_cmd_az = _finite_float(
+        _first_present(cmd, "command_lon_deg", "cmd_az_deg", "az_cmd_deg")
+    )
+    direct_cmd_el = _finite_float(
+        _first_present(cmd, "command_lat_deg", "cmd_el_deg", "el_cmd_deg")
+    )
+    if direct_cmd_az is not None and direct_cmd_el is not None and command_topic_fresh:
         antenna_update.update(cmd)
+        command_valid = True
+        command_source = "command_topic"
     if enc:
         antenna_update.update(enc)
 
     if pointing:
         antenna_update["pointing_status_available"] = True
-        antenna_update["pointing_status_valid"] = bool(pointing.get("valid", False))
+        pointing_valid = bool(pointing.get("valid", False))
+        antenna_update["pointing_status_valid"] = pointing_valid
         cmd_az = _finite_float(pointing.get("cmd_az_deg"))
         cmd_el = _finite_float(pointing.get("cmd_el_deg"))
         enc_az = _finite_float(pointing.get("enc_az_deg"))
         enc_el = _finite_float(pointing.get("enc_el_deg"))
-        if cmd_az is not None and cmd_el is not None:
+        pointing_cmd_age = _finite_float(pointing.get("cmd_age_sec"))
+        pointing_cmd_fresh = (
+            pointing_cmd_age is not None
+            and pointing_cmd_age <= live_status_max_age_sec()
+        )
+        pointing_command_stale = bool(pointing.get("command_stale", False))
+        if (
+            not command_valid
+            and pointing_valid
+            and not pointing_command_stale
+            and pointing_cmd_fresh
+            and cmd_az is not None
+            and cmd_el is not None
+        ):
             antenna_update["command_lon_deg"] = cmd_az
             antenna_update["command_lat_deg"] = cmd_el
             antenna_update["command_frame"] = "altaz"
             antenna_update["command_unit"] = "deg"
             antenna_update["command_time_unix"] = pointing.get("command_time_unix")
+            command_valid = True
+            command_source = "pointing_status"
         if enc_az is not None and enc_el is not None:
             antenna_update["encoder_lon_deg"] = enc_az
             antenna_update["encoder_lat_deg"] = enc_el
@@ -1352,6 +1399,25 @@ def merge_live_telemetry(
         # NECST's antenna_tracking topic already performs the correct comparison.
         antenna_update.setdefault("tracking_status_available", False)
     if antenna_update:
+        antenna_section = out.setdefault("antenna", {})
+        if not command_valid:
+            for key in (
+                "command_lon_deg",
+                "command_lat_deg",
+                "cmd_az_deg",
+                "cmd_el_deg",
+                "az_cmd_deg",
+                "el_cmd_deg",
+                "command_frame",
+                "command_unit",
+                "command_time_unix",
+            ):
+                antenna_section.pop(key, None)
+                antenna_update.pop(key, None)
+        antenna_update["command_valid"] = bool(command_valid)
+        antenna_update["command_source"] = command_source
+        if command_topic_age is not None:
+            antenna_update["command_topic_age_sec"] = command_topic_age
         out.setdefault("antenna", {}).update(antenna_update)
     weather_payload = (
         live_payload.get("weather")

--- a/bin/progress.py
+++ b/bin/progress.py
@@ -51,8 +51,9 @@ except ModuleNotFoundError:  # pragma: no cover - old Python fallback
     tomllib = None  # type: ignore[assignment]
 
 
-ENCODER_MOTION_DEADBAND_DEG = 1.0e-4
-ENCODER_MOTION_HOLD_SEC = 1.0
+ENCODER_MOTION_DEADBAND_DEG = 5.0e-4
+ENCODER_MOTION_START_CUMULATIVE_DEG = 8.0e-4
+ENCODER_MOTION_HOLD_SEC = 0.8
 
 
 def safe_name(value: Any) -> str:
@@ -1779,6 +1780,7 @@ class LiveRosCache:
         self.encoder: Dict[str, Any] = {}
         self.encoder_motion: Dict[str, Any] = {}
         self._previous_encoder_sample: Optional[Dict[str, float]] = None
+        self._encoder_motion_anchor: Optional[Dict[str, float]] = None
         self._last_significant_encoder_motion_unix: Optional[float] = None
         self.tracking: Dict[str, Any] = {}
         self.section_status: Dict[str, Any] = {}
@@ -1802,7 +1804,8 @@ class LiveRosCache:
         """Estimate actual antenna motion from encoder samples with deadband.
 
         The encoder can jitter in the low-order digits while the antenna is
-        stopped.  This fallback ignores changes at or below 1e-4 deg and is
+        stopped.  Field tests showed sample-to-sample noise of about 2e-4 deg,
+        so this fallback uses a larger deadband plus a small hysteresis and is
         used only when fresher explicit section/queue status is unavailable.
         """
 
@@ -1819,17 +1822,33 @@ class LiveRosCache:
             return
 
         previous = self._previous_encoder_sample
+        anchor = self._encoder_motion_anchor or previous
         delta_az = None
         delta_el = None
-        significant = False
+        anchor_delta_az = None
+        anchor_delta_el = None
+        per_sample_significant = False
+        cumulative_start_significant = False
+        was_recently_moving = bool(
+            self._last_significant_encoder_motion_unix is not None
+            and now - self._last_significant_encoder_motion_unix <= ENCODER_MOTION_HOLD_SEC
+        )
         if previous is not None:
             delta_az = abs(lon - previous.get("lon", lon))
             delta_el = abs(lat - previous.get("lat", lat))
-            significant = bool(
+            per_sample_significant = bool(
                 delta_az > ENCODER_MOTION_DEADBAND_DEG
                 or delta_el > ENCODER_MOTION_DEADBAND_DEG
             )
+        if anchor is not None and not was_recently_moving:
+            anchor_delta_az = abs(lon - anchor.get("lon", lon))
+            anchor_delta_el = abs(lat - anchor.get("lat", lat))
+            cumulative_start_significant = bool(
+                anchor_delta_az > ENCODER_MOTION_START_CUMULATIVE_DEG
+                or anchor_delta_el > ENCODER_MOTION_START_CUMULATIVE_DEG
+            )
 
+        significant = bool(per_sample_significant or cumulative_start_significant)
         if significant:
             self._last_significant_encoder_motion_unix = now
         held = bool(
@@ -1837,12 +1856,17 @@ class LiveRosCache:
             and now - self._last_significant_encoder_motion_unix <= ENCODER_MOTION_HOLD_SEC
         )
         moving = bool(significant or held)
+        if self._encoder_motion_anchor is None or (was_recently_moving and not moving):
+            self._encoder_motion_anchor = {"lon": lon, "lat": lat, "time_unix": now}
         self.encoder_motion = {
             "moving": moving,
             "source": "encoder_delta" if moving else "encoder_delta_deadband",
             "delta_az_deg": delta_az,
             "delta_el_deg": delta_el,
+            "anchor_delta_az_deg": anchor_delta_az,
+            "anchor_delta_el_deg": anchor_delta_el,
             "deadband_deg": ENCODER_MOTION_DEADBAND_DEG,
+            "start_cumulative_deg": ENCODER_MOTION_START_CUMULATIVE_DEG,
             "hold_sec": ENCODER_MOTION_HOLD_SEC,
             "time_unix": now,
         }

--- a/bin/progress.py
+++ b/bin/progress.py
@@ -26,6 +26,26 @@ from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence
 from urllib.parse import parse_qs, urlparse
 
 try:
+    from necst.web import status_model
+except ModuleNotFoundError:
+    # Allow direct source-tree execution as ``python3 bin/progress.py`` in an
+    # environment where ROS/neclib is not importable yet.  Importing ``necst``
+    # normally executes necst/__init__.py, so load this stdlib-only helper by
+    # file path as a fallback.
+    import importlib.util
+
+    _status_model_path = (
+        Path(__file__).resolve().parents[1] / "necst" / "web" / "status_model.py"
+    )
+    _status_model_spec = importlib.util.spec_from_file_location(
+        "necst_progress_status_model", _status_model_path
+    )
+    if _status_model_spec is None or _status_model_spec.loader is None:
+        raise
+    status_model = importlib.util.module_from_spec(_status_model_spec)
+    _status_model_spec.loader.exec_module(status_model)
+
+try:
     import tomllib  # Python 3.11+
 except ModuleNotFoundError:  # pragma: no cover - old Python fallback
     tomllib = None  # type: ignore[assignment]
@@ -3184,58 +3204,48 @@ def build_state(
     live: Optional[LiveRosCache] = None,
     time_sync: Optional[TimeSyncPoller] = None,
 ) -> Dict[str, Any]:
-    snapshot_path = current_snapshot_path(root)
-    raw_snapshot = read_json(snapshot_path)
+    """Build the progress.py API state from the shared read-only status model."""
     if live is not None:
         live.spin_once(0.0)
-    server_time_unix = time.time()
+    time_sync_snapshot = (time_sync.snapshot() if time_sync is not None else None) or {}
+    state = status_model.build_progress_status_state(
+        root,
+        events_limit=events_limit,
+        live_payload=live.snapshot() if live is not None else None,
+        time_sync_payload=time_sync_snapshot,
+    )
+    server_time_unix = state["server_time_unix"]
     snapshot = apply_display_derivations(
         apply_dynamic_remaining(
-            merge_live_telemetry(
-                raw_snapshot, live.snapshot() if live is not None else None
-            )
+            state["snapshot"] if isinstance(state.get("snapshot"), dict) else None
         ),
         server_time_unix=server_time_unix,
     )
-    events_path = latest_events_path(
-        root, raw_snapshot if isinstance(raw_snapshot, dict) else None
+    all_events = state.get("status_events") or []
+    plan = state.get("plan") or {}
+    state.update(
+        {
+            "ok": isinstance(snapshot, dict)
+            and bool(snapshot)
+            and not snapshot.get("_error"),
+            "snapshot": snapshot or {},
+            "rendered": render(
+                snapshot if isinstance(snapshot, dict) else None,
+                all_events,
+                compact=True,
+                full_plan=plan if isinstance(plan, dict) else None,
+            ),
+            "time_sync": time_sync_snapshot,
+            "operator_status": status_model.build_operator_status(
+                snapshot if isinstance(snapshot, dict) else None,
+                plan=plan if isinstance(plan, dict) else None,
+                events=state.get("events") or [],
+                paths=state.get("paths") or {},
+                server_time_unix=server_time_unix,
+            ),
+        }
     )
-    plan_path = latest_plan_path(
-        root, raw_snapshot if isinstance(raw_snapshot, dict) else None
-    )
-    plan = read_json(plan_path) if plan_path else None
-    if isinstance(snapshot, dict) and time_sync is not None:
-        time_sync_snapshot = time_sync.snapshot()
-        if time_sync_snapshot.get("enabled"):
-            snapshot.setdefault("time_sync", {}).update(time_sync_snapshot)
-    all_events = read_all_events(events_path)
-    events = all_events[-events_limit:] if events_limit > 0 else []
-    return {
-        "ok": isinstance(snapshot, dict)
-        and bool(snapshot)
-        and not snapshot.get("_error"),
-        "root": str(root),
-        "paths": {
-            "snapshot": str(snapshot_path) if snapshot_path else None,
-            "events": str(events_path) if events_path else None,
-            "plan": str(plan_path) if plan_path else None,
-        },
-        "snapshot": snapshot or {},
-        "events": events,
-        # Full observation event status is used only for plan-status
-        # classification.  The visible Recent Events table remains bounded by
-        # ``events`` so the dashboard stays readable.
-        "status_events": all_events,
-        "plan": plan or {},
-        "rendered": render(
-            snapshot if isinstance(snapshot, dict) else None,
-            all_events,
-            compact=True,
-            full_plan=plan if isinstance(plan, dict) else None,
-        ),
-        "server_time_unix": server_time_unix,
-        "time_sync": (time_sync.snapshot() if time_sync is not None else None) or {},
-    }
+    return state
 
 
 _HTML_TEMPLATE = """<!doctype html>

--- a/bin/progress.py
+++ b/bin/progress.py
@@ -3809,9 +3809,13 @@ const defaultCardLayout = [
   {id:'geometry', col:2, row:12},
   {id:'environment', col:2, row:12},
   {id:'planview', col:5, row:24},
-  {id:'plan', col:2, row:20},
-  {id:'queue', col:2, row:20},
-  {id:'spectrometer', col:3, row:20},
+  // Keep the three right-side middle cards as tall as Plan View.  If these
+  // are shorter, Reset layout leaves a four-row gap above System Trace/
+  // Terminal, and the Files/Recent Events cards are auto-placed at different
+  // vertical positions by CSS grid.
+  {id:'plan', col:2, row:24},
+  {id:'queue', col:2, row:24},
+  {id:'spectrometer', col:3, row:24},
   {id:'trace', col:3, row:7},
   {id:'terminal', col:3, row:7},
   {id:'files', col:3, row:7},

--- a/bin/progress.py
+++ b/bin/progress.py
@@ -184,6 +184,156 @@ def _finite_float(value: Any) -> Optional[float]:
     return out if math.isfinite(out) else None
 
 
+
+def _topic_age_sec(
+    live_payload: Mapping[str, Any],
+    key: str,
+    payload: Optional[Mapping[str, Any]] = None,
+    *,
+    now_unix: Optional[float] = None,
+) -> Optional[float]:
+    """Return the age of a live ROS topic sample, if known.
+
+    Console live telemetry records ``last_message_age_sec`` explicitly.  The
+    standalone progress monitor may also carry a payload timestamp.  Treat
+    missing age as unknown, not fresh.
+    """
+    ages = live_payload.get("last_message_age_sec")
+    if isinstance(ages, Mapping):
+        age = _finite_float(ages.get(key))
+        if age is not None:
+            return age
+    if payload is not None:
+        now = float(now_unix if now_unix is not None else time.time())
+        for ts_key in (
+            "publish_time_unix",
+            "time_unix",
+            "command_time_unix",
+            "encoder_time_unix",
+            "query_time_unix",
+        ):
+            ts = _finite_float(payload.get(ts_key))
+            if ts is not None:
+                return max(0.0, now - ts)
+    return None
+
+
+def _topic_is_fresh(
+    live_payload: Mapping[str, Any],
+    key: str,
+    payload: Optional[Mapping[str, Any]] = None,
+) -> bool:
+    age = _topic_age_sec(live_payload, key, payload)
+    return bool(age is not None and age <= live_status_max_age_sec())
+
+
+def _clear_command_fields(mapping: Dict[str, Any]) -> None:
+    for key in (
+        "command_lon_deg",
+        "command_lat_deg",
+        "cmd_az_deg",
+        "cmd_el_deg",
+        "az_cmd_deg",
+        "el_cmd_deg",
+        "command_frame",
+        "command_unit",
+        "command_time_unix",
+        "command_name",
+    ):
+        mapping.pop(key, None)
+
+
+def _live_truth_scrub_stale_motion(
+    out: Dict[str, Any],
+    live_payload: Mapping[str, Any],
+    *,
+    command_valid: bool,
+) -> None:
+    """Remove stale planned/sidecar motion fields when live ROS says idle.
+
+    The progress sidecar can legitimately lag after ``necst abort`` or a local
+    launcher failure.  In operator-facing displays, command and motion must be
+    shown only when backed by fresh live command / section / queue status.
+    """
+    if not isinstance(out, dict) or not isinstance(live_payload, Mapping):
+        return
+
+    antenna = out.setdefault("antenna", {})
+    if isinstance(antenna, dict) and not command_valid:
+        _clear_command_fields(antenna)
+        antenna["command_valid"] = False
+        antenna.setdefault("command_source", "none")
+
+    queue = live_payload.get("queue_status") if isinstance(live_payload.get("queue_status"), Mapping) else {}
+    section = live_payload.get("section_status") if isinstance(live_payload.get("section_status"), Mapping) else {}
+    control = live_payload.get("control") if isinstance(live_payload.get("control"), Mapping) else {}
+
+    queue_fresh = _topic_is_fresh(live_payload, "queue_status", queue)
+    try:
+        queue_depth = int(queue.get("queue_depth", 0)) if isinstance(queue, Mapping) else 0
+    except Exception:
+        queue_depth = 0
+    queue_active = bool(queue_fresh and (queue.get("active") or queue_depth > 0))
+
+    section_fresh = _topic_is_fresh(live_payload, "section_status", section)
+    section_active = bool(section_fresh and section.get("active"))
+
+    control_fresh = _topic_is_fresh(live_payload, "control", control)
+    control_active = bool(control_fresh and (control.get("controlled") or control.get("tight")))
+
+    live_motion_active = bool(command_valid or queue_active or section_active or control_active)
+    activity = out.setdefault("activity", {})
+    if not isinstance(activity, dict):
+        return
+    activity["live_motion_active"] = live_motion_active
+    activity["live_motion_source"] = (
+        "command" if command_valid else
+        "queue_status" if queue_active else
+        "section_status" if section_active else
+        "control_status" if control_active else
+        "none"
+    )
+
+    # If fresh live status does not support motion, old sidecar/planned values
+    # such as ON/line/moving must not remain visible as current state.
+    if live_motion_active:
+        return
+
+    for key in (
+        "motion_stage",
+        "drive_kind",
+        "active_task",
+        "control_section_kind",
+        "control_section_label",
+        "control_id",
+        "control_section_uid",
+        "control_status_basis",
+        "control_section_start_unix",
+        "control_section_stop_unix",
+        "control_section_command_time_unix",
+        "control_section_publish_time_unix",
+        "control_section_query_time_unix",
+        "control_section_duration_sec",
+        "control_section_fraction",
+        "phase",
+    ):
+        activity.pop(key, None)
+    activity["active_task"] = "idle"
+    activity["phase"] = "IDLE"
+    activity["motion_stage"] = "idle"
+    activity["drive_kind"] = "idle"
+    activity["control_section_active"] = False
+    activity["control_section_fresh"] = False
+    activity["control_section_age_sec"] = _topic_age_sec(live_payload, "section_status", section)
+
+    geometry = out.get("geometry")
+    if isinstance(geometry, dict):
+        for key in (
+            "current_line_label",
+            "live_section_geometry",
+        ):
+            geometry.pop(key, None)
+
 def _first_present(mapping: Mapping[str, Any], *keys: str) -> Any:
     for key in keys:
         try:
@@ -1296,11 +1446,8 @@ def merge_live_telemetry(
         if isinstance(live_payload.get("last_message_age_sec"), dict)
         else {}
     )
-    command_topic_age = _finite_float(live_ages.get("command"))
-    command_topic_fresh = (
-        command_topic_age is not None
-        and command_topic_age <= live_status_max_age_sec()
-    )
+    command_topic_age = _topic_age_sec(live_payload, "command", cmd)
+    command_topic_fresh = bool(command_topic_age is not None and command_topic_age <= live_status_max_age_sec())
     direct_cmd_az = _finite_float(
         _first_present(cmd, "command_lon_deg", "cmd_az_deg", "az_cmd_deg")
     )
@@ -1401,19 +1548,8 @@ def merge_live_telemetry(
     if antenna_update:
         antenna_section = out.setdefault("antenna", {})
         if not command_valid:
-            for key in (
-                "command_lon_deg",
-                "command_lat_deg",
-                "cmd_az_deg",
-                "cmd_el_deg",
-                "az_cmd_deg",
-                "el_cmd_deg",
-                "command_frame",
-                "command_unit",
-                "command_time_unix",
-            ):
-                antenna_section.pop(key, None)
-                antenna_update.pop(key, None)
+            _clear_command_fields(antenna_section)
+            _clear_command_fields(antenna_update)
         antenna_update["command_valid"] = bool(command_valid)
         antenna_update["command_source"] = command_source
         if command_topic_age is not None:
@@ -1578,6 +1714,7 @@ def merge_live_telemetry(
             # present.
             if data.get("latest_control_line_index") is None:
                 data["latest_control_line_index"] = line_index
+    _live_truth_scrub_stale_motion(out, live_payload, command_valid=command_valid)
     return apply_dynamic_remaining(out)
 
 

--- a/bin/progress.py
+++ b/bin/progress.py
@@ -15,13 +15,20 @@ import json
 import math
 import os
 import re
+import shutil
+import subprocess
 import sys
 import time
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Mapping, Optional
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence
 from urllib.parse import parse_qs, urlparse
+
+try:
+    import tomllib  # Python 3.11+
+except ModuleNotFoundError:  # pragma: no cover - old Python fallback
+    tomllib = None  # type: ignore[assignment]
 
 
 def safe_name(value: Any) -> str:
@@ -155,6 +162,669 @@ def _finite_float(value: Any) -> Optional[float]:
     except Exception:
         return None
     return out if math.isfinite(out) else None
+
+
+def _finite_int(value: Any) -> Optional[int]:
+    try:
+        out = int(value)
+    except Exception:
+        return None
+    return out
+
+
+def _bool_config(value: Any, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    if isinstance(value, (int, float)):
+        return bool(value)
+    token = str(value).strip().lower()
+    if token in {"1", "true", "yes", "on", "enable", "enabled"}:
+        return True
+    if token in {"0", "false", "no", "off", "disable", "disabled"}:
+        return False
+    return default
+
+
+def _config_section_to_plain_dict(
+    section: Any, prefix: str
+) -> Optional[Dict[str, Any]]:
+    """Convert a neclib ConfigurationView or mapping to unprefixed keys."""
+    if isinstance(section, Mapping):
+        return dict(section)
+    if hasattr(section, "items"):
+        try:
+            return dict(section.items())
+        except Exception:
+            pass
+    if hasattr(section, "parameters"):
+        try:
+            raw = dict(section.parameters)
+        except Exception:
+            return None
+        prefix_norm = prefix.replace(".", "_") + "_"
+        out: Dict[str, Any] = {}
+        for key, value in raw.items():
+            key_s = str(key)
+            if key_s.startswith(prefix_norm):
+                key_s = key_s[len(prefix_norm) :]
+            out[key_s] = value
+        return out
+    return None
+
+
+def _progress_time_sync_from_necst_config() -> Optional[Dict[str, Any]]:
+    """Read [progress.time_sync] from the active NECST/neclib site config.
+
+    This intentionally fails closed.  Progress monitor must remain usable even
+    when it is run outside a fully configured NECST/ROS environment.
+    """
+    try:
+        from necst import config as necst_config  # type: ignore
+    except Exception:
+        return None
+    for key in ("progress.time_sync", "progress_time_sync"):
+        try:
+            section = necst_config.get(key)
+        except Exception:
+            continue
+        plain = _config_section_to_plain_dict(section, key)
+        if plain is not None:
+            return plain
+    return None
+
+
+def _progress_time_sync_from_toml_text(text: str) -> Optional[Dict[str, Any]]:
+    """Extract only [progress.time_sync] from TOML-like site config text.
+
+    Some existing NECST site config files contain constructs that the stdlib
+    TOML parser rejects even though neclib can read them.  The fallback reader
+    must therefore avoid parsing the entire site file.  It only parses the
+    requested section so that an unrelated legacy table elsewhere cannot disable
+    the optional progress time-sync indicator.
+    """
+    if tomllib is None:
+        return None
+    lines = text.splitlines()
+    section_lines: List[str] = []
+    in_section = False
+    header_pattern = re.compile(r"^\s*\[([^\[\]]+)\]\s*(?:#.*)?$")
+    array_header_pattern = re.compile(r"^\s*\[\[([^\[\]]+)\]\]\s*(?:#.*)?$")
+    for line in lines:
+        header = header_pattern.match(line)
+        array_header = array_header_pattern.match(line)
+        table_name = None
+        if header:
+            table_name = header.group(1).strip()
+        elif array_header:
+            table_name = array_header.group(1).strip()
+        if table_name is not None:
+            if table_name == "progress.time_sync" or table_name.startswith(
+                "progress.time_sync."
+            ):
+                in_section = True
+                section_lines.append(line)
+                continue
+            if in_section:
+                break
+        if in_section:
+            section_lines.append(line)
+    if not section_lines:
+        return None
+    snippet = "\n".join(section_lines) + "\n"
+    try:
+        data = tomllib.loads(snippet)
+    except Exception:
+        return None
+    progress = data.get("progress") if isinstance(data, Mapping) else None
+    if not isinstance(progress, Mapping):
+        return None
+    section = progress.get("time_sync")
+    return dict(section) if isinstance(section, Mapping) else None
+
+
+def _progress_time_sync_from_toml_file() -> Optional[Dict[str, Any]]:
+    """Fallback section reader used when necst/neclib import is unavailable."""
+    telescope = os.environ.get("TELESCOPE")
+    filename = f"{telescope}_config.toml" if telescope else "config.toml"
+    roots: List[Path] = []
+    necst_root = os.environ.get("NECST_ROOT")
+    if necst_root:
+        roots.append(Path(necst_root).expanduser())
+    roots.append(Path.home() / ".necst")
+    for root in roots:
+        path = root / filename
+        try:
+            section = _progress_time_sync_from_toml_text(
+                path.read_text(encoding="utf-8")
+            )
+        except Exception:
+            continue
+        if isinstance(section, Mapping):
+            return dict(section)
+    return None
+
+
+def _normalize_time_sync_hosts(raw_hosts: Any) -> List[Dict[str, Any]]:
+    hosts: List[Dict[str, Any]] = []
+    if raw_hosts is None:
+        return hosts
+    items: Iterable[Any]
+    if isinstance(raw_hosts, Mapping):
+        mapped: List[Any] = []
+        for name, value in raw_hosts.items():
+            if isinstance(value, Mapping):
+                entry = dict(value)
+                entry.setdefault("name", name)
+                mapped.append(entry)
+            else:
+                mapped.append({"name": name, "host": value})
+        items = mapped
+    elif isinstance(raw_hosts, (list, tuple)):
+        items = raw_hosts
+    else:
+        items = [raw_hosts]
+
+    for item in items:
+        if isinstance(item, str):
+            name = item.strip()
+            host = name
+            method = "auto"
+        elif isinstance(item, Mapping):
+            host_value = (
+                item.get("host")
+                if item.get("host") not in (None, "")
+                else item.get("address")
+            )
+            host = str(host_value or "").strip()
+            name = str(item.get("name") or host).strip()
+            method = str(item.get("method") or "auto").strip().lower()
+        else:
+            continue
+        if not host:
+            continue
+        hosts.append({"name": name or host, "host": host, "method": method or "auto"})
+    return hosts
+
+
+def load_progress_time_sync_config() -> Optional[Dict[str, Any]]:
+    """Return normalized progress time-sync config, or None when absent/disabled.
+
+    The only intended configuration location is the active site config, e.g.
+    OMU1p85m_config.toml or NANTEN2_config.toml.  No separate profile switch is
+    introduced; TELESCOPE/neclib already selects the site.
+    """
+    raw = _progress_time_sync_from_necst_config()
+    if raw is None:
+        raw = _progress_time_sync_from_toml_file()
+    if not isinstance(raw, Mapping):
+        return None
+    hosts = _normalize_time_sync_hosts(raw.get("hosts"))
+    enabled = _bool_config(raw.get("enabled"), default=bool(hosts))
+    if not enabled or not hosts:
+        return None
+    interval = _finite_float(raw.get("interval_sec"))
+    timeout = _finite_float(raw.get("timeout_sec"))
+    ok_offset = _finite_float(raw.get("ok_offset_ms"))
+    warn_offset = _finite_float(raw.get("warn_offset_ms"))
+    bad_after = _finite_int(raw.get("bad_after_failures"))
+    return {
+        "enabled": True,
+        "hosts": hosts,
+        "interval_sec": max(10.0, interval if interval is not None else 60.0),
+        "timeout_sec": max(0.2, timeout if timeout is not None else 2.0),
+        "ok_offset_ms": max(0.0, ok_offset if ok_offset is not None else 5.0),
+        "warn_offset_ms": max(0.0, warn_offset if warn_offset is not None else 20.0),
+        "bad_after_failures": max(1, bad_after if bad_after is not None else 3),
+    }
+
+
+def _compact_command(argv: Sequence[str]) -> str:
+    return " ".join(str(x) for x in argv)
+
+
+def _parse_float_token(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    match = re.search(r"[-+]?\d+(?:\.\d*)?(?:[eE][-+]?\d+)?", str(value))
+    return _finite_float(match.group(0)) if match else None
+
+
+def _split_ntp_assignments(text: str) -> Dict[str, str]:
+    out: Dict[str, str] = {}
+    for token in re.split(r",\s*|\s+", text.replace("\n", " ")):
+        if "=" not in token:
+            continue
+        key, value = token.split("=", 1)
+        key = key.strip().lower()
+        if key:
+            out[key] = value.strip().strip(',')
+    return out
+
+
+class TimeSyncPoller:
+    """Low-frequency best-effort NTP/chrony monitor for progress.py only."""
+
+    def __init__(self, config: Mapping[str, Any]) -> None:
+        self.hosts = list(config.get("hosts") or [])
+        self.interval_sec = float(config.get("interval_sec") or 60.0)
+        self.timeout_sec = float(config.get("timeout_sec") or 2.0)
+        self.ok_offset_ms = float(config.get("ok_offset_ms") or 5.0)
+        self.warn_offset_ms = float(config.get("warn_offset_ms") or 20.0)
+        if self.warn_offset_ms < self.ok_offset_ms:
+            self.warn_offset_ms = self.ok_offset_ms
+        self.bad_after_failures = int(config.get("bad_after_failures") or 3)
+        self._lock = threading.RLock()
+        self._stop = threading.Event()
+        self._failures: Dict[str, int] = {}
+        self._state: Dict[str, Any] = {
+            "enabled": True,
+            "status": "unknown",
+            "label": "unknown",
+            "summary": "time sync: not checked yet",
+            "checked_at_unix": None,
+            "hosts": [],
+        }
+        self._thread = threading.Thread(
+            target=self._loop, name="necst-progress-time-sync", daemon=True
+        )
+        self._thread.start()
+
+    @classmethod
+    def from_site_config(cls) -> Optional["TimeSyncPoller"]:
+        config = load_progress_time_sync_config()
+        if not config:
+            return None
+        return cls(config)
+
+    def snapshot(self) -> Dict[str, Any]:
+        with self._lock:
+            return copy.deepcopy(self._state)
+
+    def close(self) -> None:
+        self._stop.set()
+        try:
+            if self._thread.is_alive():
+                self._thread.join(timeout=1.0)
+        except Exception:
+            pass
+
+    def _loop(self) -> None:
+        while not self._stop.is_set():
+            try:
+                self.poll_once()
+            except Exception as exc:
+                with self._lock:
+                    self._state = {
+                        "enabled": True,
+                        "status": "unknown",
+                        "label": "unknown",
+                        "summary": (
+                            "time sync: monitor error "
+                            f"({exc.__class__.__name__})"
+                        ),
+                        "checked_at_unix": time.time(),
+                        "hosts": [],
+                    }
+            self._stop.wait(self.interval_sec)
+
+    def poll_once(self) -> None:
+        checked_at = time.time()
+        results: List[Dict[str, Any]] = []
+        for host_cfg in self.hosts:
+            if not isinstance(host_cfg, Mapping):
+                continue
+            result = self._check_host(host_cfg)
+            key = str(result.get("name") or result.get("host") or "host")
+            if result.get("status") in {"ok", "warn", "bad"} and not result.get(
+                "query_failed"
+            ):
+                self._failures[key] = 0
+            else:
+                self._failures[key] = self._failures.get(key, 0) + 1
+                result["failures"] = self._failures[key]
+                if self._failures[key] >= self.bad_after_failures:
+                    result["status"] = "bad"
+                    result["synced"] = False
+            results.append(result)
+
+        statuses = [str(r.get("status") or "unknown") for r in results]
+        ok_count = statuses.count("ok")
+        total = len(statuses)
+        offsets = [
+            abs(float(r["offset_ms"]))
+            for r in results
+            if _finite_float(r.get("offset_ms")) is not None
+        ]
+        max_offset = max(offsets) if offsets else None
+        if total <= 0:
+            status = "unknown"
+        elif ok_count == total:
+            status = "ok"
+        elif any(s in {"bad", "warn"} for s in statuses):
+            status = "bad"
+        else:
+            status = "unknown"
+        label = (
+            "sync"
+            if status == "ok"
+            else ("nosync" if status == "bad" else "unknown")
+        )
+        worst = next(
+            (r for r in results if str(r.get("status")) in {"bad", "warn"}),
+            next((r for r in results if str(r.get("status")) == "unknown"), None),
+        )
+        parts = [f"time sync: {label}", f"{ok_count}/{total} OK"]
+        if max_offset is not None:
+            parts.append(f"max offset {max_offset:.3g} ms")
+        if worst is not None and status != "ok":
+            reason = str(worst.get("reason") or worst.get("status") or "unknown")
+            parts.append(f"worst {worst.get('name')}: {reason}")
+        state = {
+            "enabled": True,
+            "status": status,
+            "label": label,
+            "summary": ", ".join(parts),
+            "checked_at_unix": checked_at,
+            "ok_count": ok_count,
+            "host_count": total,
+            "max_offset_ms": max_offset,
+            "hosts": results,
+        }
+        with self._lock:
+            self._state = state
+
+    def _run_command(self, argv: Sequence[str]) -> Dict[str, Any]:
+        exe = str(argv[0]) if argv else ""
+        if not exe or shutil.which(exe) is None:
+            return {
+                "ok": False,
+                "command_available": False,
+                "reason": f"{exe or 'command'} not found",
+                "command": _compact_command(argv),
+            }
+        try:
+            proc = subprocess.run(
+                list(argv),
+                text=True,
+                capture_output=True,
+                timeout=self.timeout_sec,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            return {
+                "ok": False,
+                "command_available": True,
+                "reason": "timeout",
+                "command": _compact_command(argv),
+            }
+        except Exception as exc:
+            return {
+                "ok": False,
+                "command_available": True,
+                "reason": exc.__class__.__name__,
+                "command": _compact_command(argv),
+            }
+        text = (proc.stdout or "") + ("\n" + proc.stderr if proc.stderr else "")
+        return {
+            "ok": proc.returncode == 0 and bool((proc.stdout or "").strip()),
+            "command_available": True,
+            "returncode": proc.returncode,
+            "stdout": proc.stdout or "",
+            "stderr": proc.stderr or "",
+            "text": text,
+            "reason": f"exit {proc.returncode}" if proc.returncode != 0 else "",
+            "command": _compact_command(argv),
+        }
+
+    def _check_host(self, host_cfg: Mapping[str, Any]) -> Dict[str, Any]:
+        name = str(host_cfg.get("name") or host_cfg.get("host") or "host")
+        host = str(host_cfg.get("host") or host_cfg.get("address") or name)
+        method = str(host_cfg.get("method") or "auto").strip().lower()
+        methods = (
+            ["chrony", "ntpq", "xntpdq", "ntpdc"]
+            if method == "auto"
+            else [method]
+        )
+        last: Optional[Dict[str, Any]] = None
+        for candidate in methods:
+            result = self._check_host_with_method(name, host, candidate)
+            last = result
+            # In auto mode, try the next tool only for command/query failures.
+            if method == "auto" and result.get("query_failed"):
+                continue
+            return result
+        return last or {
+            "name": name,
+            "host": host,
+            "method": method,
+            "status": "unknown",
+            "synced": None,
+            "reason": "no method usable",
+            "query_failed": True,
+        }
+
+    def _check_host_with_method(
+        self, name: str, host: str, method: str
+    ) -> Dict[str, Any]:
+        if method in {"chrony", "chronyc"}:
+            if host in {"localhost", "127.0.0.1", "::1"}:
+                argv = ["chronyc", "-n", "tracking"]
+            else:
+                argv = ["chronyc", "-n", "-h", host, "tracking"]
+            run = self._run_command(argv)
+            if not run.get("ok"):
+                return self._query_failed_result(name, host, "chrony", run)
+            return self._classify_host_result(
+                name,
+                host,
+                "chrony",
+                self._parse_chronyc_tracking(str(run.get("stdout") or "")),
+            )
+        if method == "ntpq":
+            argv = ["ntpq", "-n", "-c", "rv", "-c", "peers", host]
+            run = self._run_command(argv)
+            if not run.get("ok"):
+                return self._query_failed_result(name, host, "ntpq", run)
+            return self._classify_host_result(
+                name,
+                host,
+                "ntpq",
+                self._parse_ntpq_output(str(run.get("stdout") or "")),
+            )
+        if method == "xntpdq":
+            for argv in (
+                ["xntpdq", "-n", "-c", "rv", "-c", "peers", host],
+                ["xntpdq", "-n", "-p", host],
+            ):
+                run = self._run_command(argv)
+                if run.get("ok"):
+                    return self._classify_host_result(
+                        name,
+                        host,
+                        "xntpdq",
+                        self._parse_ntpq_output(str(run.get("stdout") or "")),
+                    )
+                last = run
+            return self._query_failed_result(name, host, "xntpdq", last)
+        if method == "ntpdc":
+            argv = ["ntpdc", "-n", "-c", "sysinfo", "-c", "peers", host]
+            run = self._run_command(argv)
+            if not run.get("ok"):
+                return self._query_failed_result(name, host, "ntpdc", run)
+            return self._classify_host_result(
+                name,
+                host,
+                "ntpdc",
+                self._parse_ntpdc_output(str(run.get("stdout") or "")),
+            )
+        return {
+            "name": name,
+            "host": host,
+            "method": method,
+            "status": "unknown",
+            "synced": None,
+            "reason": f"unsupported method {method!r}",
+            "query_failed": True,
+        }
+
+    def _query_failed_result(
+        self, name: str, host: str, method: str, run: Optional[Mapping[str, Any]]
+    ) -> Dict[str, Any]:
+        return {
+            "name": name,
+            "host": host,
+            "method": method,
+            "status": "unknown",
+            "synced": None,
+            "offset_ms": None,
+            "source": "",
+            "reason": str((run or {}).get("reason") or "query failed"),
+            "query_failed": True,
+            "command": str((run or {}).get("command") or ""),
+        }
+
+    def _classify_host_result(
+        self, name: str, host: str, method: str, parsed: Mapping[str, Any]
+    ) -> Dict[str, Any]:
+        synced = parsed.get("synced")
+        offset_ms = _finite_float(parsed.get("offset_ms"))
+        if synced is False:
+            status = "bad"
+            reason = str(parsed.get("reason") or "unsynchronised")
+        elif offset_ms is not None and abs(offset_ms) > self.warn_offset_ms:
+            status = "bad"
+            reason = f"offset {offset_ms:+.3g} ms"
+        elif offset_ms is not None and abs(offset_ms) > self.ok_offset_ms:
+            status = "warn"
+            reason = f"offset {offset_ms:+.3g} ms"
+        elif synced is True:
+            status = "ok"
+            reason = "synchronised"
+        else:
+            status = "unknown"
+            reason = str(parsed.get("reason") or "sync state unknown")
+        return {
+            "name": name,
+            "host": host,
+            "method": method,
+            "status": status,
+            "synced": synced,
+            "offset_ms": offset_ms,
+            "source": parsed.get("source") or "",
+            "stratum": parsed.get("stratum"),
+            "reach": parsed.get("reach"),
+            "reason": reason,
+            "query_failed": False,
+        }
+
+    def _parse_chronyc_tracking(self, text: str) -> Dict[str, Any]:
+        out: Dict[str, Any] = {"synced": None, "offset_ms": None, "source": ""}
+        for line in text.splitlines():
+            if ":" not in line:
+                continue
+            key, value = line.split(":", 1)
+            key_l = key.strip().lower()
+            value_s = value.strip()
+            if key_l == "reference id":
+                out["source"] = value_s
+            elif key_l == "stratum":
+                out["stratum"] = _finite_int(value_s)
+            elif key_l == "system time":
+                seconds = _parse_float_token(value_s)
+                if seconds is not None:
+                    sign = -1.0 if "slow" in value_s.lower() else 1.0
+                    out["offset_ms"] = sign * seconds * 1000.0
+            elif key_l == "leap status":
+                token = value_s.lower()
+                if "normal" in token:
+                    out["synced"] = True
+                elif "not" in token or "unsynchron" in token:
+                    out["synced"] = False
+                    out["reason"] = value_s
+        stratum = _finite_int(out.get("stratum"))
+        if stratum is not None and stratum >= 16:
+            out["synced"] = False
+            out.setdefault("reason", f"stratum {stratum}")
+        return out
+
+    def _parse_ntpq_output(self, text: str) -> Dict[str, Any]:
+        out: Dict[str, Any] = {"synced": None, "offset_ms": None, "source": ""}
+        assignments = _split_ntp_assignments(text)
+        if "offset" in assignments:
+            # ntpq rv reports offset in milliseconds.
+            out["offset_ms"] = _parse_float_token(assignments.get("offset"))
+        if "stratum" in assignments:
+            out["stratum"] = _finite_int(assignments.get("stratum"))
+        leap = str(assignments.get("leap") or "").lower()
+        if leap in {"00", "leap_none", "none"}:
+            out["synced"] = True
+        elif leap in {"11", "leap_alarm", "alarm"}:
+            out["synced"] = False
+            out["reason"] = f"leap {leap}"
+        for line in text.splitlines():
+            stripped = line.lstrip()
+            if not stripped or stripped[0] not in {"*", "o"}:
+                continue
+            fields = stripped[1:].split()
+            if fields:
+                out["source"] = fields[0]
+                out["synced"] = True
+            if len(fields) >= 9:
+                offset = _finite_float(fields[8])
+                if offset is not None:
+                    out["offset_ms"] = offset
+            if len(fields) >= 7:
+                out["reach"] = fields[6]
+            break
+        stratum = _finite_int(out.get("stratum"))
+        if stratum is not None and stratum >= 16:
+            out["synced"] = False
+            out.setdefault("reason", f"stratum {stratum}")
+        if out.get("synced") is None and "sync_unspec" in text.lower():
+            out["synced"] = False
+            out.setdefault("reason", "sync_unspec")
+        return out
+
+    def _parse_ntpdc_output(self, text: str) -> Dict[str, Any]:
+        out: Dict[str, Any] = {"synced": None, "offset_ms": None, "source": ""}
+        for line in text.splitlines():
+            if ":" in line:
+                key, value = line.split(":", 1)
+                key_l = key.strip().lower()
+                value_s = value.strip()
+                if key_l == "system peer":
+                    out["source"] = value_s
+                    if value_s and value_s not in {"0.0.0.0", "none"}:
+                        out["synced"] = True
+                elif key_l == "stratum":
+                    out["stratum"] = _finite_int(value_s)
+                elif key_l == "leap indicator":
+                    token = value_s.lower()
+                    if token.startswith("00") or "none" in token:
+                        out["synced"] = True
+                    elif token.startswith("11") or "alarm" in token:
+                        out["synced"] = False
+                        out["reason"] = value_s
+            stripped = line.lstrip()
+            if stripped and stripped[0] in {"*", "o"}:
+                fields = stripped[1:].split()
+                if fields:
+                    out["source"] = fields[0]
+                    out["synced"] = True
+                # ntpdc peers usually ends with delay, offset, dispersion.
+                if len(fields) >= 3:
+                    offset = _finite_float(fields[-2])
+                    if offset is not None:
+                        out["offset_ms"] = (
+                            offset * 1000.0 if abs(offset) < 1.0 else offset
+                        )
+        stratum = _finite_int(out.get("stratum"))
+        if stratum is not None and stratum >= 16:
+            out["synced"] = False
+            out.setdefault("reason", f"stratum {stratum}")
+        return out
 
 
 def angular_delta_deg(measured: float, commanded: float) -> float:
@@ -675,6 +1345,13 @@ def merge_live_telemetry(
     )
     if spec_payload:
         out.setdefault("spectrometer", {}).update(spec_payload)
+    chopper_payload = (
+        live_payload.get("chopper_status")
+        if isinstance(live_payload.get("chopper_status"), dict)
+        else {}
+    )
+    if chopper_payload:
+        out.setdefault("chopper", {}).update(chopper_payload)
 
     lifecycle = out.get("lifecycle") if isinstance(out.get("lifecycle"), dict) else {}
     final_state = str(lifecycle.get("state") or "").lower() in {
@@ -832,6 +1509,7 @@ class LiveRosCache:
         self.az_unwrap_status: Dict[str, Any] = {}
         self.queue_status: Dict[str, Any] = {}
         self.spectrometer_status: Dict[str, Any] = {}
+        self.chopper_status: Dict[str, Any] = {}
         self.weather: Dict[str, Dict[str, Any]] = {}
         if self.requested:
             self._start()
@@ -842,6 +1520,7 @@ class LiveRosCache:
             if repo_root not in sys.path:
                 sys.path.insert(0, repo_root)
             import rclpy  # type: ignore
+            from necst import config as necst_config  # type: ignore
             from necst.definitions import topic  # type: ignore
 
             self._rclpy = rclpy
@@ -1084,6 +1763,61 @@ class LiveRosCache:
                     "warning": str(getattr(msg, "warning", "")),
                 }
 
+            def chopper_status_cb(msg: Any) -> None:
+                try:
+                    position = int(getattr(msg, "position"))
+                except Exception:
+                    position = None
+                try:
+                    insert = bool(getattr(msg, "insert"))
+                except Exception:
+                    insert = None
+                try:
+                    insert_position = int(necst_config.chopper_motor_position["insert"])
+                    remove_position = int(necst_config.chopper_motor_position["remove"])
+                except Exception:
+                    insert_position = None
+                    remove_position = None
+                try:
+                    simulator_boolean_only = bool(getattr(necst_config, "simulator", False))
+                except Exception:
+                    simulator_boolean_only = False
+                # ChopperSimulator publishes only the boolean insert flag; the
+                # int32 position field remains the ROS default 0.  In real
+                # hardware mode, position=0 must be treated as a real counter
+                # value.  In simulator mode, display position=0 + insert flag as
+                # the simulator state even for NANTEN2 OUT where remove=250.
+
+                if (
+                    position is not None
+                    and position == insert_position
+                    and insert is not False
+                ):
+                    state = "in"
+                elif (
+                    position is not None
+                    and position == remove_position
+                    and insert is not True
+                ):
+                    state = "out"
+                elif simulator_boolean_only and position == 0 and insert is True:
+                    state = "in"
+                elif simulator_boolean_only and position == 0 and insert is False:
+                    state = "out"
+                elif insert is True:
+                    state = "in?"
+                elif insert is False:
+                    state = "out?"
+                else:
+                    state = "unknown"
+
+                self.chopper_status = {
+                    "insert": insert,
+                    "state": state,
+                    "position": position,
+                    "time_unix": _finite_float(getattr(msg, "time", None)),
+                }
+
             def weather_cb(key: str):
                 def _callback(msg: Any) -> None:
                     payload = {
@@ -1130,6 +1864,7 @@ class LiveRosCache:
                 (getattr(topic, "antenna_az_unwrap_status", None), az_unwrap_status_cb),
                 (getattr(topic, "antenna_command_queue_status", None), queue_status_cb),
                 (getattr(topic, "spectrometer_status", None), spectrometer_status_cb),
+                (getattr(topic, "chopper_status", None), chopper_status_cb),
             ):
                 try:
                     if topic_obj is not None:
@@ -1226,6 +1961,8 @@ class LiveRosCache:
                 payload["queue_status"] = dict(self.queue_status)
             if self.spectrometer_status:
                 payload["spectrometer_status"] = dict(self.spectrometer_status)
+            if self.chopper_status:
+                payload["chopper_status"] = dict(self.chopper_status)
             if self.weather:
                 payload["weather"] = {
                     key: dict(value) for key, value in self.weather.items()
@@ -2441,7 +3178,11 @@ def _int_query(
 
 
 def build_state(
-    root: Path, *, events_limit: int = 12, live: Optional[LiveRosCache] = None
+    root: Path,
+    *,
+    events_limit: int = 12,
+    live: Optional[LiveRosCache] = None,
+    time_sync: Optional[TimeSyncPoller] = None,
 ) -> Dict[str, Any]:
     snapshot_path = current_snapshot_path(root)
     raw_snapshot = read_json(snapshot_path)
@@ -2463,6 +3204,10 @@ def build_state(
         root, raw_snapshot if isinstance(raw_snapshot, dict) else None
     )
     plan = read_json(plan_path) if plan_path else None
+    if isinstance(snapshot, dict) and time_sync is not None:
+        time_sync_snapshot = time_sync.snapshot()
+        if time_sync_snapshot.get("enabled"):
+            snapshot.setdefault("time_sync", {}).update(time_sync_snapshot)
     all_events = read_all_events(events_path)
     events = all_events[-events_limit:] if events_limit > 0 else []
     return {
@@ -2489,6 +3234,7 @@ def build_state(
             full_plan=plan if isinstance(plan, dict) else None,
         ),
         "server_time_unix": server_time_unix,
+        "time_sync": (time_sync.snapshot() if time_sync is not None else None) or {},
     }
 
 
@@ -3153,6 +3899,18 @@ function utcText(unixSec) {
   const n = Number(unixSec);
   return Number.isFinite(n) ? new Date(n*1000).toISOString().replace('T',' ').replace(/\\.\\d+Z$/,' UTC') : '-';
 }
+function timeSyncUtcRow(snapshot, utcUnix, serverTimeUnix=null) {
+  const base = utcText(utcUnix);
+  const ts = snapshot?.time_sync;
+  if (!ts || ts.enabled !== true) return ['UTC', base, ''];
+  const status = String(ts.status || '').toLowerCase();
+  const label = status === 'ok' ? 'sync' : (status === 'bad' || status === 'warn' ? 'nosync' : 'unknown');
+  const role = label === 'sync' ? 'ok' : (label === 'nosync' ? 'critical' : 'warning');
+  const checkedAge = ageSinceUnix(ts.checked_at_unix, serverTimeUnix);
+  const ageTextValue = Number.isFinite(checkedAge) ? ` / checked ${secText(checkedAge)} ago` : '';
+  const summary = String(ts.summary || `time sync: ${label}`) + ageTextValue;
+  return ['UTC', `${base}  ${label}`, role, summary];
+}
 function lstDisplayText(snapshot) {
   const text = snapshot?.display?.lst_hms;
   return isBlank(text) ? '-' : String(text);
@@ -3327,12 +4085,13 @@ function kvSmart(id, rows) {
     const label = Array.isArray(row) ? row[0] : '-';
     const raw = Array.isArray(row) ? row[1] : row;
     const role = Array.isArray(row) ? (row[2] || '') : '';
+    const title = Array.isArray(row) && row.length >= 4 ? row[3] : raw;
     if (role === 'html') {
-      el.insertAdjacentHTML('beforeend', `<div class="k">${esc(label)}</div><div class="v">${raw ?? '-'}</div>`);
+      el.insertAdjacentHTML('beforeend', `<div class="k">${esc(label)}</div><div class="v" title="${esc(title ?? raw ?? '-')}">${raw ?? '-'}</div>`);
       continue;
     }
     const cls = role ? ` ${role}-pos` : '';
-    el.insertAdjacentHTML('beforeend', `<div class="k">${esc(label)}</div><div class="v${cls}" title="${esc(raw ?? '-')}">${esc(raw ?? '-')}</div>`);
+    el.insertAdjacentHTML('beforeend', `<div class="k">${esc(label)}</div><div class="v${cls}" title="${esc(title ?? raw ?? '-')}">${esc(raw ?? '-')}</div>`);
   }
 }
 function geometryRows(snapshot) {
@@ -3667,9 +4426,27 @@ function compactSpectrometerTime(v) {
   return s.length > 20 ? shortPathText(s, 24) : s;
 }
 
+function spectrometerIrigbRow(sp) {
+  const raw = String(sp?.latest_time_spectrometer ?? '').trim();
+  if (!raw) return ['IRIG-B', 'NO TIMESTAMP', 'critical'];
+  return raw.endsWith('GPS') ? ['IRIG-B', 'GPS OK', 'ok'] : ['IRIG-B', 'NO GPS', 'critical'];
+}
+function chopperRow(snapshot, serverTimeUnix=null) {
+  const ch = snapshot?.chopper || {};
+  if (!ch || !Object.keys(ch).length) return ['chopper', 'not reported', 'muted'];
+  const stateRaw = String(ch.state ?? '').trim().toLowerCase();
+  const state = stateRaw || (ch.insert === true ? 'in' : (ch.insert === false ? 'out' : 'unknown'));
+  const pos = Number(ch.position);
+  const age = ageSinceUnix(ch.time_unix, serverTimeUnix);
+  const text = `${state.toUpperCase()}${Number.isFinite(pos) ? ` / pos ${pos}` : ''}${Number.isFinite(age) ? ` / ${secText(age)}` : ''}`;
+  return ['chopper', text, state === 'unknown' ? 'warning' : 'important'];
+}
+
 function spectrometerRows(snapshot, serverTimeUnix=null) {
   const sp = snapshot?.spectrometer || {};
-  if (!sp || !Object.keys(sp).length) return [['status', 'not reported', 'muted'], ['source', 'SpectrometerStatus unavailable', 'muted']];
+  if (!sp || !Object.keys(sp).length) {
+    return [['status', 'not reported', 'muted'], ['source', 'SpectrometerStatus unavailable', 'muted']];
+  }
   const valid = !!sp.valid;
   const acquiring = !!sp.acquiring;
   const recording = !!sp.recorder_active;
@@ -3688,7 +4465,8 @@ function spectrometerRows(snapshot, serverTimeUnix=null) {
     ['ch', `TP ${val(sp.tp_range_start)}:${val(sp.tp_range_stop)}; q ${val(sp.qlook_ch_start)}:${val(sp.qlook_ch_stop)}`, ''],
     ['age', secText(pubAge), ageRole(pubAge, 3.0, 10.0)]
   ];
-  if (!isBlank(sp.latest_time_spectrometer)) rows.splice(2, 0, ['clock', compactSpectrometerTime(sp.latest_time_spectrometer), 'muted']);
+  rows.splice(2, 0, spectrometerIrigbRow(sp));
+  if (!isBlank(sp.latest_time_spectrometer)) rows.splice(3, 0, ['clock', compactSpectrometerTime(sp.latest_time_spectrometer), 'muted']);
   if (!isBlank(sp.warning)) rows.push(['warning', sp.warning, 'warning']);
   return rows;
 }
@@ -3741,14 +4519,14 @@ function positionRows(snapshot, psummary=null, serverTimeUnix=null) {
     ...officialTrackingRows(a, snapshot),
     [isCal ? 'calibration now' : (g.cos_correction ? 'map offset actual' : 'map offset'), isCal ? phase : (off ? coordPairText(off, frame, 'arcsec') : '-'), 'important'],
     ['progress item', psummary?.progress || '-', 'important'],
-    ['UTC', utcText(utcUnix), ''],
+    timeSyncUtcRow(snapshot, utcUnix, serverTimeUnix),
     ['LST', lstDisplayText(snapshot), ''],
     ['Target RA, Dec', radec ? radecText(radec, 'J2000') : '-', ''],
     ['Target L, B', gal ? galText(gal, 'galactic') : '-', '']
   ];
   return rows;
 }
-function activityRows(snapshot) {
+function activityRows(snapshot, serverTimeUnix=null) {
   const a = snapshot?.activity || {};
   const d = snapshot?.data || {};
   const g = snapshot?.geometry || {};
@@ -3758,6 +4536,7 @@ function activityRows(snapshot) {
     ['motion', a.motion_stage || a.control_section_kind],
     ['data', a.data_state]
   ];
+  if (snapshot?.chopper && Object.keys(snapshot.chopper).length) rows.push(chopperRow(snapshot, serverTimeUnix));
   if (!isBlank(a.control_id)) rows.push(['control id', a.control_id]);
   if (!isBlank(g.current_line_index0) && !isBlank(g.line_total)) rows.push(['control line', `${Number(g.current_line_index0)+1}/${g.line_total}`]);
   if (!isBlank(a.location_context)) rows.push(['location', a.location_context]);
@@ -4436,7 +5215,7 @@ async function update() {
     kv('plan', psummary, [['progress','progress'], ['basis','basis'], ['current','current'], ['completed','completed'], ['remaining','remaining'], ['total','total'], ['mode','mode'], ['role (plan)','role'], ['target','target'], ['label','label']]);
     document.getElementById('bar').style.width = pct(plan).toFixed(1) + '%';
     renderPlanView(snap, s.plan || {}, statusEvents, s.server_time_unix);
-    kvSmart('activity', activityRows(snap));
+    kvSmart('activity', activityRows(snap, s.server_time_unix));
     kvSmart('position', positionRows(snap, psummary, s.server_time_unix));
     kvSmart('geometry', geometryRows(snap));
     kvSmart('queue', commandQueueRows(snap, s.server_time_unix));
@@ -4470,6 +5249,7 @@ def cmd_serve(args: argparse.Namespace) -> int:
     root = progress_root(args.root)
     refresh_ms = max(250, int(args.refresh_ms))
     live = LiveRosCache(enabled=not args.no_ros)
+    time_sync = TimeSyncPoller.from_site_config()
 
     class ProgressHandler(BaseHTTPRequestHandler):
         server_version = "NECSTProgressHTTP/1.0"
@@ -4486,7 +5266,12 @@ def cmd_serve(args: argparse.Namespace) -> int:
                 return
             if parsed.path == "/api/state":
                 limit = _int_query(query, "events", args.events, minimum=0, maximum=200)
-                _json_response(self, build_state(root, events_limit=limit, live=live))
+                _json_response(
+                    self,
+                    build_state(
+                        root, events_limit=limit, live=live, time_sync=time_sync
+                    ),
+                )
                 return
             if parsed.path == "/api/progress":
                 _json_response(self, read_json(current_snapshot_path(root)) or {})
@@ -4525,10 +5310,15 @@ def cmd_serve(args: argparse.Namespace) -> int:
             f"Could not start progress server on {args.host}:{args.port}: {exc}",
             file=sys.stderr,
         )
+        live.close()
+        if time_sync is not None:
+            time_sync.close()
         return 1
     host, port = server.server_address[:2]
     print(f"Serving NECST progress dashboard at http://{host}:{port}/")
     print(f"Progress root: {root}")
+    if time_sync is not None:
+        print("Time sync monitor: enabled from [progress.time_sync]")
     try:
         server.serve_forever(poll_interval=0.5)
     except KeyboardInterrupt:
@@ -4537,6 +5327,8 @@ def cmd_serve(args: argparse.Namespace) -> int:
     finally:
         server.server_close()
         live.close()
+        if time_sync is not None:
+            time_sync.close()
     return 0
 
 

--- a/bin/progress.py
+++ b/bin/progress.py
@@ -51,6 +51,10 @@ except ModuleNotFoundError:  # pragma: no cover - old Python fallback
     tomllib = None  # type: ignore[assignment]
 
 
+ENCODER_MOTION_DEADBAND_DEG = 1.0e-4
+ENCODER_MOTION_HOLD_SEC = 1.0
+
+
 def safe_name(value: Any) -> str:
     original = str(value or "unknown")
     sanitized = re.sub(r"[^A-Za-z0-9_.-]+", "_", original)
@@ -270,6 +274,17 @@ def _clear_command_fields(mapping: Dict[str, Any]) -> None:
         mapping.pop(key, None)
 
 
+def _clear_tracking_fields(mapping: Dict[str, Any]) -> None:
+    for key in (
+        "tracking_ok",
+        "tracking_error_deg",
+        "tracking_status_time_unix",
+        "tracking_status_age_sec",
+        "tracking_status_source",
+    ):
+        mapping.pop(key, None)
+
+
 def _live_truth_scrub_stale_motion(
     out: Dict[str, Any],
     live_payload: Mapping[str, Any],
@@ -278,9 +293,10 @@ def _live_truth_scrub_stale_motion(
 ) -> None:
     """Remove stale planned/sidecar motion fields when live ROS says idle.
 
-    The progress sidecar can legitimately lag after ``necst abort`` or a local
-    launcher failure.  In operator-facing displays, command and motion must be
-    shown only when backed by fresh live command / section / queue status.
+    Motion display is based on explicit fresh motion/status topics first
+    (section status, command queue, control status).  Encoder-delta motion is
+    only a fallback and uses a deadband, because the low-order encoder digits
+    can jitter while the antenna is physically stopped.
     """
     if not isinstance(out, dict) or not isinstance(live_payload, Mapping):
         return
@@ -288,12 +304,19 @@ def _live_truth_scrub_stale_motion(
     antenna = out.setdefault("antenna", {})
     if isinstance(antenna, dict) and not command_valid:
         _clear_command_fields(antenna)
+        _clear_tracking_fields(antenna)
         antenna["command_valid"] = False
+        antenna["tracking_status_available"] = False
         antenna.setdefault("command_source", "none")
 
     queue = live_payload.get("queue_status") if isinstance(live_payload.get("queue_status"), Mapping) else {}
     section = live_payload.get("section_status") if isinstance(live_payload.get("section_status"), Mapping) else {}
     control = live_payload.get("control") if isinstance(live_payload.get("control"), Mapping) else {}
+    encoder_motion = live_payload.get("encoder_motion") if isinstance(live_payload.get("encoder_motion"), Mapping) else {}
+
+    section_fresh = _topic_received_fresh(live_payload, "section_status")
+    section_active = bool(section_fresh and section.get("active"))
+    section_stage = str(section.get("section_kind") or section.get("section_label") or "").strip()
 
     queue_fresh = _topic_received_fresh(live_payload, "queue_status")
     try:
@@ -302,26 +325,73 @@ def _live_truth_scrub_stale_motion(
         queue_depth = 0
     queue_active = bool(queue_fresh and (queue.get("active") or queue_depth > 0))
 
-    # Operator-facing Moving/Tracking must not be inferred from section/control
-    # diagnostic topics.  These can remain active or carry planned scan metadata
-    # after stop/abort.  Use the real altaz command stream and explicit command
-    # queue activity only.
-    live_motion_active = bool(command_valid or queue_active)
+    control_fresh = _topic_received_fresh(live_payload, "control")
+    control_stage = str(control.get("section_kind") or control.get("section_label") or "").strip()
+    control_active = bool(
+        control_fresh
+        and (control.get("controlled") or control.get("tight") or control_stage)
+    )
+
+    encoder_motion_fresh = _topic_received_fresh(live_payload, "encoder")
+    encoder_moving = bool(encoder_motion_fresh and encoder_motion.get("moving"))
+
+    # command_valid keeps Tracking diagnostics meaningful, but by itself it is
+    # not physical movement.  Prefer explicit motion topics; use the encoder
+    # only as a deadbanded fallback for manual motion cases.
+    live_motion_active = bool(section_active or queue_active or control_active or encoder_moving)
+    if section_active:
+        motion_source = "section_status"
+    elif queue_active:
+        motion_source = "queue_status"
+    elif control_active:
+        motion_source = "control_status"
+    elif encoder_moving:
+        motion_source = "encoder_delta"
+    elif command_valid:
+        motion_source = "command"
+    else:
+        motion_source = "none"
+
     activity = out.setdefault("activity", {})
     if not isinstance(activity, dict):
         return
     activity["live_motion_active"] = live_motion_active
-    activity["live_motion_source"] = (
-        "command" if command_valid else
-        "queue_status" if queue_active else
-        "none"
-    )
+    activity["live_motion_source"] = motion_source
+    activity["encoder_motion_deadband_deg"] = encoder_motion.get("deadband_deg")
+    activity["encoder_motion_delta_az_deg"] = encoder_motion.get("delta_az_deg")
+    activity["encoder_motion_delta_el_deg"] = encoder_motion.get("delta_el_deg")
+
+    if section_active:
+        if section_stage:
+            activity["motion_stage"] = section_stage
+            activity["control_section_kind"] = section_stage
+        activity["control_section_active"] = True
+        activity["control_section_fresh"] = True
+        activity["control_section_age_sec"] = _topic_age_sec(live_payload, "section_status", section)
+        return
+
+    if queue_active:
+        if not activity.get("motion_stage") or str(activity.get("motion_stage")).lower() in {"idle", "none", "unknown"}:
+            activity["motion_stage"] = "moving"
+        return
+
+    if control_active:
+        if control_stage:
+            activity["motion_stage"] = control_stage
+            activity["control_section_kind"] = control_stage
+        elif not activity.get("motion_stage") or str(activity.get("motion_stage")).lower() in {"idle", "none", "unknown"}:
+            activity["motion_stage"] = "moving"
+        return
+
+    if encoder_moving:
+        activity["motion_stage"] = "moving"
+        return
+
+    # Fresh command without explicit movement can still support tracking error
+    # display, but it must not preserve or invent a Moving state.
 
     # If fresh live status does not support motion, old sidecar/planned values
     # such as ON/line/moving must not remain visible as current state.
-    if live_motion_active:
-        return
-
     for key in (
         "motion_stage",
         "drive_kind",
@@ -356,7 +426,6 @@ def _live_truth_scrub_stale_motion(
             "live_section_geometry",
         ):
             geometry.pop(key, None)
-
 def _first_present(mapping: Mapping[str, Any], *keys: str) -> Any:
     for key in keys:
         try:
@@ -1491,13 +1560,13 @@ def merge_live_telemetry(
         else {}
     )
     tracking_fresh = bool(tracking and _topic_received_fresh(live_payload, "tracking"))
-    if tracking_fresh:
-        terr = _finite_float(tracking.get("error_deg"))
+    terr = _finite_float(tracking.get("error_deg")) if tracking else None
+    tracking_available = bool(command_valid and tracking_fresh and terr is not None)
+    if tracking_available:
         tstat = _finite_float(tracking.get("time_unix"))
         antenna_update["tracking_status_available"] = True
         antenna_update["tracking_ok"] = bool(tracking.get("ok", False))
-        if terr is not None:
-            antenna_update["tracking_error_deg"] = terr
+        antenna_update["tracking_error_deg"] = terr
         if tstat is not None:
             antenna_update["tracking_status_time_unix"] = tstat
         antenna_update["tracking_status_age_sec"] = _topic_receipt_age_sec(
@@ -1508,8 +1577,10 @@ def merge_live_telemetry(
         # Do not compute a tracking error from the latest command and latest
         # encoder samples here.  altaz_cmd is a time-tagged command stream and
         # its newest sample is not necessarily the command at the encoder time.
-        # NECST's antenna_tracking topic already performs the correct comparison.
-        antenna_update.setdefault("tracking_status_available", False)
+        # NECST's antenna_tracking topic already performs the correct comparison,
+        # but it is meaningful for the UI only while a fresh altaz command exists.
+        antenna_update["tracking_status_available"] = False
+        _clear_tracking_fields(antenna_update)
     # Command Az/El must be backed by an actually received fresh command topic.
     # The progress sidecar and observation plan may contain command-like values,
     # but those are not the live command and must not survive after abort.
@@ -1517,6 +1588,9 @@ def merge_live_telemetry(
     if not command_valid:
         _clear_command_fields(antenna_section)
         _clear_command_fields(antenna_update)
+    if not tracking_available:
+        _clear_tracking_fields(antenna_section)
+        _clear_tracking_fields(antenna_update)
     if antenna_update or isinstance(antenna_section, dict):
         antenna_update["command_valid"] = bool(command_valid)
         antenna_update["command_source"] = command_source
@@ -1703,6 +1777,9 @@ class LiveRosCache:
         self.control: Dict[str, Any] = {}
         self.command: Dict[str, Any] = {}
         self.encoder: Dict[str, Any] = {}
+        self.encoder_motion: Dict[str, Any] = {}
+        self._previous_encoder_sample: Optional[Dict[str, float]] = None
+        self._last_significant_encoder_motion_unix: Optional[float] = None
         self.tracking: Dict[str, Any] = {}
         self.section_status: Dict[str, Any] = {}
         self.pointing_status: Dict[str, Any] = {}
@@ -1720,6 +1797,56 @@ class LiveRosCache:
         now = time.time()
         self._sample_counts[key] = int(self._sample_counts.get(key, 0)) + 1
         self._last_message_time_unix[key] = now
+
+    def _update_encoder_motion_locked(self, payload: Dict[str, Any]) -> None:
+        """Estimate actual antenna motion from encoder samples with deadband.
+
+        The encoder can jitter in the low-order digits while the antenna is
+        stopped.  This fallback ignores changes at or below 1e-4 deg and is
+        used only when fresher explicit section/queue status is unavailable.
+        """
+
+        now = time.time()
+        lon = _finite_float(payload.get("encoder_lon_deg"))
+        lat = _finite_float(payload.get("encoder_lat_deg"))
+        if lon is None or lat is None:
+            self.encoder_motion = {
+                "moving": False,
+                "source": "encoder_unavailable",
+                "deadband_deg": ENCODER_MOTION_DEADBAND_DEG,
+                "time_unix": now,
+            }
+            return
+
+        previous = self._previous_encoder_sample
+        delta_az = None
+        delta_el = None
+        significant = False
+        if previous is not None:
+            delta_az = abs(lon - previous.get("lon", lon))
+            delta_el = abs(lat - previous.get("lat", lat))
+            significant = bool(
+                delta_az > ENCODER_MOTION_DEADBAND_DEG
+                or delta_el > ENCODER_MOTION_DEADBAND_DEG
+            )
+
+        if significant:
+            self._last_significant_encoder_motion_unix = now
+        held = bool(
+            self._last_significant_encoder_motion_unix is not None
+            and now - self._last_significant_encoder_motion_unix <= ENCODER_MOTION_HOLD_SEC
+        )
+        moving = bool(significant or held)
+        self.encoder_motion = {
+            "moving": moving,
+            "source": "encoder_delta" if moving else "encoder_delta_deadband",
+            "delta_az_deg": delta_az,
+            "delta_el_deg": delta_el,
+            "deadband_deg": ENCODER_MOTION_DEADBAND_DEG,
+            "hold_sec": ENCODER_MOTION_HOLD_SEC,
+            "time_unix": now,
+        }
+        self._previous_encoder_sample = {"lon": lon, "lat": lat, "time_unix": now}
 
     def _start(self) -> None:
         try:
@@ -1742,17 +1869,19 @@ class LiveRosCache:
                     line_index = int(line_index)
                 except Exception:
                     line_index = -1
-                self.control = {
-                    "controlled": bool(getattr(msg, "controlled", False)),
-                    "tight": bool(getattr(msg, "tight", False)),
-                    "remote": bool(getattr(msg, "remote", False)),
-                    "id": str(getattr(msg, "id", "")),
-                    "interrupt_ok": bool(getattr(msg, "interrupt_ok", False)),
-                    "time_unix": _finite_float(getattr(msg, "time", None)),
-                    "section_kind": str(getattr(msg, "section_kind", "")),
-                    "section_label": str(getattr(msg, "section_label", "")),
-                    "line_index": line_index,
-                }
+                with self._lock:
+                    self.control = {
+                        "controlled": bool(getattr(msg, "controlled", False)),
+                        "tight": bool(getattr(msg, "tight", False)),
+                        "remote": bool(getattr(msg, "remote", False)),
+                        "id": str(getattr(msg, "id", "")),
+                        "interrupt_ok": bool(getattr(msg, "interrupt_ok", False)),
+                        "time_unix": _finite_float(getattr(msg, "time", None)),
+                        "section_kind": str(getattr(msg, "section_kind", "")),
+                        "section_label": str(getattr(msg, "section_label", "")),
+                        "line_index": line_index,
+                    }
+                    self._record_sample_locked("control")
 
             def command_cb(msg: Any) -> None:
                 with self._lock:
@@ -1762,6 +1891,7 @@ class LiveRosCache:
             def encoder_cb(msg: Any) -> None:
                 with self._lock:
                     self.encoder = _msg_coord(msg, prefix="encoder")
+                    self._update_encoder_motion_locked(self.encoder)
                     self._record_sample_locked("encoder")
 
             def tracking_cb(msg: Any) -> None:
@@ -2179,6 +2309,8 @@ class LiveRosCache:
                 payload["command"] = dict(self.command)
             if self.encoder:
                 payload["encoder"] = dict(self.encoder)
+            if self.encoder_motion:
+                payload["encoder_motion"] = dict(self.encoder_motion)
             if self.tracking:
                 payload["tracking"] = dict(self.tracking)
             if self.section_status:
@@ -2871,8 +3003,8 @@ def azel_text(lon: Any, lat: Any, frame: Any = "altaz") -> str:
         return "-"
     f = str(frame or "").lower()
     if f in {"altaz", "azel", "alt-az"}:
-        return f"Az={x:.3f} El={y:.3f} deg"
-    return f"lon={x:.3f} lat={y:.3f} {frame or ''}".strip()
+        return f"Az={x:.4f} El={y:.4f} deg"
+    return f"lon={x:.4f} lat={y:.4f} {frame or ''}".strip()
 
 
 def observer_target_name(obs: Mapping[str, Any], geom: Mapping[str, Any]) -> str:
@@ -4267,8 +4399,8 @@ function offsetArcsecText(v, label='') {
 function azElText(lon, lat, frame='altaz') {
   const x=Number(lon), y=Number(lat); if (!Number.isFinite(x) || !Number.isFinite(y)) return '-';
   const f=String(frame || '').toLowerCase();
-  if (f === 'altaz' || f === 'alt-az' || f === 'azel') return `Az ${x.toFixed(3)}°, El ${y.toFixed(3)}°`;
-  return `${String(frame || 'coord')} lon ${x.toFixed(3)}°, lat ${y.toFixed(3)}°`;
+  if (f === 'altaz' || f === 'alt-az' || f === 'azel') return `Az ${x.toFixed(4)}°, El ${y.toFixed(4)}°`;
+  return `${String(frame || 'coord')} lon ${x.toFixed(4)}°, lat ${y.toFixed(4)}°`;
 }
 function azUnwrapBadgeHtml(a) {
   if (!a || !a.az_unwrap_enabled) return '';

--- a/bin/progress.py
+++ b/bin/progress.py
@@ -3679,17 +3679,24 @@ th, td { border-bottom:1px solid var(--border); text-align:left; padding:.10rem 
 #events th:nth-child(1), #events td:nth-child(1) { width:4.2rem; white-space:nowrap; }
 #events th:nth-child(2), #events td:nth-child(2) { width:7.6rem; }
 #events th:nth-child(3), #events td:nth-child(3) { width:auto; }
-.plotbox { min-height: 210px; display:flex; align-items:center; justify-content:center; }
-.plotbox svg { width:100%; height:100%; max-height:none; color:var(--plot-text); }
+.plotbox { min-height: 210px; min-width:0; display:flex; align-items:center; justify-content:center; overflow:hidden; box-sizing:border-box; }
+.plotbox svg { display:block; width:var(--plan-plot-render-w, 100%); height:var(--plan-plot-render-h, 100%); max-width:none; max-height:none; color:var(--plot-text); flex:0 0 auto; }
 .plotbox svg text { fill: currentColor; paint-order: stroke; stroke: var(--bg); stroke-width: 3px; stroke-linejoin: round; }
-.legend { display:flex; gap:.45rem; flex-wrap:wrap; margin:.08rem 0 .14rem; font-size:.92em; color:var(--muted); }
+.legend { display:flex; gap:.45rem; flex-wrap:wrap; margin:.08rem 0 .14rem; font-size:.92em; color:var(--muted); align-items:center; }
 .legend-note { flex-basis:auto; font-size:.89em; }
+.plot-scale-tools { margin-left:auto; display:inline-flex; align-items:center; gap:.16rem; flex:0 0 auto; flex-wrap:nowrap; white-space:nowrap; }
+.plot-scale-btn, .plot-scale-reset { font:inherit; font-size:.70rem; line-height:1.05; padding:.10rem .28rem; border:1px solid var(--border); border-radius:999px; background:var(--panel); color:var(--fg); cursor:pointer; }
+.plot-scale-btn:hover, .plot-scale-reset:hover { background:#9992; }
+#plotScaleReadout { min-width:2.35rem; text-align:right; color:var(--muted); font-size:.84em; }
 .dot { display:inline-block; width:.62rem; height:.62rem; border-radius:999px; vertical-align:-.06rem; margin-right:.18rem; }
 .small { font-size:.70rem; color:var(--muted); }
 .card .small { font-size:.92em; }
 .queueview, .spectrometerview, .traceview, .envview, .terminalview, .filesview, .eventview { min-height: 0; }
-.planview { min-height:0; }
-.planview .plotbox { min-height: 0; height: calc(100% - 3.0rem); }
+.planview { min-height:0; overflow:hidden; }
+.planview .card-content { display:flex; flex-direction:column; height:100%; min-height:0; }
+.planview h2 { flex:0 0 auto; }
+.planview .legend { flex:0 0 auto; }
+.planview .plotbox { flex:1 1 auto; min-height:0; height:auto; width:100%; }
 .planview svg { max-height:none; }
 #terminal { max-height: none; }
 .axis-label { font-size:var(--card-plot-font-size, 11px); fill:currentColor; }
@@ -3716,6 +3723,7 @@ th, td { border-bottom:1px solid var(--border); text-align:left; padding:.10rem 
   .grid { display:flex; flex-direction:column; gap:.45rem; grid-template-columns:none; grid-auto-rows:auto; }
   .card[data-card-id] { grid-column:auto !important; grid-row:auto !important; min-height:auto !important; height:auto !important; overflow:visible; }
   .plotbox { min-height: 260px; }
+  .planview .card-content { height:auto; }
   .planview .plotbox { height:min(72vw, 430px) !important; min-height:270px; }
   .planview svg { max-height:none; }
   .kv, .bigpos, .obsview .kv, .planinfoview .kv, .activityview .kv { grid-template-columns: 7.0rem minmax(0, 1fr); }
@@ -3723,6 +3731,7 @@ th, td { border-bottom:1px solid var(--border); text-align:left; padding:.10rem 
 body.narrow-layout .grid { display:flex; flex-direction:column; gap:.45rem; grid-template-columns:none; grid-auto-rows:auto; }
 body.narrow-layout .card[data-card-id] { grid-column:auto !important; grid-row:auto !important; min-height:auto !important; height:auto !important; overflow:visible; }
 body.narrow-layout .plotbox { min-height:260px; }
+body.narrow-layout .planview .card-content { height:auto; }
 body.narrow-layout .planview .plotbox { height:min(72vw, 430px) !important; min-height:270px; }
 body.narrow-layout .kv, body.narrow-layout .bigpos, body.narrow-layout .obsview .kv, body.narrow-layout .planinfoview .kv, body.narrow-layout .activityview .kv { grid-template-columns:7.0rem minmax(0, 1fr); }
 
@@ -3779,7 +3788,7 @@ body.layout-unlocked .card.resizing { outline:2px solid var(--warn); cursor:nwse
 <section class="card planinfoview" data-card-id="plan"><h2>Plan</h2><div class=\"kv\" id=\"plan\"></div><div class=\"bar\"><div id=\"bar\" class=\"fill\"></div></div></section>
 <section class="card activityview" data-card-id="activity"><h2>Activity</h2><div class=\"kv\" id=\"activity\"></div></section>
 <section class="card geometryview" data-card-id="geometry"><h2>Geometry</h2><div class="kv" id="geometry"></div></section>
-<section class="card planview" data-card-id="planview"><h2>Plan View</h2><div class="legend"><span><i class="dot" style="background:#2ca02c"></i>done</span><span><i class="dot" style="background:#ff7f0e"></i>current</span><span><i class="dot" style="background:#bdbdbd"></i>pending</span><span class="legend-note">OTF lines / ON visits</span></div><div id="plotview" class="plotbox small">-</div></section>
+<section class="card planview" data-card-id="planview"><h2>Plan View</h2><div class="legend"><span><i class="dot" style="background:#2ca02c"></i>done</span><span><i class="dot" style="background:#ff7f0e"></i>current</span><span><i class="dot" style="background:#bdbdbd"></i>pending</span><span class="legend-note">OTF lines / ON visits</span><span class="plot-scale-tools" title="Change the Plan View plot size inside this card"><button type="button" id="plotScaleMinus" class="plot-scale-btn" title="Make Plan View smaller">−</button><button type="button" id="plotScaleReset" class="plot-scale-reset" title="Fit Plan View to card">Fit</button><button type="button" id="plotScalePlus" class="plot-scale-btn" title="Make Plan View larger">+</button><span id="plotScaleReadout">100%</span></span></div><div id="plotview" class="plotbox small">-</div></section>
 <section class="card traceview" data-card-id="trace"><h2>System Trace</h2><div class="kv" id="trace"></div></section>
 <section class="card queueview" data-card-id="queue"><h2>Command Queue</h2><div class="kv" id="queue"></div></section>
 <section class="card spectrometerview" data-card-id="spectrometer"><h2>Spectrometer</h2><div class="kv" id="spectrometer"></div></section>
@@ -3790,15 +3799,16 @@ body.layout-unlocked .card.resizing { outline:2px solid var(--warn); cursor:nwse
 </div>
 <script>
 const refreshMs = __REFRESH_MS__;
-const layoutStorageKey = 'necst-progress-card-layout-v52';
-const oldLayoutStorageKeys = ['necst-progress-card-layout-v51', 'necst-progress-card-layout-v50', 'necst-progress-card-layout-v49', 'necst-progress-card-layout-v48', 'necst-progress-card-layout-v47', 'necst-progress-card-layout-v46', 'necst-progress-card-layout-v45', 'necst-progress-card-layout-v44', 'necst-progress-card-layout-v43', 'necst-progress-card-layout-v42'];
+const PLOT = {w: 660, h: 460, left: 64, right: 612, top: 42, bottom: 362};
+const layoutStorageKey = 'necst-progress-card-layout-v54';
+const oldLayoutStorageKeys = ['necst-progress-card-layout-v53', 'necst-progress-card-layout-v52', 'necst-progress-card-layout-v51', 'necst-progress-card-layout-v50', 'necst-progress-card-layout-v49', 'necst-progress-card-layout-v48', 'necst-progress-card-layout-v47', 'necst-progress-card-layout-v46', 'necst-progress-card-layout-v45', 'necst-progress-card-layout-v44', 'necst-progress-card-layout-v43', 'necst-progress-card-layout-v42'];
 const defaultCardLayout = [
   {id:'position', col:3, row:12},
   {id:'observation', col:3, row:12},
   {id:'activity', col:2, row:12},
   {id:'geometry', col:2, row:12},
   {id:'environment', col:2, row:12},
-  {id:'planview', col:5, row:20},
+  {id:'planview', col:5, row:24},
   {id:'plan', col:2, row:20},
   {id:'queue', col:2, row:20},
   {id:'spectrometer', col:3, row:20},
@@ -3819,6 +3829,11 @@ const defaultCardFontScale = 1.0;
 const minCardFontScale = 0.70;
 const maxCardFontScale = 1.40;
 const cardFontScaleStep = 0.05;
+const planPlotScaleStorageKey = 'necst-progress-plan-plot-scale-v2';
+const defaultPlanPlotScale = 1.0;
+const minPlanPlotScale = 0.65;
+const maxPlanPlotScale = 1.35;
+const planPlotScaleStep = 0.08;
 const supportsCssZoom = (() => { try { return !!(window.CSS && CSS.supports && CSS.supports('zoom', '1')); } catch (_) { return false; } })();
 const isSafariBrowser = (() => {
   const ua = String(navigator.userAgent || '');
@@ -4013,6 +4028,7 @@ function applyLayoutState(state) {
     el.style.minHeight = '';
     delete el.dataset.layoutMinHeight;
   });
+  schedulePlanPlotResize();
 }
 function currentLayoutState() {
   const def = defaultLayoutState();
@@ -4159,6 +4175,71 @@ function ensureCardFontControls(card) {
   tools.append(dec, reset, inc);
   card.appendChild(tools);
 }
+function readPlanPlotScale() {
+  try {
+    const raw = Number(localStorage.getItem(planPlotScaleStorageKey));
+    if (Number.isFinite(raw)) return clampNumber(raw, minPlanPlotScale, maxPlanPlotScale);
+  } catch (_) {}
+  return defaultPlanPlotScale;
+}
+function resizePlanPlotToCard() {
+  const plot = document.getElementById('plotview');
+  const svg = plot ? plot.querySelector('svg') : null;
+  if (!plot || !svg) return;
+  const width = Math.max(1, plot.clientWidth || plot.getBoundingClientRect().width || 1);
+  const height = Math.max(1, plot.clientHeight || plot.getBoundingClientRect().height || 1);
+  const fit = Math.min(width / PLOT.w, height / PLOT.h);
+  if (!Number.isFinite(fit) || fit <= 0) return;
+  const scale = readPlanPlotScale();
+  const renderW = Math.max(1, PLOT.w * fit * scale);
+  const renderH = Math.max(1, PLOT.h * fit * scale);
+  plot.style.setProperty('--plan-plot-render-w', `${renderW.toFixed(1)}px`);
+  plot.style.setProperty('--plan-plot-render-h', `${renderH.toFixed(1)}px`);
+}
+function schedulePlanPlotResize() {
+  if (typeof window === 'undefined') return;
+  window.requestAnimationFrame(() => resizePlanPlotToCard());
+}
+function applyPlanPlotScale(scale) {
+  const value = clampNumber(scale, minPlanPlotScale, maxPlanPlotScale);
+  const readout = document.getElementById('plotScaleReadout');
+  if (readout) readout.textContent = `${Math.round(value * 100)}%`;
+  schedulePlanPlotResize();
+  return value;
+}
+function setPlanPlotScale(scale, persist=true) {
+  const value = applyPlanPlotScale(scale);
+  if (persist) {
+    try { localStorage.setItem(planPlotScaleStorageKey, String(value)); } catch (_) {}
+  }
+}
+function initPlanPlotControls() {
+  applyPlanPlotScale(readPlanPlotScale());
+  const minus = document.getElementById('plotScaleMinus');
+  const plus = document.getElementById('plotScalePlus');
+  const reset = document.getElementById('plotScaleReset');
+  const stopBubble = (event) => { event.stopPropagation(); };
+  const stopDrag = (event) => { event.preventDefault(); event.stopPropagation(); };
+  const handleClick = (event) => { event.preventDefault(); event.stopPropagation(); };
+  for (const el of [minus, plus, reset]) {
+    if (!el) continue;
+    el.draggable = false;
+    el.addEventListener('pointerdown', stopBubble);
+    el.addEventListener('mousedown', stopBubble);
+    el.addEventListener('touchstart', stopBubble, {passive:true});
+    el.addEventListener('dragstart', stopDrag);
+  }
+  if (minus) minus.addEventListener('click', (event) => { handleClick(event); setPlanPlotScale(readPlanPlotScale() - planPlotScaleStep); });
+  if (plus) plus.addEventListener('click', (event) => { handleClick(event); setPlanPlotScale(readPlanPlotScale() + planPlotScaleStep); });
+  if (reset) reset.addEventListener('click', (event) => { handleClick(event); setPlanPlotScale(defaultPlanPlotScale); });
+  const plot = document.getElementById('plotview');
+  if (plot && typeof ResizeObserver !== 'undefined') {
+    const observer = new ResizeObserver(() => schedulePlanPlotResize());
+    observer.observe(plot);
+    const card = document.querySelector('[data-card-id="planview"]');
+    if (card) observer.observe(card);
+  }
+}
 function initLayoutEditor() {
   document.body.classList.toggle('safari-browser', isSafariBrowser);
   applyLayoutState(readLayoutState());
@@ -4178,8 +4259,9 @@ function initLayoutEditor() {
     saveAndApplyLayout(st);
   });
   if (reset) reset.addEventListener('click', () => {
-    try { localStorage.removeItem(layoutStorageKey); for (const key of oldLayoutStorageKeys) localStorage.removeItem(key); } catch (_) {}
+    try { localStorage.removeItem(layoutStorageKey); for (const key of oldLayoutStorageKeys) localStorage.removeItem(key); localStorage.removeItem(planPlotScaleStorageKey); localStorage.removeItem('necst-progress-plan-plot-scale-v1'); } catch (_) {}
     applyLayoutState(defaultLayoutState());
+    setPlanPlotScale(defaultPlanPlotScale);
     setLayoutUnlocked(false);
   });
   for (const card of document.querySelectorAll('.card[data-card-id]')) {
@@ -4217,11 +4299,12 @@ function initLayoutEditor() {
       saveAndApplyLayout(state);
     });
   }
-  const onViewportResize = () => applyLayoutState(readLayoutState());
+  const onViewportResize = () => { applyLayoutState(readLayoutState()); schedulePlanPlotResize(); };
   window.addEventListener('resize', onViewportResize);
   if (window.visualViewport) window.visualViewport.addEventListener('resize', onViewportResize);
 }
 initLayoutEditor();
+initPlanPlotControls();
 
 function esc(v) { return String(v ?? '-').replace(/[&<>\"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','\"':'&quot;',"'":'&#39;'}[c])); }
 function isTimeLike(label, key) {
@@ -5037,7 +5120,6 @@ function statusFor(item, snapshot, events) {
   if (!finalState && ((cur && (uid === cur || parent === cur)) || inRange(item, cr))) return 'current';
   return 'pending';
 }
-const PLOT = {w: 660, h: 460, left: 64, right: 612, top: 42, bottom: 362};
 function sx(x, bounds) { return PLOT.left + (x-bounds.xmin) * (PLOT.right-PLOT.left) / Math.max(1e-9, bounds.xmax-bounds.xmin); }
 function sy(y, bounds) { return PLOT.bottom - (y-bounds.ymin) * (PLOT.bottom-PLOT.top) / Math.max(1e-9, bounds.ymax-bounds.ymin); }
 function colorFor(status) { return status === 'done' ? '#2ca02c' : status === 'current' ? '#ff7f0e' : '#bdbdbd'; }
@@ -5046,9 +5128,20 @@ function renderPlanView(snapshot, plan, events, serverTimeUnix=null) {
   const kinds = new Set(items.map(it=>geomOf(it).kind));
   const obsType = String(snapshot?.observation?.type || '').toLowerCase();
   const plot = document.getElementById('plotview');
-  if (kinds.has('skydip_elevation') || obsType.includes('sky')) { plot.innerHTML = renderSkydipSvg(snapshot, items, events); return; }
-  if ([...kinds].some(k => ['scan_line','scan_block_line','point','grid_point'].includes(k))) { plot.innerHTML = renderMapSvg(snapshot, items, events, serverTimeUnix); return; }
+  if (!plot) return;
+  if (kinds.has('skydip_elevation') || obsType.includes('sky')) {
+    plot.innerHTML = renderSkydipSvg(snapshot, items, events);
+    schedulePlanPlotResize();
+    return;
+  }
+  if ([...kinds].some(k => ['scan_line','scan_block_line','point','grid_point'].includes(k))) {
+    plot.innerHTML = renderMapSvg(snapshot, items, events, serverTimeUnix);
+    schedulePlanPlotResize();
+    return;
+  }
   plot.innerHTML = '<div>No plottable geometry yet.</div>';
+  plot.style.removeProperty('--plan-plot-render-w');
+  plot.style.removeProperty('--plan-plot-render-h');
 }
 function itemMode(item) { return String(item?.mode || geomOf(item).mode || '').toUpperCase(); }
 function pointKind(item) {
@@ -5523,7 +5616,7 @@ function renderMapSvg(snapshot, items, events, serverTimeUnix=null) {
     countText = `Point ${c.done}/${c.total} done, cur ${c.current}, rem ${c.remaining}`;
     note = 'orange=current; HOT hidden';
   }
-  return `<svg viewBox="0 0 ${PLOT.w} ${PLOT.h}" role="img" preserveAspectRatio="xMidYMid meet"><defs><marker id="arrowhead" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="5" markerHeight="5" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#ff7f0e"/></marker></defs><rect x="1" y="1" width="${PLOT.w-2}" height="${PLOT.h-2}" fill="none" stroke="#9995"/><line x1="${PLOT.left}" y1="${PLOT.bottom}" x2="${PLOT.right}" y2="${PLOT.bottom}" stroke="#777"/><line x1="${PLOT.left}" y1="${PLOT.top}" x2="${PLOT.left}" y2="${PLOT.bottom}" stroke="#777"/><text class="axis-label" x="${(PLOT.left+PLOT.right)/2-55}" y="${PLOT.bottom+42}">${esc(axes.x)}</text><text class="axis-label" transform="translate(17 ${(PLOT.top+PLOT.bottom)/2+35}) rotate(-90)">${esc(axes.y)}</text>${axisDecorations(b, axes)}${sequencePath}${lineEls}${liveEls}<text x="${PLOT.left}" y="${PLOT.h-36}" font-size="10">${esc(countText)}</text><text x="${PLOT.left}" y="${PLOT.h-18}" font-size="10">${esc(note)}</text></svg>`;
+  return `<svg width="${PLOT.w}" height="${PLOT.h}" viewBox="0 0 ${PLOT.w} ${PLOT.h}" role="img" preserveAspectRatio="xMidYMid meet"><defs><marker id="arrowhead" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="5" markerHeight="5" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#ff7f0e"/></marker></defs><rect x="1" y="1" width="${PLOT.w-2}" height="${PLOT.h-2}" fill="none" stroke="#9995"/><line x1="${PLOT.left}" y1="${PLOT.bottom}" x2="${PLOT.right}" y2="${PLOT.bottom}" stroke="#777"/><line x1="${PLOT.left}" y1="${PLOT.top}" x2="${PLOT.left}" y2="${PLOT.bottom}" stroke="#777"/><text class="axis-label" x="${(PLOT.left+PLOT.right)/2-55}" y="${PLOT.bottom+42}">${esc(axes.x)}</text><text class="axis-label" transform="translate(17 ${(PLOT.top+PLOT.bottom)/2+35}) rotate(-90)">${esc(axes.y)}</text>${axisDecorations(b, axes)}${sequencePath}${lineEls}${liveEls}<text x="${PLOT.left}" y="${PLOT.h-36}" font-size="10">${esc(countText)}</text><text x="${PLOT.left}" y="${PLOT.h-18}" font-size="10">${esc(note)}</text></svg>`;
 }
 function skydipRowsFrom(snapshot, items, events) {
   const rows=[];
@@ -5563,7 +5656,7 @@ function renderSkydipSvg(snapshot, items, events) {
   const c = pointCounts(rows);
   const cur = rows.find(r=>r.status==='current');
   const curText = cur ? `Current elevation ${cur.y.toFixed(1)} deg at step ${cur.x}/${rows.length}` : `Elevation sequence ${rows.length} steps`;
-  return `<svg viewBox="0 0 ${PLOT.w} ${PLOT.h}" role="img" preserveAspectRatio="xMidYMid meet"><rect x="1" y="1" width="${PLOT.w-2}" height="${PLOT.h-2}" fill="none" stroke="#9995"/><line x1="${PLOT.left}" y1="${PLOT.bottom}" x2="${PLOT.right}" y2="${PLOT.bottom}" stroke="#777"/><line x1="${PLOT.left}" y1="${PLOT.top}" x2="${PLOT.left}" y2="${PLOT.bottom}" stroke="#777"/>${grid}<polyline points="${poly}" fill="none" stroke="#9467bd" stroke-width="2"/>${pts}<text class="axis-label" x="${(PLOT.left+PLOT.right)/2-58}" y="${PLOT.bottom+42}">sequence step</text><text class="axis-label" transform="translate(17 ${(PLOT.top+PLOT.bottom)/2+35}) rotate(-90)">elevation (deg)</text><text x="${PLOT.left}" y="${PLOT.h-36}" font-size="10">Skydip ${c.done}/${c.total} done, cur ${c.current}, rem ${c.remaining}: ${esc(curText)}</text><text x="${PLOT.left}" y="${PLOT.h-18}" font-size="10">elevation vs sequence; HOT/load labelled when present</text></svg>`;
+  return `<svg width="${PLOT.w}" height="${PLOT.h}" viewBox="0 0 ${PLOT.w} ${PLOT.h}" role="img" preserveAspectRatio="xMidYMid meet"><rect x="1" y="1" width="${PLOT.w-2}" height="${PLOT.h-2}" fill="none" stroke="#9995"/><line x1="${PLOT.left}" y1="${PLOT.bottom}" x2="${PLOT.right}" y2="${PLOT.bottom}" stroke="#777"/><line x1="${PLOT.left}" y1="${PLOT.top}" x2="${PLOT.left}" y2="${PLOT.bottom}" stroke="#777"/>${grid}<polyline points="${poly}" fill="none" stroke="#9467bd" stroke-width="2"/>${pts}<text class="axis-label" x="${(PLOT.left+PLOT.right)/2-58}" y="${PLOT.bottom+42}">sequence step</text><text class="axis-label" transform="translate(17 ${(PLOT.top+PLOT.bottom)/2+35}) rotate(-90)">elevation (deg)</text><text x="${PLOT.left}" y="${PLOT.h-36}" font-size="10">Skydip ${c.done}/${c.total} done, cur ${c.current}, rem ${c.remaining}: ${esc(curText)}</text><text x="${PLOT.left}" y="${PLOT.h-18}" font-size="10">elevation vs sequence; HOT/load labelled when present</text></svg>`;
 }
 async function update() {
   try {

--- a/bin/progress.py
+++ b/bin/progress.py
@@ -4177,8 +4177,14 @@ function ensureCardFontControls(card) {
 }
 function readPlanPlotScale() {
   try {
-    const raw = Number(localStorage.getItem(planPlotScaleStorageKey));
-    if (Number.isFinite(raw)) return clampNumber(raw, minPlanPlotScale, maxPlanPlotScale);
+    const text = localStorage.getItem(planPlotScaleStorageKey);
+    // localStorage.getItem() returns null when the key is absent.
+    // Number(null) is 0 in JavaScript, which was accidentally clamped to
+    // minPlanPlotScale (=65%) and made first-time Plan View too small.
+    if (text !== null && String(text).trim() !== '') {
+      const raw = Number(text);
+      if (Number.isFinite(raw)) return clampNumber(raw, minPlanPlotScale, maxPlanPlotScale);
+    }
   } catch (_) {}
   return defaultPlanPlotScale;
 }

--- a/bin/progress.py
+++ b/bin/progress.py
@@ -302,13 +302,11 @@ def _live_truth_scrub_stale_motion(
         queue_depth = 0
     queue_active = bool(queue_fresh and (queue.get("active") or queue_depth > 0))
 
-    section_fresh = _topic_received_fresh(live_payload, "section_status")
-    section_active = bool(section_fresh and section.get("active"))
-
-    control_fresh = _topic_received_fresh(live_payload, "control")
-    control_active = bool(control_fresh and (control.get("controlled") or control.get("tight")))
-
-    live_motion_active = bool(command_valid or queue_active or section_active or control_active)
+    # Operator-facing Moving/Tracking must not be inferred from section/control
+    # diagnostic topics.  These can remain active or carry planned scan metadata
+    # after stop/abort.  Use the real altaz command stream and explicit command
+    # queue activity only.
+    live_motion_active = bool(command_valid or queue_active)
     activity = out.setdefault("activity", {})
     if not isinstance(activity, dict):
         return
@@ -316,8 +314,6 @@ def _live_truth_scrub_stale_motion(
     activity["live_motion_source"] = (
         "command" if command_valid else
         "queue_status" if queue_active else
-        "section_status" if section_active else
-        "control_status" if control_active else
         "none"
     )
 
@@ -1336,28 +1332,19 @@ def _live_payload_has_position(live_payload: Mapping[str, Any]) -> bool:
     """
     if not isinstance(live_payload, Mapping):
         return False
-    pointing = (
-        live_payload.get("pointing_status")
-        if isinstance(live_payload.get("pointing_status"), Mapping)
-        else {}
-    )
     encoder = (
         live_payload.get("encoder")
         if isinstance(live_payload.get("encoder"), Mapping)
         else {}
     )
 
-    # An idle snapshot must represent the actual telescope position.  A live
-    # command-only sample may be stale or merely the last target, so it must not
-    # fabricate an "idle antenna position" when no encoder/pointing encoder value
-    # is available.
-    for payload, keys in (
-        (pointing, ("enc_az_deg", "enc_el_deg")),
-        (encoder, ("encoder_lon_deg", "encoder_lat_deg")),
-    ):
-        if any(_finite_float(payload.get(key)) is not None for key in keys):
-            return True
-    return False
+    # An idle snapshot must represent the actual telescope position.  Use only
+    # the real encoder topic here.  AntennaPointingStatus is a diagnostic topic
+    # and may be invalid or extrapolated when no command is active.
+    return (
+        _finite_float(encoder.get("encoder_lon_deg")) is not None
+        and _finite_float(encoder.get("encoder_lat_deg")) is not None
+    )
 
 
 def make_idle_live_snapshot(
@@ -1451,21 +1438,21 @@ def merge_live_telemetry(
         if isinstance(live_payload.get("encoder"), dict)
         else {}
     )
-    pointing = (
-        live_payload.get("pointing_status")
-        if isinstance(live_payload.get("pointing_status"), dict)
-        else {}
-    )
+    # AntennaPointingStatus is a diagnostic topic derived from altaz + encoder
+    # and may contain interpolated/extrapolated command values even after the
+    # real altaz command stream stops.  Do not use it for Current, Command,
+    # Tracking, or Moving state in operator-facing displays.
+    pointing: Dict[str, Any] = {}
     az_unwrap = (
         live_payload.get("az_unwrap_status")
         if isinstance(live_payload.get("az_unwrap_status"), dict)
         else {}
     )
     # Always start from direct encoder telemetry.  Command display is stricter:
-    # it must represent a real, fresh command status topic (or a valid
-    # pointing_status command), not an observation plan, old progress snapshot,
-    # or interpolated section.  Otherwise Command Az/El can keep moving after
-    # abort even when no command topic is being published.
+    # it must represent a real, fresh altaz command topic callback only, not an
+    # observation plan, old progress snapshot, AntennaPointingStatus, or
+    # interpolated section.  Otherwise Command Az/El can keep moving after abort
+    # even when no real command topic is being published.
     command_valid = False
     command_source = "none"
     live_ages = (
@@ -1488,61 +1475,8 @@ def merge_live_telemetry(
     if enc:
         antenna_update.update(enc)
 
-    if pointing:
-        antenna_update["pointing_status_available"] = True
-        pointing_valid = bool(pointing.get("valid", False))
-        antenna_update["pointing_status_valid"] = pointing_valid
-        cmd_az = _finite_float(pointing.get("cmd_az_deg"))
-        cmd_el = _finite_float(pointing.get("cmd_el_deg"))
-        enc_az = _finite_float(pointing.get("enc_az_deg"))
-        enc_el = _finite_float(pointing.get("enc_el_deg"))
-        pointing_cmd_age = _finite_float(pointing.get("cmd_age_sec"))
-        pointing_cmd_fresh = (
-            pointing_cmd_age is not None
-            and pointing_cmd_age <= live_status_max_age_sec()
-        )
-        pointing_command_stale = bool(pointing.get("command_stale", False))
-        if (
-            not command_valid
-            and pointing_valid
-            and not pointing_command_stale
-            and pointing_cmd_fresh
-            and cmd_az is not None
-            and cmd_el is not None
-        ):
-            antenna_update["command_lon_deg"] = cmd_az
-            antenna_update["command_lat_deg"] = cmd_el
-            antenna_update["command_frame"] = "altaz"
-            antenna_update["command_unit"] = "deg"
-            antenna_update["command_time_unix"] = pointing.get("command_time_unix")
-            command_valid = True
-            command_source = "pointing_status"
-        if enc_az is not None and enc_el is not None:
-            antenna_update["encoder_lon_deg"] = enc_az
-            antenna_update["encoder_lat_deg"] = enc_el
-            antenna_update["encoder_frame"] = "altaz"
-            antenna_update["encoder_unit"] = "deg"
-            antenna_update["encoder_time_unix"] = pointing.get("encoder_time_unix")
-        antenna_update["tracking_status_available"] = True
-        antenna_update["tracking_ok"] = bool(pointing.get("tracking_ok", False))
-        antenna_update["tracking_error_deg"] = pointing.get("tracking_error_deg")
-        antenna_update["tracking_status_time_unix"] = pointing.get("publish_time_unix")
-        antenna_update["tracking_status_age_sec"] = (
-            max(0.0, time.time() - pointing.get("publish_time_unix", time.time()))
-            if pointing.get("publish_time_unix") is not None
-            else None
-        )
-        antenna_update["tracking_threshold_deg"] = pointing.get(
-            "tracking_threshold_deg"
-        )
-        antenna_update["command_stale"] = bool(pointing.get("command_stale", False))
-        antenna_update["encoder_stale"] = bool(pointing.get("encoder_stale", False))
-        antenna_update["command_age_sec"] = pointing.get("cmd_age_sec")
-        antenna_update["encoder_age_sec"] = pointing.get("enc_age_sec")
-        antenna_update["delta_az_deg"] = pointing.get("delta_az_deg")
-        antenna_update["delta_el_deg"] = pointing.get("delta_el_deg")
-        antenna_update["delta_az_cos_el_deg"] = pointing.get("delta_az_cos_el_deg")
-        antenna_update["pointing_basis"] = pointing.get("basis")
+    # Intentionally ignore AntennaPointingStatus for normal display.
+    # Tracking error is taken only from topic.antenna_tracking below.
     if az_unwrap and az_unwrap.get("enabled"):
         antenna_update["az_unwrap"] = dict(az_unwrap)
         antenna_update["az_unwrap_enabled"] = True
@@ -1556,7 +1490,8 @@ def merge_live_telemetry(
         if isinstance(live_payload.get("tracking"), dict)
         else {}
     )
-    if tracking:
+    tracking_fresh = bool(tracking and _topic_received_fresh(live_payload, "tracking"))
+    if tracking_fresh:
         terr = _finite_float(tracking.get("error_deg"))
         tstat = _finite_float(tracking.get("time_unix"))
         antenna_update["tracking_status_available"] = True
@@ -1565,7 +1500,10 @@ def merge_live_telemetry(
             antenna_update["tracking_error_deg"] = terr
         if tstat is not None:
             antenna_update["tracking_status_time_unix"] = tstat
-            antenna_update["tracking_status_age_sec"] = max(0.0, time.time() - tstat)
+        antenna_update["tracking_status_age_sec"] = _topic_receipt_age_sec(
+            live_payload, "tracking"
+        )
+        antenna_update["tracking_status_source"] = "antenna_tracking"
     else:
         # Do not compute a tracking error from the latest command and latest
         # encoder samples here.  altaz_cmd is a time-tagged command stream and
@@ -2144,7 +2082,6 @@ class LiveRosCache:
                 pass
             for topic_obj, callback in (
                 (getattr(topic, "antenna_section_status", None), section_status_cb),
-                (getattr(topic, "antenna_pointing_status", None), pointing_status_cb),
                 (getattr(topic, "antenna_az_unwrap_status", None), az_unwrap_status_cb),
                 (getattr(topic, "antenna_command_queue_status", None), queue_status_cb),
                 (getattr(topic, "spectrometer_status", None), spectrometer_status_cb),
@@ -2246,8 +2183,9 @@ class LiveRosCache:
                 payload["tracking"] = dict(self.tracking)
             if self.section_status:
                 payload["section_status"] = dict(self.section_status)
-            if self.pointing_status:
-                payload["pointing_status"] = dict(self.pointing_status)
+            # AntennaPointingStatus is intentionally not exposed to the status
+            # model.  It is diagnostic/extrapolated and must not drive
+            # Command Az/El, Tracking, or Moving display.
             if self.az_unwrap_status:
                 payload["az_unwrap_status"] = dict(self.az_unwrap_status)
             if self.queue_status:

--- a/bin/progress.py
+++ b/bin/progress.py
@@ -1572,16 +1572,19 @@ def merge_live_telemetry(
         # its newest sample is not necessarily the command at the encoder time.
         # NECST's antenna_tracking topic already performs the correct comparison.
         antenna_update.setdefault("tracking_status_available", False)
-    if antenna_update:
-        antenna_section = out.setdefault("antenna", {})
-        if not command_valid:
-            _clear_command_fields(antenna_section)
-            _clear_command_fields(antenna_update)
+    # Command Az/El must be backed by an actually received fresh command topic.
+    # The progress sidecar and observation plan may contain command-like values,
+    # but those are not the live command and must not survive after abort.
+    antenna_section = out.setdefault("antenna", {})
+    if not command_valid:
+        _clear_command_fields(antenna_section)
+        _clear_command_fields(antenna_update)
+    if antenna_update or isinstance(antenna_section, dict):
         antenna_update["command_valid"] = bool(command_valid)
         antenna_update["command_source"] = command_source
         if command_topic_age is not None:
             antenna_update["command_topic_age_sec"] = command_topic_age
-        out.setdefault("antenna", {}).update(antenna_update)
+        antenna_section.update(antenna_update)
     weather_payload = (
         live_payload.get("weather")
         if isinstance(live_payload.get("weather"), dict)
@@ -3193,7 +3196,7 @@ def render(
         cmd_lat = antenna.get("command_lat_deg")
         enc_lon = antenna.get("encoder_lon_deg")
         enc_lat = antenna.get("encoder_lat_deg")
-        if cmd_lon is not None or cmd_lat is not None:
+        if antenna.get("command_valid") is True and (cmd_lon is not None or cmd_lat is not None):
             lines.append(
                 frame_line(
                     f"cmd  : {azel_text(cmd_lon, cmd_lat, antenna.get('command_frame'))}"
@@ -4563,6 +4566,7 @@ function isOtfScanBlock(snapshot) {
 }
 function trackingExpected(snapshot) {
   const act = snapshot?.activity || {};
+  if (act.live_motion_active === false) return false;
   const stage = String(act.motion_stage || act.control_section_kind || '').toLowerCase();
   const phase = String(act.phase || snapshot?.plan?.mode || '').toUpperCase();
   if (phase !== 'ON') return false;
@@ -4810,10 +4814,11 @@ function activityRows(snapshot, serverTimeUnix=null) {
   const a = snapshot?.activity || {};
   const d = snapshot?.data || {};
   const g = snapshot?.geometry || {};
+  const liveIdle = a.live_motion_active === false;
   const rows = [
-    ['phase', a.phase],
-    ['drive', a.drive_kind],
-    ['motion', a.motion_stage || a.control_section_kind],
+    ['phase', liveIdle ? 'IDLE' : a.phase],
+    ['drive', liveIdle ? 'idle' : a.drive_kind],
+    ['motion', liveIdle ? 'idle' : (a.motion_stage || a.control_section_kind)],
     ['data', a.data_state]
   ];
   if (snapshot?.chopper && Object.keys(snapshot.chopper).length) rows.push(chopperRow(snapshot, serverTimeUnix));
@@ -4992,6 +4997,7 @@ function projectFraction(a, b, p) {
 }
 function antennaPoint(snapshot, prefix, requiredFrame) {
   const a = snapshot?.antenna || {};
+  if (prefix === 'command' && a.command_valid !== true) return null;
   const x = Number(a[`${prefix}_lon_deg`]);
   const y = Number(a[`${prefix}_lat_deg`]);
   const frame = String(a[`${prefix}_frame`] || '').toLowerCase();
@@ -5236,6 +5242,7 @@ function lineMotionKey(snapshot, row) {
   return `${rec}|${uid}|${line}|${id}|${ctrlId}|${sectionUid}`;
 }
 function isActualLineMotion(snapshot) {
+  if (snapshot?.activity?.live_motion_active !== true) return false;
   // Test/debug invariant: motion_stage=line means the line/scanning section is active.
   const drive = String(snapshot?.activity?.drive_kind || snapshot?.plan?.drive_kind || '').toLowerCase();
   const stage = String(snapshot?.activity?.motion_stage || '').toLowerCase();

--- a/bin/progress.py
+++ b/bin/progress.py
@@ -218,6 +218,33 @@ def _topic_age_sec(
     return None
 
 
+def _topic_receipt_age_sec(
+    live_payload: Mapping[str, Any],
+    key: str,
+) -> Optional[float]:
+    """Return age since the local subscriber actually received this topic.
+
+    This intentionally does *not* use timestamps carried inside the message.
+    For antenna command and control topics, message timestamps may describe the
+    planned command time rather than the wall-clock arrival time.  Using those
+    timestamps made old or interpolated command data look live after abort.
+    """
+    ages = live_payload.get("last_message_age_sec")
+    if isinstance(ages, Mapping):
+        age = _finite_float(ages.get(key))
+        if age is not None:
+            return age
+    return None
+
+
+def _topic_received_fresh(
+    live_payload: Mapping[str, Any],
+    key: str,
+) -> bool:
+    age = _topic_receipt_age_sec(live_payload, key)
+    return bool(age is not None and age <= live_status_max_age_sec())
+
+
 def _topic_is_fresh(
     live_payload: Mapping[str, Any],
     key: str,
@@ -268,17 +295,17 @@ def _live_truth_scrub_stale_motion(
     section = live_payload.get("section_status") if isinstance(live_payload.get("section_status"), Mapping) else {}
     control = live_payload.get("control") if isinstance(live_payload.get("control"), Mapping) else {}
 
-    queue_fresh = _topic_is_fresh(live_payload, "queue_status", queue)
+    queue_fresh = _topic_received_fresh(live_payload, "queue_status")
     try:
         queue_depth = int(queue.get("queue_depth", 0)) if isinstance(queue, Mapping) else 0
     except Exception:
         queue_depth = 0
     queue_active = bool(queue_fresh and (queue.get("active") or queue_depth > 0))
 
-    section_fresh = _topic_is_fresh(live_payload, "section_status", section)
+    section_fresh = _topic_received_fresh(live_payload, "section_status")
     section_active = bool(section_fresh and section.get("active"))
 
-    control_fresh = _topic_is_fresh(live_payload, "control", control)
+    control_fresh = _topic_received_fresh(live_payload, "control")
     control_active = bool(control_fresh and (control.get("controlled") or control.get("tight")))
 
     live_motion_active = bool(command_valid or queue_active or section_active or control_active)
@@ -1446,8 +1473,8 @@ def merge_live_telemetry(
         if isinstance(live_payload.get("last_message_age_sec"), dict)
         else {}
     )
-    command_topic_age = _topic_age_sec(live_payload, "command", cmd)
-    command_topic_fresh = bool(command_topic_age is not None and command_topic_age <= live_status_max_age_sec())
+    command_topic_age = _topic_receipt_age_sec(live_payload, "command")
+    command_topic_fresh = _topic_received_fresh(live_payload, "command")
     direct_cmd_az = _finite_float(
         _first_present(cmd, "command_lon_deg", "cmd_az_deg", "az_cmd_deg")
     )
@@ -1743,8 +1770,15 @@ class LiveRosCache:
         self.spectrometer_status: Dict[str, Any] = {}
         self.chopper_status: Dict[str, Any] = {}
         self.weather: Dict[str, Dict[str, Any]] = {}
+        self._sample_counts: Dict[str, int] = {}
+        self._last_message_time_unix: Dict[str, float] = {}
         if self.requested:
             self._start()
+
+    def _record_sample_locked(self, key: str) -> None:
+        now = time.time()
+        self._sample_counts[key] = int(self._sample_counts.get(key, 0)) + 1
+        self._last_message_time_unix[key] = now
 
     def _start(self) -> None:
         try:
@@ -1780,24 +1814,31 @@ class LiveRosCache:
                 }
 
             def command_cb(msg: Any) -> None:
-                self.command = _msg_coord(msg, prefix="command")
+                with self._lock:
+                    self.command = _msg_coord(msg, prefix="command")
+                    self._record_sample_locked("command")
 
             def encoder_cb(msg: Any) -> None:
-                self.encoder = _msg_coord(msg, prefix="encoder")
+                with self._lock:
+                    self.encoder = _msg_coord(msg, prefix="encoder")
+                    self._record_sample_locked("encoder")
 
             def tracking_cb(msg: Any) -> None:
                 # TrackingStatus is produced by NECST's antenna tracking node.
                 # It compares the encoder position with the command value at the
                 # encoder timestamp, using the control-side interpolation/extrapolation.
                 # Progress should not recompute tracking error from two latest samples.
-                self.tracking = {
-                    "ok": bool(getattr(msg, "ok", False)),
-                    "error_deg": _finite_float(getattr(msg, "error", None)),
-                    "time_unix": _finite_float(getattr(msg, "time", None)),
-                }
+                with self._lock:
+                    self.tracking = {
+                        "ok": bool(getattr(msg, "ok", False)),
+                        "error_deg": _finite_float(getattr(msg, "error", None)),
+                        "time_unix": _finite_float(getattr(msg, "time", None)),
+                    }
+                    self._record_sample_locked("tracking")
 
             def section_status_cb(msg: Any) -> None:
-                self.section_status = {
+                with self._lock:
+                    self.section_status = {
                     "active": bool(getattr(msg, "active", False)),
                     "control_id": str(getattr(msg, "control_id", "")),
                     "section_uid": str(getattr(msg, "section_uid", "")),
@@ -1852,10 +1893,12 @@ class LiveRosCache:
                         getattr(msg, "section_speed_deg_per_sec", None)
                     ),
                     "status_basis": str(getattr(msg, "status_basis", "")),
-                }
+                    }
+                    self._record_sample_locked("section_status")
 
             def pointing_status_cb(msg: Any) -> None:
-                self.pointing_status = {
+                with self._lock:
+                    self.pointing_status = {
                     "valid": bool(getattr(msg, "valid", False)),
                     "publish_time_unix": _finite_float(
                         getattr(msg, "publish_time_unix", None)
@@ -1887,10 +1930,12 @@ class LiveRosCache:
                     "command_stale": bool(getattr(msg, "command_stale", False)),
                     "encoder_stale": bool(getattr(msg, "encoder_stale", False)),
                     "basis": str(getattr(msg, "basis", "")),
-                }
+                    }
+                    self._record_sample_locked("pointing_status")
 
             def az_unwrap_status_cb(msg: Any) -> None:
-                self.az_unwrap_status = {
+                with self._lock:
+                    self.az_unwrap_status = {
                     "enabled": bool(getattr(msg, "enabled", False)),
                     "valid": bool(getattr(msg, "valid", False)),
                     "mode": str(getattr(msg, "mode", "")),
@@ -1917,7 +1962,8 @@ class LiveRosCache:
                 }
 
             def queue_status_cb(msg: Any) -> None:
-                self.queue_status = {
+                with self._lock:
+                    self.queue_status = {
                     "active": bool(getattr(msg, "active", False)),
                     "control_id": str(getattr(msg, "control_id", "")),
                     "mode": str(getattr(msg, "mode", "")),
@@ -2043,12 +2089,14 @@ class LiveRosCache:
                 else:
                     state = "unknown"
 
-                self.chopper_status = {
+                with self._lock:
+                    self.chopper_status = {
                     "insert": insert,
                     "state": state,
                     "position": position,
                     "time_unix": _finite_float(getattr(msg, "time", None)),
-                }
+                    }
+                    self._record_sample_locked("chopper_status")
 
             def weather_cb(key: str):
                 def _callback(msg: Any) -> None:
@@ -2077,6 +2125,7 @@ class LiveRosCache:
                     }
                     with self._lock:
                         self.weather[key] = payload
+                    self._record_sample_locked(f"weather/{key}")
 
                 return _callback
 
@@ -2169,9 +2218,18 @@ class LiveRosCache:
 
     def snapshot(self) -> Dict[str, Any]:
         with self._lock:
+            now = time.time()
+            last_age_sec = {
+                key: max(0.0, now - float(ts))
+                for key, ts in self._last_message_time_unix.items()
+            }
             payload: Dict[str, Any] = {
                 "available": self.available,
                 "spin_mode": self._spin_mode,
+                "sample_counts": dict(self._sample_counts),
+                "last_message_time_unix": dict(self._last_message_time_unix),
+                "last_message_age_sec": last_age_sec,
+                "received_topics": sorted(self._sample_counts),
             }
             if self.error:
                 payload["error"] = self.error
@@ -4737,7 +4795,7 @@ function positionRows(snapshot, psummary=null, serverTimeUnix=null) {
   const rows = [
     ['Encoder Az/El', azElText(a.encoder_lon_deg, a.encoder_lat_deg, a.encoder_frame), 'important'],
     ...(a.az_unwrap_enabled ? [['Az unwrap', azUnwrapBadgeHtml(a), 'html']] : []),
-    ['Command Az/El', azElText(a.command_lon_deg, a.command_lat_deg, a.command_frame), ''],
+    ['Command Az/El', a.command_valid === true ? azElText(a.command_lon_deg, a.command_lat_deg, a.command_frame) : '-', a.command_valid === true ? '' : 'muted'],
     ...officialTrackingRows(a, snapshot),
     [isCal ? 'calibration now' : (g.cos_correction ? 'map offset actual' : 'map offset'), isCal ? phase : (off ? coordPairText(off, frame, 'arcsec') : '-'), 'important'],
     ['progress item', psummary?.progress || '-', 'important'],

--- a/bin/progress.py
+++ b/bin/progress.py
@@ -1273,18 +1273,32 @@ def merge_live_telemetry(
         if isinstance(live_payload.get("az_unwrap_status"), dict)
         else {}
     )
+    # Always start from direct command/encoder telemetry.  The pointing_status
+    # topic can be present while invalid (for example basis=missing-command);
+    # in that case its cmd/enc fields are NaN and must not mask a valid encoder
+    # topic.  Pointing status may overwrite these values only when it provides
+    # finite values for the same quantity.
+    if cmd:
+        antenna_update.update(cmd)
+    if enc:
+        antenna_update.update(enc)
+
     if pointing:
         antenna_update["pointing_status_available"] = True
         antenna_update["pointing_status_valid"] = bool(pointing.get("valid", False))
-        if pointing.get("cmd_az_deg") is not None:
-            antenna_update["command_lon_deg"] = pointing.get("cmd_az_deg")
-            antenna_update["command_lat_deg"] = pointing.get("cmd_el_deg")
+        cmd_az = _finite_float(pointing.get("cmd_az_deg"))
+        cmd_el = _finite_float(pointing.get("cmd_el_deg"))
+        enc_az = _finite_float(pointing.get("enc_az_deg"))
+        enc_el = _finite_float(pointing.get("enc_el_deg"))
+        if cmd_az is not None and cmd_el is not None:
+            antenna_update["command_lon_deg"] = cmd_az
+            antenna_update["command_lat_deg"] = cmd_el
             antenna_update["command_frame"] = "altaz"
             antenna_update["command_unit"] = "deg"
             antenna_update["command_time_unix"] = pointing.get("command_time_unix")
-        if pointing.get("enc_az_deg") is not None:
-            antenna_update["encoder_lon_deg"] = pointing.get("enc_az_deg")
-            antenna_update["encoder_lat_deg"] = pointing.get("enc_el_deg")
+        if enc_az is not None and enc_el is not None:
+            antenna_update["encoder_lon_deg"] = enc_az
+            antenna_update["encoder_lat_deg"] = enc_el
             antenna_update["encoder_frame"] = "altaz"
             antenna_update["encoder_unit"] = "deg"
             antenna_update["encoder_time_unix"] = pointing.get("encoder_time_unix")
@@ -1308,11 +1322,6 @@ def merge_live_telemetry(
         antenna_update["delta_el_deg"] = pointing.get("delta_el_deg")
         antenna_update["delta_az_cos_el_deg"] = pointing.get("delta_az_cos_el_deg")
         antenna_update["pointing_basis"] = pointing.get("basis")
-    else:
-        if cmd:
-            antenna_update.update(cmd)
-        if enc:
-            antenna_update.update(enc)
     if az_unwrap and az_unwrap.get("enabled"):
         antenna_update["az_unwrap"] = dict(az_unwrap)
         antenna_update["az_unwrap_enabled"] = True

--- a/docs/az_unwrap_state_service_ja.md
+++ b/docs/az_unwrap_state_service_ja.md
@@ -1,0 +1,89 @@
+# Az unwrap state service 運用メモ
+
+## 結論
+
+`antenna_az_unwrap_state.json` は、encoder_readout が読んでいる `state_path` に保存されなければ意味がない。
+Docker 内の `~/.necst` が永続化されていない場合、`state_path = "~/.necst/antenna_az_unwrap_state.json"` のまま運用すると、container 再作成で branch state が消える危険がある。
+
+本パッチでは、制御PCから直接 local file を書かず、encoder_readout node に ROS service call で依頼する経路を追加した。
+実際に JSON を書くのは encoder_readout process なので、実行端末の `~/.necst` ではなく、encoder node の `state_path` に書かれる。
+
+## 推奨設定
+
+Docker 内の `~` に依存しないように、観測所 TOML では永続 bind mount された絶対パスを使う。
+
+```toml
+[antenna_encoder_unwrap.az]
+enabled = true
+state_path = "/necst_state/antenna_az_unwrap_state.json"
+```
+
+Docker 起動時には host 側の永続 directory を bind mount する。
+
+```bash
+-v /persistent/necst_state:/necst_state
+```
+
+## 通常操作
+
+encoder_readout が起動している状態で、制御PCから次を実行する。
+
+```bash
+necst az-unwrap-state status
+necst az-unwrap-state set --raw-az 8.997253 --continuous-az 368.997253
+```
+
+または ROS executable として直接呼ぶ。
+
+```bash
+ros2 run necst necst-antenna-az-unwrap-state status
+ros2 run necst necst-antenna-az-unwrap-state set --raw-az 8.997253 --continuous-az 368.997253
+```
+
+これらは default では encoder_readout の service を呼ぶ。
+
+## local fallback
+
+encoder node が起動していない非常時だけ、encoder PC/container 内で明示的に `--local` を付けて使う。
+
+```bash
+python3 -m necst.ctrl.antenna.az_unwrap --local status
+python3 -m necst.ctrl.antenna.az_unwrap --local set --raw-az 8.997253 --continuous-az 368.997253
+```
+
+`--local` は実行した process の config/state_path を直接読むため、制御PCで使うと誤った `~/.necst` に書く可能性がある。
+通常運用では使わない。
+
+## service 名
+
+```text
+/necst/<OBSERVATORY>/ctrl/antenna/az_unwrap_state/get
+/necst/<OBSERVATORY>/ctrl/antenna/az_unwrap_state/set
+```
+
+`set` service は raw/continuous/branch の整合性、drive range、enabled/state_path を encoder node 側で検査し、拒否時は JSON を書かない。
+
+
+## unwrap無効時のAz指令制限
+
+absolute-modulo Az encoder 用の `[antenna_encoder_unwrap.az]` が設定されているが、`enabled = false` の場合、controllerはbranchを持たない。この状態で `Az=370 deg` のような連続Azを許すと、raw `10 deg` と区別できず危険である。
+
+そのため、本パッチでは `enabled = false` の間、Az指令を次のraw absolute encoder範囲に制限する。
+
+```toml
+[antenna_encoder_unwrap.az]
+enabled = false
+"raw_min[deg]" = 0.0
+"raw_max[deg]" = 360.0
+```
+
+対象は次の共通経路である。
+
+```text
+necst mount-move
+operator console mount move / dry-run
+Commander.antenna(... az_target_mode="mount")
+horizontal_coord node が生成する最終Az command
+```
+
+`antenna_encoder_unwrap` 設定自体が存在しない望遠鏡では、この制限は入らず従来通りである。北またぎ・Az>360運用を行う場合は、`enabled = true` とし、progress/consoleでbranchとraw Azを確認する。

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,5 +8,6 @@ maxdepth: 2
 ---
 
 Home <self>
+Az unwrap state service <az_unwrap_state_service_ja>
 API Reference <_source/necst>
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,5 +9,8 @@ maxdepth: 2
 
 Home <self>
 Az unwrap state service <az_unwrap_state_service_ja>
+Operator Console entry and logs <operator_console_entry_and_logs_ja>
+Operator Console runbook <operator_console_runbook_ja>
+Operator Console server and observation browser <operator_console_server_obs_browser_ja>
 API Reference <_source/necst>
 ```

--- a/docs/operator_console_entry_and_logs_ja.md
+++ b/docs/operator_console_entry_and_logs_ja.md
@@ -1,0 +1,80 @@
+# NECST Operator Console 起動コマンドとログ運用（basev24 ver29）
+
+## 1. 結論
+
+Operator Console GUI は次で起動できる。
+
+```bash
+necst console --open
+```
+
+ROS の executable として明示する場合は次でもよい。
+
+```bash
+ros2 run necst necst console --open
+ros2 run necst necst-console --open
+```
+
+従来通り、source tree から直接起動する場合は次も使える。
+
+```bash
+python3 bin/console.py --open
+```
+
+## 2. operator log の保存先
+
+Console は operator action を JSONL 形式で追記保存する。既定保存先は次である。
+
+```text
+~/.necst/operator_console/operator_console.jsonl
+```
+
+`NECST_OPERATOR_LOG_DIR` を設定すると既定保存先を変更できる。CLI で明示する場合は `--operator-log-dir` を使う。
+
+```bash
+necst console --open --operator-log-dir /data/necst/operator_console
+```
+
+`operator_console.jsonl` は同じファイルへ追記する。各行は1つのJSON objectで、時刻、成功/失敗、action名、message、session id、関連dataを含む。
+
+## 3. launcher / progress log
+
+観測、RSky、SkyDip など console が起動した subprocess の stdout/stderr は、既定では operator log directory 配下に保存される。
+
+```text
+~/.necst/operator_console/launcher_logs/
+~/.necst/operator_console/progress_logs/
+```
+
+operator log は「誰がいつ何を押したか、何が拒否されたか、どの launcher が起動したか」を追うための log である。一方、launcher log は各観測 subprocess の標準出力・標準エラーを見るための log である。
+
+## 4. log の確認
+
+GUI の Runtime status には operator log path と launcher log directory が表示される。`Read operator log` で `operator_console.jsonl` の末尾を読める。Log browser から launcher stdout/stderr の tail も確認できる。
+
+端末から確認する場合は次を使う。
+
+```bash
+necst console-log path
+necst console-log tail --limit 80
+necst console-log cat
+```
+
+ROS executable として呼ぶ場合は次でもよい。
+
+```bash
+ros2 run necst necst-console-log tail --limit 80
+```
+
+## 5. 運用上の推奨
+
+観測 trace を残す目的では、operator log directory は `/tmp` ではなく、制御PC上の永続ディレクトリ、または永続 bind mount された directory にする。
+
+推奨例:
+
+```bash
+export NECST_OPERATOR_LOG_DIR=/data/necst/operator_console
+necst console --open
+```
+
+これにより、console を再起動しても同じ `operator_console.jsonl` に追記される。

--- a/docs/operator_console_runbook_ja.md
+++ b/docs/operator_console_runbook_ja.md
@@ -1,0 +1,236 @@
+# NECST Operator Console runbook
+
+作成日: 2026-06-05  
+対象: `original zip + 06041931_v16_necst_progress_chopper_obs_defaults_upstream_patch.zip` に、本patchを適用した状態
+
+## 1. 結論
+
+通常観測時の起動は短くする。実機環境で active site config が正しく解決できる場合は、基本的に次だけでよい。
+
+```bash
+python3 bin/console.py --open
+```
+
+実機投入前の練習・確認では、`dry-run` で console server を起動し、`console-check.py` で自己診断を行う。
+
+```bash
+python3 bin/console.py --action-mode dry-run --open
+python3 bin/console-check.py
+```
+
+`console-check.py` は read-only の確認であり、望遠鏡・chopper・観測launcherを動かさない。
+
+## 2. 用語と正方向
+
+```text
+mount Az/El:
+  架台の機械角。単位はdegree。
+  Az=360をAz=0へ自動wrapしない。
+
+STOP:
+  常時使えるアンテナ停止導線。
+  browser session authority gateを通さない。
+
+ABORT observation:
+  観測sequence cleanup付き中断導線。
+
+Terminate local launcher:
+  consoleが起動したローカル子プロセスだけを止める。
+  望遠鏡STOPや観測cleanupは送らない。
+```
+
+## 3. dry-run 起動
+
+実機にcommandを送らず、site config・画面・API・log directoryを確認する。通常は次でよい。
+
+```bash
+python3 bin/console.py --action-mode dry-run --open
+```
+
+実機外でsite configを明示する場合だけ、次のように指定する。
+
+```bash
+python3 bin/console.py \
+  --action-mode dry-run \
+  --site-config ../neclib-main/neclib/defaults/OMU1p85m_config.toml \
+  --open
+```
+
+別端末で確認する。
+
+```bash
+python3 bin/console-check.py
+```
+
+consoleのURLやportを変えた場合だけ、`--url` を指定する。
+
+```bash
+python3 bin/console-check.py --url http://127.0.0.1:8092/
+```
+
+warningは、progress monitor未起動などの確認事項でも出る。errorが0であれば、read-only配線としては通っている。
+
+## 4. live 起動前の確認
+
+live modeへ進む前に、少なくとも次を確認する。
+
+```text
+1. site config sourceが意図したsiteである。
+2. mount Az/El limitが実機のsite TOMLと一致している。
+3. chopper IN/OUT位置がsiteに合っている。
+4. disabled capabilityが意図通りである。
+5. operator log directoryが書き込み可能である。
+6. launcher log directoryが書き込み可能である。
+7. /api/self-check の error_count が0である。
+8. STOP / ABORT / Stop tracking が常時使える導線として表示される。
+```
+
+## 5. live 起動
+
+通常観測時は次でよい。
+
+```bash
+python3 bin/console.py --open
+```
+
+`--action-mode` の既定値は `live` である。live modeでは、mount move / chopper / target tracking / Start observation / RSky / SkyDip などのwrite系操作が有効になる。
+
+`--site-config` を省略した場合は、実機環境の `necst.config` / neclib config の解決結果を使う。解決できない場合、mount moveはserver側で拒否される。
+
+status更新間隔の既定値は1秒である。必要な場合だけCLIで変更する。
+
+```bash
+python3 bin/console.py --open --status-refresh-ms 500
+```
+
+`--status-refresh-ms` はOperator Console自身の `/api/status` 更新間隔である。`--progress-refresh-ms` はconsoleが起動するprogress.py側のブラウザ更新間隔であり、別物である。
+
+## 6. smoke test の判定
+
+通常表示:
+
+```bash
+python3 bin/console-check.py --url http://127.0.0.1:8092/
+```
+
+JSON出力:
+
+```bash
+python3 bin/console-check.py --url http://127.0.0.1:8092/ --json
+```
+
+warningも失敗扱いにする:
+
+```bash
+python3 bin/console-check.py --url http://127.0.0.1:8092/ --fail-on-warning
+```
+
+## 7. 既知の安全設計
+
+```text
+invalid mount Az/El:
+  command送信前にserver側で拒否する。
+
+browser session authority:
+  Acquire authority は、console process内に保持Commanderを作り、
+  mount move / chopper IN/OUT/maintenance / target tracking start で再利用する。
+  このため、同じbrowser sessionからの直接Commander操作では、
+  操作ごとのCommander生成・NECST privilege取得・releaseを省ける。
+  保持session以外からの非安全操作は拒否する。
+  STOP / Stop tracking / ABORTは安全導線として拒否しない。
+  保持Commanderが外部要因でprivilegeを失った場合は、
+  staleなbrowser gateを自動的に解除する。
+
+Start / RSky / SkyDip:
+  HTTP requestを観測終了までブロックしない。
+  launcher subprocessとして起動し、PID・stdout/stderr・return codeを記録する。
+  これらは別processでprivilegeを取得するため、consoleがAcquire authority済みなら、
+  launcher commandのpreflight validationを通した後、launcher起動直前に
+  console側の保持privilegeを解放する。入力不正の場合はauthorityを解放しない。
+  従って、Acquire authorityは観測launcher自体を高速化しない。
+  役割は、観測開始ボタンを押すまで同じconsole sessionで操作権を保持することに限られる。
+
+console shutdown:
+  console-owned authorityを解放する。
+  console-owned progress monitorを停止する。
+  console-owned local launcherをterminateする。
+```
+
+## 8. 実機で最初に押すべき順序
+
+```text
+1. Run self-check
+2. Launch progress monitor
+3. Check obs file
+4. Dry run
+5. Mount move dry-run
+6. 必要ならAcquire authority
+   - mount move / chopper / target tracking start を連続して行う場合は有効。
+   - Start observation / RSky / SkyDip では、launcher起動直前にconsole側authorityを解放するため、
+     観測launcherの実行時間短縮にはならない。
+7. live操作へ進む
+```
+
+いきなりStart observationやmount moveを押さない。
+
+## 8. operator log / launcher log の確認
+
+console は操作結果を `operator_console.jsonl` に永続記録します。観測launcher / RSky / SkyDip をconsoleから起動した場合は、launcher の stdout/stderr も `launcher_logs/` 以下に保存します。
+
+GUIでは Runtime status の `Log browser` から次を確認できます。
+
+```text
+Read operator log
+  operator_console.jsonl の末尾を読む。
+  操作時刻、action名、OK/NG、rejected reasonを確認する。
+
+launcher stdout/stderr button
+  consoleが起動したlocal launcher subprocessのstdout/stderr log末尾を読む。
+  望遠鏡STOPやABORTは送らない。read-only確認である。
+```
+
+APIで確認する場合:
+
+```bash
+curl http://127.0.0.1:8092/api/operator-log?limit=80
+curl "http://127.0.0.1:8092/api/log-file?path=/absolute/path/to/launcher.stdout.log&max_bytes=32768"
+```
+
+`/api/log-file` は任意ファイルを読ませないため、consoleが設定した operator log directory / launcher log directory / progress log directory の内側だけを許可します。観測データや任意の設定ファイルをブラウザから読む用途には使わないでください。
+
+smoke testにも `/api/operator-log` のread-only確認を含めています。
+
+```bash
+python3 bin/console-check.py --url http://127.0.0.1:8092/
+```
+
+## 9. live / dry-run / guarded live の使い分け
+
+通常の実機観測では、追加のarming optionは不要である。
+
+```bash
+python3 bin/console.py --open
+```
+
+実機にcommandを送りたくない検証では、`dry-run` を使う。
+
+```bash
+python3 bin/console.py --action-mode dry-run --open
+```
+
+特殊な診断として、live telemetryやread-only APIは見たいがwrite系live操作だけ止めたい場合は、`--guard-live-actions` を使える。ただし通常運用では使わない。
+
+```bash
+python3 bin/console.py --open --guard-live-actions
+```
+
+`--guard-live-actions` 中でも許可される安全操作:
+
+```text
+STOP
+Stop tracking
+ABORT observation
+local launcher terminate/kill
+```
+
+write系操作を止めたい通常の確認では、`--guard-live-actions` より `--action-mode dry-run` を推奨する。

--- a/docs/operator_console_runbook_ja.md
+++ b/docs/operator_console_runbook_ja.md
@@ -105,6 +105,44 @@ python3 bin/console.py --open --status-refresh-ms 500
 
 `--status-refresh-ms` はOperator Console自身の `/api/status` 更新間隔である。`--progress-refresh-ms` はconsoleが起動するprogress.py側のブラウザ更新間隔であり、別物である。
 
+
+## 5.1 Current Az/El / Chopper state の取得
+
+Operator Console は、通常起動では console process 自身が read-only ROS subscriber を持ち、
+`/necst/antenna/encoder`, command, pointing status, chopper status などのlive telemetryを
+`/api/status`へ反映する。したがって、通常はCurrent Az/ElとChopper IN/OUTはconsole画面だけで更新される。
+
+```bash
+python3 bin/console.py --open
+```
+
+実機外でROSなし確認をしたい場合、またはstatus取得経路を意図的に切り離す場合だけ、次を使う。
+
+```bash
+python3 bin/console.py --open --no-ros
+```
+
+`--no-ros` を指定すると、consoleはROS topicを購読しない。この場合、観測中のprogress sidecarから得られる値以外は、Current Az/ElやChopper状態が更新されないことがある。
+実機でCurrent Az/Elが更新されない場合は、まずRuntime statusの `live_telemetry.available` 相当、operator logの `live_telemetry enabled/unavailable`、および `/api/status` の `live_telemetry` フィールドを確認する。
+
+## 5.2 観測データディレクトリ表示
+
+Runtime status の `Current observation data` には、現在の観測に対応するディレクトリを表示する。
+
+```text
+Record:
+  observation record_name
+
+Data directory:
+  NECST_RECORD_ROOT/record_name
+  ただし record_name が絶対pathならそのまま
+
+Progress directory:
+  NECST_PROGRESS_ROOT/<safe_record_name>
+```
+
+RecorderControllerの既定値と同じく、`NECST_RECORD_ROOT` が未設定の場合のData directoryは `~/data/<record_name>` として表示する。これは表示用の推定であり、実際の保存先はRecorderControllerの設定に従う。
+
 ## 6. smoke test の判定
 
 通常表示:

--- a/docs/operator_console_server_obs_browser_ja.md
+++ b/docs/operator_console_server_obs_browser_ja.md
@@ -1,16 +1,16 @@
 # NECST Operator Console: NECST側 file chooser
 
-対象: `06051943_ver35_basev24_console_necst_side_file_chooser_patch.zip`
+対象: `06051950_ver36_basev24_console_modal_file_chooser_patch.zip`
 
 ## 1. 結論
 
-Operator Console の観測指示書選択は、ブラウザPCの通常 file chooser ではなく、**NECST console を起動している側のファイルシステム**を GUI 内で参照する方式にした。
+Operator Console の観測指示書選択は、ブラウザ標準の file chooser ではなく、**NECST console を起動している側のファイルシステム**を GUI から選ぶ方式である。
 
 - console が Docker 内で起動している場合: Docker/container 内のファイルを見る。
 - console が物理PC上で起動している場合: そのPC上のファイルを見る。
 - 選んだ `.obs` / `.toml` は、Preview / Check / Dry run / Start で同じ path を使う。
 
-これにより、ブラウザPCのローカルファイルを選んだつもりで、Docker 内の観測実行 path とずれる問題を避ける。
+ブラウザ標準 file chooser は、ブラウザを開いているPCのファイルしか見えない。そのため、Docker 内や NECST 側の実行 path とは一致しない。このずれを避けるため、Operator Console では NECST側 file chooser を使う。
 
 ## 2. 基本操作
 
@@ -20,22 +20,46 @@ Operator Console の観測指示書選択は、ブラウザPCの通常 file choo
 necst console --open
 ```
 
-GUI の Observation setup で、`NECST-side file location` から開始場所を選び、下の file chooser でフォルダを開いて `.obs` または `.toml` をクリックする。
+Observation setup の `Obs file on NECST side` の横にある `Choose...` を押す。
+
+ダイアログが開くので、通常の file chooser と同じ感覚でフォルダを開き、`.obs` または `.toml` をクリックする。
 
 クリックしたファイルについて、次が自動で更新される。
 
 ```text
+Obs file on NECST side
 Obs directory on NECST side
 Obs filename
-Computed run path on NECST side
 Preview text
 ```
 
-この `Computed run path` が、Check / Dry run / Start observation に使われる実行 path である。
+この `Obs file on NECST side` が、Check / Dry run / Start observation に使われる実行 path である。
 
-## 3. `--obs-root` を指定しない場合
+## 3. 画面上の考え方
 
-`--obs-root` を指定しない場合でも、GUI は空にならない。console は、NECST console を起動している側から見える次のような場所を開始候補として出す。
+通常画面には、大きなファイル一覧を常時表示しない。
+
+```text
+通常画面:
+  選択済みobs file
+  Choose...
+  Preview
+  Check / Dry run / Start
+
+Choose... ダイアログ:
+  NECST側のフォルダ一覧
+  .obs/.toml ファイル一覧
+  Home / Up / Refresh
+  Current folder
+```
+
+これにより、観測開始画面のスペースを無駄にせず、必要な時だけ file chooser を開く。
+
+## 4. `--obs-root` を指定しない場合
+
+`--obs-root` は必須ではない。指定しない場合でも、console は NECST console を起動している側から見える一般的な場所を開始候補として出す。
+
+例:
 
 ```text
 Home
@@ -43,11 +67,11 @@ Current directory
 ~/obs
 ~/observations
 ~/data
+/root
 /root/obs
 /root/observations
 /root/data
 /root/ros2_ws
-/root
 /data
 /data/obs
 /data/observations
@@ -58,9 +82,9 @@ Current directory
 
 存在するディレクトリだけを表示する。`/` も候補に入るので、通常の file chooser に近い感覚で上位階層からたどれる。
 
-## 4. `--obs-root` を指定する場合
+## 5. `--obs-root` を指定する場合
 
-観測指示書の置き場を限定したい場合、または特殊な場所を最初から出したい場合だけ、明示する。
+観測指示書の置き場を限定したい場合、または特定ディレクトリを最初から出したい場合だけ明示する。
 
 ```bash
 necst console --open --obs-root /root/obs
@@ -81,51 +105,48 @@ export NECST_CONSOLE_OBS_ROOTS=/root/obs:/data/observations/current
 necst console --open
 ```
 
-`--obs-root` または `NECST_CONSOLE_OBS_ROOTS` を指定した場合は、それらを file chooser の開始場所として使う。
+`--obs-root` は必須設定ではなく、開始場所を絞るための補助である。
 
-## 5. ブラウザPCの file chooser との違い
-
-HTML の通常 file chooser は、ブラウザを開いているPCのファイルしか見えない。そのため、Docker 内や NECST 側の path は取得できない。
-
-今回の GUI 内 file chooser は、console が `/api/obs-list` と `/api/obs-preview` で NECST 側ファイルを一覧・previewする。
-
-つまり:
+## 6. ブラウザPCの file chooser との違い
 
 ```text
-通常のブラウザ file chooser:
+ブラウザ標準 file chooser:
   ブラウザPCのファイルを見る
+  Docker内/NECST側の絶対pathは取得できない
 
-Operator Console の NECST-side file chooser:
+Operator Console の NECST側 file chooser:
   consoleを起動している側のファイルを見る
+  Docker内で起動していればDocker内を見る
+  previewしたファイルとStartするファイルが一致する
 ```
 
-## 6. local preview
+## 7. local preview
 
-`Optional local preview only` は残しているが、これは比較用である。Start observation には使わない。
+`Optional local preview only` は比較用である。Start observation には使わない。
 
-通常運用では、NECST-side file chooser で選んだファイルを使う。
+通常運用では、`Choose...` で開く NECST側 file chooser から観測指示書を選ぶ。
 
-## 7. 読み取り範囲とpreview
+## 8. preview制限
 
-既定では通常の file chooser に近く使えるよう、`/` も開始候補に含める。ただし、preview は観測指示書向けに限定し、`.obs`, `.toml`, `.txt` だけを表示する。
+preview は観測指示書向けに限定し、`.obs`, `.toml`, `.txt` だけを表示する。
 
 ネットワーク越しに console を公開する運用では、必要に応じて `--obs-root` で開始場所を観測指示書ディレクトリに限定する。
 
-## 8. demoでの表示
+## 9. demoでの表示
 
 `bin/console-demo.py` を単独で開いた場合、実際の NECST 側ファイルシステムは読めない。その場合は demo 用の仮想 file chooser を表示する。
 
 実運用の `necst console --open` では、実際に console を起動している側のファイルシステムを表示する。
 
-## 9. 確認方法
+## 10. 確認方法
 
 起動後に以下を確認する。
 
 ```text
-NECST-side file location が表示される
+Choose... を押すと NECST側 file chooser ダイアログが開く
 フォルダをクリックするとその中へ移動する
 Up / Home / Refresh が動く
-.obs / .toml をクリックすると preview が出る
-Computed run path が preview と同じ path になる
+.obs / .toml をクリックするとダイアログが閉じ、preview が出る
+Obs file on NECST side が preview と同じ path になる
 Check / Dry run / Start が同じ path を使う
 ```

--- a/docs/operator_console_server_obs_browser_ja.md
+++ b/docs/operator_console_server_obs_browser_ja.md
@@ -1,0 +1,131 @@
+# NECST Operator Console: NECST側 file chooser
+
+対象: `06051943_ver35_basev24_console_necst_side_file_chooser_patch.zip`
+
+## 1. 結論
+
+Operator Console の観測指示書選択は、ブラウザPCの通常 file chooser ではなく、**NECST console を起動している側のファイルシステム**を GUI 内で参照する方式にした。
+
+- console が Docker 内で起動している場合: Docker/container 内のファイルを見る。
+- console が物理PC上で起動している場合: そのPC上のファイルを見る。
+- 選んだ `.obs` / `.toml` は、Preview / Check / Dry run / Start で同じ path を使う。
+
+これにより、ブラウザPCのローカルファイルを選んだつもりで、Docker 内の観測実行 path とずれる問題を避ける。
+
+## 2. 基本操作
+
+通常起動:
+
+```bash
+necst console --open
+```
+
+GUI の Observation setup で、`NECST-side file location` から開始場所を選び、下の file chooser でフォルダを開いて `.obs` または `.toml` をクリックする。
+
+クリックしたファイルについて、次が自動で更新される。
+
+```text
+Obs directory on NECST side
+Obs filename
+Computed run path on NECST side
+Preview text
+```
+
+この `Computed run path` が、Check / Dry run / Start observation に使われる実行 path である。
+
+## 3. `--obs-root` を指定しない場合
+
+`--obs-root` を指定しない場合でも、GUI は空にならない。console は、NECST console を起動している側から見える次のような場所を開始候補として出す。
+
+```text
+Home
+Current directory
+~/obs
+~/observations
+~/data
+/root/obs
+/root/observations
+/root/data
+/root/ros2_ws
+/root
+/data
+/data/obs
+/data/observations
+/workspace
+/workspaces
+/
+```
+
+存在するディレクトリだけを表示する。`/` も候補に入るので、通常の file chooser に近い感覚で上位階層からたどれる。
+
+## 4. `--obs-root` を指定する場合
+
+観測指示書の置き場を限定したい場合、または特殊な場所を最初から出したい場合だけ、明示する。
+
+```bash
+necst console --open --obs-root /root/obs
+```
+
+複数指定も可能:
+
+```bash
+necst console --open \
+  --obs-root /root/obs \
+  --obs-root /data/observations/current
+```
+
+環境変数でも指定できる。
+
+```bash
+export NECST_CONSOLE_OBS_ROOTS=/root/obs:/data/observations/current
+necst console --open
+```
+
+`--obs-root` または `NECST_CONSOLE_OBS_ROOTS` を指定した場合は、それらを file chooser の開始場所として使う。
+
+## 5. ブラウザPCの file chooser との違い
+
+HTML の通常 file chooser は、ブラウザを開いているPCのファイルしか見えない。そのため、Docker 内や NECST 側の path は取得できない。
+
+今回の GUI 内 file chooser は、console が `/api/obs-list` と `/api/obs-preview` で NECST 側ファイルを一覧・previewする。
+
+つまり:
+
+```text
+通常のブラウザ file chooser:
+  ブラウザPCのファイルを見る
+
+Operator Console の NECST-side file chooser:
+  consoleを起動している側のファイルを見る
+```
+
+## 6. local preview
+
+`Optional local preview only` は残しているが、これは比較用である。Start observation には使わない。
+
+通常運用では、NECST-side file chooser で選んだファイルを使う。
+
+## 7. 読み取り範囲とpreview
+
+既定では通常の file chooser に近く使えるよう、`/` も開始候補に含める。ただし、preview は観測指示書向けに限定し、`.obs`, `.toml`, `.txt` だけを表示する。
+
+ネットワーク越しに console を公開する運用では、必要に応じて `--obs-root` で開始場所を観測指示書ディレクトリに限定する。
+
+## 8. demoでの表示
+
+`bin/console-demo.py` を単独で開いた場合、実際の NECST 側ファイルシステムは読めない。その場合は demo 用の仮想 file chooser を表示する。
+
+実運用の `necst console --open` では、実際に console を起動している側のファイルシステムを表示する。
+
+## 9. 確認方法
+
+起動後に以下を確認する。
+
+```text
+NECST-side file location が表示される
+フォルダをクリックするとその中へ移動する
+Up / Home / Refresh が動く
+.obs / .toml をクリックすると preview が出る
+Computed run path が preview と同じ path になる
+Check / Dry run / Start が同じ path を使う
+```

--- a/necst/az_unwrap_limits.py
+++ b/necst/az_unwrap_limits.py
@@ -1,0 +1,165 @@
+"""Safety helpers for Az commands when absolute Az unwrap is disabled.
+
+This module intentionally lives at the top level of :mod:`necst`, not under
+``necst.ctrl.antenna``.  Core modules such as ``commander.py`` are imported
+while ``necst.core`` is still being initialised; importing ``necst.ctrl`` from
+there pulls in antenna controller modules and can create a circular import.
+The helpers here depend only on the already-loaded NECST configuration.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Mapping, Optional
+
+from . import config
+
+
+def _cfg_get(obj: Any, key: str, default: Any = None) -> Any:
+    if obj is None:
+        return default
+    try:
+        if isinstance(obj, Mapping) and key in obj:
+            return obj[key]
+    except Exception:
+        pass
+    try:
+        value = getattr(obj, key)
+    except Exception:
+        return default
+    return default if value is None else value
+
+
+def _to_float(value: Any, unit: str = "deg", default: Optional[float] = None) -> Optional[float]:
+    if value is None:
+        return default
+    if hasattr(value, "to_value"):
+        try:
+            return float(value.to_value(unit))
+        except Exception:
+            try:
+                return float(value.to_value(""))
+            except Exception:
+                return default
+    try:
+        return float(value)
+    except Exception:
+        return default
+
+
+def _to_bool(value: Any, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on", "enabled"}
+    return bool(value)
+
+
+def _az_unwrap_az_section() -> Optional[Any]:
+    """Return the configured Az unwrap subsection, if any exists.
+
+    A missing ``antenna_encoder_unwrap`` section means this telescope is not
+    configured for absolute-modulo Az unwrap and must keep the legacy behavior.
+    A present section with ``enabled=false`` means an absolute-modulo encoder is
+    configured but the software unwrap is disabled; in that state commands must
+    not exceed the raw absolute encoder range.
+    """
+
+    root = getattr(config, "antenna_encoder_unwrap", None)
+    if root is None:
+        return None
+    az = _cfg_get(root, "az", None)
+    return root if az is None else az
+
+
+def load_unwrap_disabled_mount_az_limit() -> Optional[dict]:
+    """Return raw-Az command limits when absolute unwrap is configured off.
+
+    When an absolute-modulo Az encoder is configured but
+    ``antenna_encoder_unwrap.az.enabled`` is false, the control system has no
+    branch information.  In that state Az commands must be confined to the raw
+    absolute encoder range (normally 0..360 deg).  If no unwrap section exists,
+    return ``None`` so NANTEN2/incremental-encoder configurations are unchanged.
+    """
+
+    az = _az_unwrap_az_section()
+    if az is None:
+        return None
+    enabled = _to_bool(_cfg_get(az, "enabled", False), False)
+    if enabled:
+        return None
+    mode = str(_cfg_get(az, "mode", "absolute_modulo") or "").strip().lower()
+    if mode not in {"absolute_modulo", "absolute-modulo"}:
+        return None
+    raw_min = float(
+        _to_float(
+            _cfg_get(az, "raw_min", _cfg_get(az, "raw_min_deg", 0.0)),
+            "deg",
+            0.0,
+        )
+    )
+    raw_max = float(
+        _to_float(
+            _cfg_get(az, "raw_max", _cfg_get(az, "raw_max_deg", 360.0)),
+            "deg",
+            360.0,
+        )
+    )
+    if not (math.isfinite(raw_min) and math.isfinite(raw_max)) or raw_min >= raw_max:
+        raise ValueError(
+            "antenna_encoder_unwrap.az raw_min/raw_max are invalid: "
+            f"raw_min={raw_min!r}, raw_max={raw_max!r}"
+        )
+    return {
+        "enabled": False,
+        "mode": mode,
+        "raw_min_deg": raw_min,
+        "raw_max_deg": raw_max,
+    }
+
+
+def _flatten_degree_values(value: Any) -> list[float]:
+    if hasattr(value, "to_value"):
+        value = value.to_value("deg")
+    if hasattr(value, "tolist"):
+        value = value.tolist()
+    if isinstance(value, (str, bytes)):
+        return [float(value)]
+    try:
+        iterator = iter(value)
+    except TypeError:
+        return [float(value)]
+    values: list[float] = []
+    for item in iterator:
+        values.extend(_flatten_degree_values(item))
+    return values
+
+
+def assert_mount_az_allowed_when_unwrap_disabled(
+    az_deg: Any, *, action_label: str = "Az target"
+) -> Optional[dict]:
+    """Reject Az commands outside raw range when unwrap is configured off.
+
+    This is a fail-closed guard for absolute-modulo encoders.  It intentionally
+    uses the configured raw absolute encoder range, not the wider continuous
+    drive range, because without unwrap the controller cannot distinguish e.g.
+    10 deg from 370 deg.
+    """
+
+    limit = load_unwrap_disabled_mount_az_limit()
+    if limit is None:
+        return None
+    raw_min = float(limit["raw_min_deg"])
+    raw_max = float(limit["raw_max_deg"])
+    values = _flatten_degree_values(az_deg)
+    for value in values:
+        if not math.isfinite(value) or value < raw_min or value > raw_max:
+            raise ValueError(
+                f"{action_label}: Az={value:g} deg is outside raw absolute "
+                f"encoder range {raw_min:g}..{raw_max:g} deg while "
+                "antenna_encoder_unwrap.az.enabled=false; enable Az unwrap "
+                "or keep Az commands within raw_min/raw_max."
+            )
+    checked = dict(limit)
+    checked["checked_value_count"] = len(values)
+    return checked

--- a/necst/az_unwrap_limits.py
+++ b/necst/az_unwrap_limits.py
@@ -30,7 +30,9 @@ def _cfg_get(obj: Any, key: str, default: Any = None) -> Any:
     return default if value is None else value
 
 
-def _to_float(value: Any, unit: str = "deg", default: Optional[float] = None) -> Optional[float]:
+def _to_float(
+    value: Any, unit: str = "deg", default: Optional[float] = None
+) -> Optional[float]:
     if value is None:
         return default
     if hasattr(value, "to_value"):

--- a/necst/cli.py
+++ b/necst/cli.py
@@ -1,0 +1,107 @@
+"""Small installable ``necst`` command dispatcher.
+
+The historical source-tree ``bin/necst`` wrapper still works.  This module makes
+``necst console`` available after a normal Python/ROS installation as well.
+"""
+
+from __future__ import annotations
+
+import runpy
+import sys
+from pathlib import Path
+from typing import Callable, Optional
+
+
+def _console(argv: list[str]) -> int:
+    from .web.console_entry import main
+
+    return int(main(argv))
+
+
+def _console_log(argv: list[str]) -> int:
+    from .web.console_log_cli import main
+
+    return int(main(argv))
+
+
+def _az_unwrap_state(argv: list[str]) -> int:
+    from .ctrl.antenna.az_unwrap import main
+
+    return int(main(argv))
+
+
+COMMANDS: dict[str, Callable[[list[str]], int]] = {
+    "console": _console,
+    "console-log": _console_log,
+    "az-unwrap-state": _az_unwrap_state,
+}
+
+
+def _source_tree_bin_dir() -> Path:
+    # In a source checkout this is <repo>/bin.  In an installed package it will
+    # usually not exist, which is fine because installable commands are handled
+    # above.
+    return Path(__file__).resolve().parents[1] / "bin"
+
+
+def _run_source_script(command: str, argv: list[str]) -> Optional[int]:
+    script = _source_tree_bin_dir() / f"{command}.py"
+    if not script.exists():
+        return None
+    old_argv = sys.argv[:]
+    try:
+        sys.argv = [str(script)] + list(argv)
+        runpy.run_path(str(script), run_name="__main__")
+    except SystemExit as exc:
+        code = exc.code
+        if code is None:
+            return 0
+        if isinstance(code, int):
+            return code
+        print(code)
+        return 1
+    finally:
+        sys.argv = old_argv
+    return 0
+
+
+def _print_help() -> None:
+    print("NECST; NEw Control System for Telescope")
+    print("")
+    print("USAGE")
+    print("  necst <command> [<options>]")
+    print("")
+    print("COMMON COMMANDS")
+    print("  console          Start the Operator Console GUI")
+    print("  console-log      Show the persistent Operator Console JSONL log")
+    print("  az-unwrap-state  Get/set Az unwrap state via encoder-node service")
+    bin_dir = _source_tree_bin_dir()
+    if bin_dir.exists():
+        scripts = sorted(p.stem for p in bin_dir.glob("*.py"))
+        if scripts:
+            print("")
+            print("SOURCE-TREE COMMANDS")
+            for name in scripts:
+                print(f"  {name}")
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    if not args or args[0] in {"-h", "--help"}:
+        _print_help()
+        return 0
+    command = args.pop(0)
+    command = command[:-3] if command.endswith(".py") else command
+    command = command.replace("_", "-")
+    if command in COMMANDS:
+        return COMMANDS[command](args)
+    source_rc = _run_source_script(command, args)
+    if source_rc is not None:
+        return int(source_rc)
+    print(f"unknown necst command: {command}", file=sys.stderr)
+    print("run 'necst --help' for available commands", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/necst/core/commander.py
+++ b/necst/core/commander.py
@@ -51,7 +51,7 @@ from rclpy.subscription import Subscription
 from .. import NECSTTimeoutError, config, namespace, service, topic
 from ..utils import Topic
 from .auth import PrivilegedNode, require_privilege
-from ..ctrl.antenna.az_unwrap import assert_mount_az_allowed_when_unwrap_disabled
+from ..az_unwrap_limits import assert_mount_az_allowed_when_unwrap_disabled
 
 
 @dataclass

--- a/necst/core/commander.py
+++ b/necst/core/commander.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, Literal, Optional, Tuple, Union
 from neclib.core import read
 from neclib.utils import ConditionChecker, ParameterList
 from std_msgs.msg import String
+from std_srvs.srv import Trigger
 
 from necst_msgs.msg import (
     AlertMsg,
@@ -159,6 +160,9 @@ class Commander(PrivilegedNode):
             "clear_spectral_recording_setup": service.clear_spectral_recording_setup.client(
                 self
             ),
+            "chopper_alarm_reset": service.chopper_alarm_reset.client(self),
+            "chopper_home": service.chopper_home.client(self),
+            "chopper_recover": service.chopper_recover.client(self),
         }
 
         self.parameters: Dict[str, ParameterList] = {}
@@ -1095,6 +1099,29 @@ class Commander(PrivilegedNode):
             self.publisher["chopper"].publish(msg)
             if wait:
                 self.wait_oc(target="chopper", position=cmd)
+
+    @require_privilege
+    def chopper_maintenance(
+        self,
+        cmd: Literal["alarm-reset", "home", "recover"],
+        /,
+    ):
+        """Request a hardware-maintenance operation on the chopper controller.
+
+        The operation is executed by the chopper controller node, i.e. on the
+        computer that owns the chopper motor interface.  This Commander only
+        sends a ROS service request.
+        """
+        key_map = {
+            "alarm-reset": "chopper_alarm_reset",
+            "home": "chopper_home",
+            "recover": "chopper_recover",
+        }
+        try:
+            client_key = key_map[cmd]
+        except KeyError:
+            raise ValueError(f"Unknown chopper maintenance command: {cmd!r}")
+        return self._send_request(Trigger.Request(), self.client[client_key])
 
     @require_privilege(escape_cmd=["?"])
     def mirror(

--- a/necst/core/commander.py
+++ b/necst/core/commander.py
@@ -51,6 +51,7 @@ from rclpy.subscription import Subscription
 from .. import NECSTTimeoutError, config, namespace, service, topic
 from ..utils import Topic
 from .auth import PrivilegedNode, require_privilege
+from ..ctrl.antenna.az_unwrap import assert_mount_az_allowed_when_unwrap_disabled
 
 
 @dataclass
@@ -679,6 +680,11 @@ class Commander(PrivilegedNode):
                     offset_frame=offset[2],
                     unit=unit,
                     direct_mode=direct_mode,
+                )
+
+            if effective_az_target_mode == "mount" and target is not None:
+                assert_mount_az_allowed_when_unwrap_disabled(
+                    float(target[0]), action_label="Commander mount Az target"
                 )
 
             # Propagate optional fields in a backward compatible way.

--- a/necst/core/emergency.py
+++ b/necst/core/emergency.py
@@ -9,6 +9,7 @@ from typing import Optional
 
 import rclpy
 
+from .. import config
 from .commander import Commander
 
 
@@ -234,3 +235,286 @@ def main_mount_move(argv: Optional[list[str]] = None) -> int:
             pass
         com.destroy_node()
         _shutdown_if_needed(should_shutdown)
+
+
+def _chopper_config_positions() -> tuple[Optional[int], Optional[int]]:
+    try:
+        insert_position = int(config.chopper_motor_position["insert"])
+        remove_position = int(config.chopper_motor_position["remove"])
+        return insert_position, remove_position
+    except Exception:
+        return None, None
+
+
+def _chopper_msg_position(msg) -> Optional[int]:
+    try:
+        return int(getattr(msg, "position"))
+    except Exception:
+        return None
+
+
+def _chopper_msg_insert_flag(msg) -> Optional[bool]:
+    try:
+        value = getattr(msg, "insert")
+    except Exception:
+        return None
+    return None if value is None else bool(value)
+
+
+def _chopper_simulator_uses_boolean_only_status() -> bool:
+    """Return True when the active chopper status is expected to be simulator-like.
+
+    NECST's ChopperSimulator publishes only the boolean insert flag; the int32
+    position field remains the ROS default value 0.  Real hardware must keep
+    using motor positions, so this fallback is enabled only when the active site
+    config explicitly says simulator=true.
+    """
+    try:
+        return bool(getattr(config, "simulator", False))
+    except Exception:
+        return False
+
+
+def _chopper_zero_is_boolean_only_simulator_for_target(
+    target_position: int,
+) -> bool:
+    """Return True when position=0 may stand for a simulator-only boolean state.
+
+    If the requested endpoint itself is 0, position=0 is a real endpoint and is
+    already handled by the explicit position match.  The boolean-only fallback
+    is therefore needed only for simulator targets whose configured endpoint is
+    non-zero, e.g. NANTEN2 OUT/remove=250 while ChopperSimulator still publishes
+    position=0, insert=False.
+    """
+    return _chopper_simulator_uses_boolean_only_status() and int(target_position) != 0
+
+
+def _chopper_status_matches(msg, target_position: int, target_insert: bool) -> bool:
+    position = _chopper_msg_position(msg)
+    insert_flag = _chopper_msg_insert_flag(msg)
+    target_position = int(target_position)
+
+    # Trust an explicit motor step only when the optional boolean flag is not
+    # contradicting it.  The real controller derives the flag from the motor
+    # endpoint, so a conflicting flag/position pair is inconsistent telemetry
+    # and must not be treated as completed.
+    if position is not None and position == target_position:
+        return insert_flag is None or insert_flag == bool(target_insert)
+
+    # If the boolean flag is absent or contradicts the requested state, the
+    # requested state has not been confirmed.
+    if insert_flag is None or insert_flag != bool(target_insert):
+        return False
+
+    # At this point the boolean flag agrees with the requested state but the
+    # motor position did not explicitly match the target.  Accept boolean-only
+    # telemetry only when the position field is genuinely absent.  The ROS
+    # simulator publishes an int32 default 0 even though it only models the
+    # boolean state, so accept that special case only when the active NECST
+    # configuration is explicitly in simulator mode.  In real hardware mode,
+    # position=0 can be an actual counter value and must not be treated as
+    # "unknown".
+    if position is None:
+        return True
+    if (
+        position == 0
+        and _chopper_zero_is_boolean_only_simulator_for_target(target_position)
+    ):
+        return True
+    return False
+
+
+def _format_chopper_status(msg) -> tuple[str, str]:
+    """Return operator-facing chopper status and detail string."""
+    position = _chopper_msg_position(msg)
+    insert_position, remove_position = _chopper_config_positions()
+    insert_flag = _chopper_msg_insert_flag(msg)
+
+    simulator_boolean_only = _chopper_simulator_uses_boolean_only_status()
+
+    if (
+        position is not None
+        and insert_position is not None
+        and position == insert_position
+        and insert_flag is not False
+    ):
+        state = "IN"
+    elif (
+        position is not None
+        and remove_position is not None
+        and position == remove_position
+        and insert_flag is not True
+    ):
+        state = "OUT"
+    elif simulator_boolean_only and position == 0 and insert_flag is True:
+        state = "IN"
+    elif simulator_boolean_only and position == 0 and insert_flag is False:
+        state = "OUT"
+    elif insert_flag is True:
+        state = "IN?"
+    elif insert_flag is False:
+        state = "OUT?"
+    else:
+        state = "UNKNOWN"
+
+    timestamp = getattr(msg, "time", None)
+    try:
+        age_sec = max(0.0, time.time() - float(timestamp))
+        age_text = f", age={age_sec:.1f}s"
+    except Exception:
+        age_text = ""
+
+    detail = f"position={position}, insert={insert_flag}{age_text}"
+    return state, detail
+
+
+def _wait_chopper_position(
+    com: Commander, target_position: int, target_insert: bool, timeout_sec: float
+) -> None:
+    """Wait for chopper status to reach target position/flag with a timeout."""
+    deadline = time.monotonic() + max(0.0, float(timeout_sec))
+    last_state = "UNKNOWN"
+    last_detail = "no status received"
+    while time.monotonic() <= deadline:
+        try:
+            msg = com.get_message("chopper", timeout_sec=0.2)
+            state, detail = _format_chopper_status(msg)
+            last_state, last_detail = state, detail
+            if _chopper_status_matches(msg, target_position, target_insert):
+                return
+        except Exception as exc:
+            last_state, last_detail = "UNKNOWN", str(exc)
+        time.sleep(0.1)
+    raise TimeoutError(
+        "chopper did not reach target position "
+        f"{target_position} within {timeout_sec:.1f}s "
+        f"(last: {last_state}, {last_detail})"
+    )
+
+
+def main_chopper(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="necst chopper",
+        description=(
+            "Move or query the chopper.  'in' inserts the ambient load; "
+            "'out' removes it.  'status' only reads telemetry."
+        ),
+    )
+    parser.add_argument(
+        "command",
+        choices=["in", "out", "status", "insert", "remove", "?"],
+        help="Chopper command: in/out/status.  insert/remove/? are aliases.",
+    )
+    parser.add_argument(
+        "--no-wait",
+        action="store_true",
+        help="Return after publishing the command without waiting for status.",
+    )
+    parser.add_argument(
+        "--timeout-sec",
+        type=float,
+        default=10.0,
+        help="Maximum time to wait for in/out completion (default: 10).",
+    )
+    parser.add_argument(
+        "--settle-sec",
+        type=float,
+        default=0.2,
+        help="ROS discovery settle delay before publishing/querying (default: 0.2).",
+    )
+    parser.add_argument(
+        "--repeat",
+        type=int,
+        default=3,
+        help="Number of command publications for in/out (default: 3).",
+    )
+    parser.add_argument(
+        "--interval-sec",
+        type=float,
+        default=0.1,
+        help="Interval between repeated command publications (default: 0.1).",
+    )
+    args = parser.parse_args(argv)
+
+    command = str(args.command).lower()
+    if command == "insert":
+        command = "in"
+    elif command == "remove":
+        command = "out"
+    elif command == "?":
+        command = "status"
+
+    should_shutdown = _ensure_rclpy()
+    com = Commander()
+    try:
+        if args.settle_sec > 0:
+            time.sleep(float(args.settle_sec))
+
+        if command == "status":
+            try:
+                msg = com.get_message(
+                    "chopper", timeout_sec=max(0.0, float(args.timeout_sec))
+                )
+            except Exception as exc:
+                print(f"failed to read chopper status: {exc}", file=sys.stderr)
+                return 1
+            state, detail = _format_chopper_status(msg)
+            print(f"chopper {state}: {detail}")
+            return 0
+
+        if command == "in":
+            commander_cmd = "insert"
+            label = "IN"
+            target_insert = True
+            target_position = int(config.chopper_motor_position["insert"])
+        elif command == "out":
+            commander_cmd = "remove"
+            label = "OUT"
+            target_insert = False
+            target_position = int(config.chopper_motor_position["remove"])
+        else:
+            parser.error(f"unknown command: {args.command!r}")
+
+        print(f"Chopper command: {label}")
+        print(f"  target position = {target_position}")
+
+        if not com.get_privilege():
+            print("failed to acquire NECST privilege", file=sys.stderr)
+            return 2
+
+        repeat = max(1, int(args.repeat))
+        interval = max(0.0, float(args.interval_sec))
+        for i in range(repeat):
+            com.chopper(commander_cmd, wait=False)
+            if i + 1 < repeat:
+                time.sleep(interval)
+
+        if not args.no_wait:
+            try:
+                _wait_chopper_position(
+                    com,
+                    target_position,
+                    target_insert,
+                    timeout_sec=max(0.0, float(args.timeout_sec)),
+                )
+                msg = com.get_message("chopper", timeout_sec=0.5)
+                state, detail = _format_chopper_status(msg)
+                print(f"chopper {state}: {detail}")
+            except KeyboardInterrupt:
+                print("interrupted while waiting for chopper status", file=sys.stderr)
+                return 130
+        return 0
+    except TimeoutError as exc:
+        print(f"timeout: {exc}", file=sys.stderr)
+        return 1
+    except KeyboardInterrupt:
+        print("interrupted", file=sys.stderr)
+        return 130
+    finally:
+        try:
+            com.quit_privilege()
+        except Exception:
+            pass
+        com.destroy_node()
+        _shutdown_if_needed(should_shutdown)
+

--- a/necst/core/emergency.py
+++ b/necst/core/emergency.py
@@ -402,8 +402,25 @@ def main_chopper(argv: Optional[list[str]] = None) -> int:
     )
     parser.add_argument(
         "command",
-        choices=["in", "out", "status", "insert", "remove", "?"],
-        help="Chopper command: in/out/status.  insert/remove/? are aliases.",
+        choices=[
+            "in",
+            "out",
+            "status",
+            "insert",
+            "remove",
+            "?",
+            "alarm-reset",
+            "alarm_reset",
+            "reset-alarm",
+            "home",
+            "zero",
+            "zero-point",
+            "recover",
+        ],
+        help=(
+            "Chopper command: in/out/status/alarm-reset/home/recover. "
+            "insert/remove/? and zero/zero-point are aliases."
+        ),
     )
     parser.add_argument(
         "--no-wait",
@@ -443,6 +460,10 @@ def main_chopper(argv: Optional[list[str]] = None) -> int:
         command = "out"
     elif command == "?":
         command = "status"
+    elif command in {"alarm_reset", "reset-alarm"}:
+        command = "alarm-reset"
+    elif command in {"zero", "zero-point"}:
+        command = "home"
 
     should_shutdown = _ensure_rclpy()
     com = Commander()
@@ -461,6 +482,21 @@ def main_chopper(argv: Optional[list[str]] = None) -> int:
             state, detail = _format_chopper_status(msg)
             print(f"chopper {state}: {detail}")
             return 0
+
+        if command in {"alarm-reset", "home", "recover"}:
+            print(f"Chopper maintenance command: {command}")
+            if not com.get_privilege():
+                print("failed to acquire NECST privilege", file=sys.stderr)
+                return 2
+            try:
+                result = com.chopper_maintenance(command)
+            except Exception as exc:
+                print(f"failed to execute chopper {command}: {exc}", file=sys.stderr)
+                return 1
+            status = "completed" if bool(getattr(result, "success", False)) else "failed"
+            message = str(getattr(result, "message", "")).strip()
+            print(f"chopper {command} {status}" + (f": {message}" if message else ""))
+            return 0 if bool(getattr(result, "success", False)) else 1
 
         if command == "in":
             commander_cmd = "insert"

--- a/necst/core/emergency.py
+++ b/necst/core/emergency.py
@@ -1,29 +1,24 @@
-"""Small operator-facing emergency and manual mount command CLIs."""
+"""Small operator-facing emergency and manual command CLIs."""
 
 from __future__ import annotations
 
 import argparse
 import sys
-import time
 from typing import Optional
 
-import rclpy
-
 from .. import config
-from .commander import Commander
-
-
-def _ensure_rclpy() -> bool:
-    """Initialize rclpy if needed and return whether this function did it."""
-    if rclpy.ok():
-        return False
-    rclpy.init()
-    return True
-
-
-def _shutdown_if_needed(should_shutdown: bool) -> None:
-    if should_shutdown:
-        rclpy.shutdown()
+from .operator_actions import (
+    OperatorActionError,
+    OperatorActionTimeout,
+    abort_observation,
+    antenna_stop,
+    chopper_maintenance,
+    chopper_move,
+    chopper_status,
+    format_chopper_status as _format_chopper_status,
+    mount_move,
+    wait_chopper_position as _wait_chopper_position,
+)
 
 
 def main_stop(argv: Optional[list[str]] = None) -> int:
@@ -52,16 +47,18 @@ def main_stop(argv: Optional[list[str]] = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    should_shutdown = _ensure_rclpy()
-    com = Commander()
     try:
-        com.antenna("stop", timeout_sec=max(0.0, float(args.confirm_timeout_sec)))
-        if args.settle_sec > 0:
-            time.sleep(float(args.settle_sec))
+        antenna_stop(
+            confirm_timeout_sec=args.confirm_timeout_sec,
+            settle_sec=args.settle_sec,
+        )
         return 0
-    finally:
-        com.destroy_node()
-        _shutdown_if_needed(should_shutdown)
+    except OperatorActionError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    except KeyboardInterrupt:
+        print("interrupted", file=sys.stderr)
+        return 130
 
 
 def main_abort(argv: Optional[list[str]] = None) -> int:
@@ -107,25 +104,25 @@ def main_abort(argv: Optional[list[str]] = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    should_shutdown = _ensure_rclpy()
-    com = Commander()
     try:
-        if args.settle_sec > 0:
-            time.sleep(float(args.settle_sec))
-        request_id = com.observation_abort(
+        result = abort_observation(
             reason=args.reason,
             requester=args.requester,
-            repeat=max(1, int(args.repeat)),
-            interval_sec=max(0.0, float(args.interval_sec)),
+            antenna_stop_after_abort=not args.no_antenna_stop,
+            repeat=args.repeat,
+            interval_sec=args.interval_sec,
+            settle_sec=args.settle_sec,
         )
-        print(f"abort request sent: {request_id}")
+        print(f"abort request sent: {result.data.get('request_id')}")
         if not args.no_antenna_stop:
             print("sending antenna stop...")
-            com.antenna("stop")
         return 0
-    finally:
-        com.destroy_node()
-        _shutdown_if_needed(should_shutdown)
+    except OperatorActionError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    except KeyboardInterrupt:
+        print("interrupted", file=sys.stderr)
+        return 130
 
 
 def main_mount_move(argv: Optional[list[str]] = None) -> int:
@@ -193,203 +190,31 @@ def main_mount_move(argv: Optional[list[str]] = None) -> int:
     print("  frame     = altaz")
     print("  direct    = true")
     print("  az mode   = mount")
-    if args.dry_run:
-        return 0
 
-    should_shutdown = _ensure_rclpy()
-    com = Commander()
     try:
-        if not com.get_privilege():
-            print("failed to acquire NECST privilege", file=sys.stderr)
-            return 2
-        cmd_id = com.antenna(
-            "point",
-            target=(az, el, "altaz"),
-            unit="deg",
-            direct_mode=True,
-            az_target_mode="mount",
-            wait=False,
+        result = mount_move(
+            az,
+            el,
+            wait=not args.no_wait,
+            timeout_sec=args.timeout_sec,
+            dry_run=args.dry_run,
         )
-        print(f"command id: {cmd_id}")
-        if not args.no_wait:
-            try:
-                com.wait_mount_point(
-                    az, el, command_id=cmd_id, timeout_sec=args.timeout_sec
-                )
-            except KeyboardInterrupt:
-                print("interrupted: sending antenna stop...", file=sys.stderr)
-                com.antenna("stop")
-                return 130
+        if not args.dry_run:
+            print(f"command id: {result.data.get('command_id')}")
         return 0
     except KeyboardInterrupt:
         print("interrupted: sending antenna stop...", file=sys.stderr)
         try:
-            com.antenna("stop")
+            antenna_stop()
         except Exception:
             pass
         return 130
-    finally:
-        try:
-            com.quit_privilege()
-        except Exception:
-            pass
-        com.destroy_node()
-        _shutdown_if_needed(should_shutdown)
-
-
-def _chopper_config_positions() -> tuple[Optional[int], Optional[int]]:
-    try:
-        insert_position = int(config.chopper_motor_position["insert"])
-        remove_position = int(config.chopper_motor_position["remove"])
-        return insert_position, remove_position
-    except Exception:
-        return None, None
-
-
-def _chopper_msg_position(msg) -> Optional[int]:
-    try:
-        return int(getattr(msg, "position"))
-    except Exception:
-        return None
-
-
-def _chopper_msg_insert_flag(msg) -> Optional[bool]:
-    try:
-        value = getattr(msg, "insert")
-    except Exception:
-        return None
-    return None if value is None else bool(value)
-
-
-def _chopper_simulator_uses_boolean_only_status() -> bool:
-    """Return True when the active chopper status is expected to be simulator-like.
-
-    NECST's ChopperSimulator publishes only the boolean insert flag; the int32
-    position field remains the ROS default value 0.  Real hardware must keep
-    using motor positions, so this fallback is enabled only when the active site
-    config explicitly says simulator=true.
-    """
-    try:
-        return bool(getattr(config, "simulator", False))
-    except Exception:
-        return False
-
-
-def _chopper_zero_is_boolean_only_simulator_for_target(
-    target_position: int,
-) -> bool:
-    """Return True when position=0 may stand for a simulator-only boolean state.
-
-    If the requested endpoint itself is 0, position=0 is a real endpoint and is
-    already handled by the explicit position match.  The boolean-only fallback
-    is therefore needed only for simulator targets whose configured endpoint is
-    non-zero, e.g. NANTEN2 OUT/remove=250 while ChopperSimulator still publishes
-    position=0, insert=False.
-    """
-    return _chopper_simulator_uses_boolean_only_status() and int(target_position) != 0
-
-
-def _chopper_status_matches(msg, target_position: int, target_insert: bool) -> bool:
-    position = _chopper_msg_position(msg)
-    insert_flag = _chopper_msg_insert_flag(msg)
-    target_position = int(target_position)
-
-    # Trust an explicit motor step only when the optional boolean flag is not
-    # contradicting it.  The real controller derives the flag from the motor
-    # endpoint, so a conflicting flag/position pair is inconsistent telemetry
-    # and must not be treated as completed.
-    if position is not None and position == target_position:
-        return insert_flag is None or insert_flag == bool(target_insert)
-
-    # If the boolean flag is absent or contradicts the requested state, the
-    # requested state has not been confirmed.
-    if insert_flag is None or insert_flag != bool(target_insert):
-        return False
-
-    # At this point the boolean flag agrees with the requested state but the
-    # motor position did not explicitly match the target.  Accept boolean-only
-    # telemetry only when the position field is genuinely absent.  The ROS
-    # simulator publishes an int32 default 0 even though it only models the
-    # boolean state, so accept that special case only when the active NECST
-    # configuration is explicitly in simulator mode.  In real hardware mode,
-    # position=0 can be an actual counter value and must not be treated as
-    # "unknown".
-    if position is None:
-        return True
-    if (
-        position == 0
-        and _chopper_zero_is_boolean_only_simulator_for_target(target_position)
-    ):
-        return True
-    return False
-
-
-def _format_chopper_status(msg) -> tuple[str, str]:
-    """Return operator-facing chopper status and detail string."""
-    position = _chopper_msg_position(msg)
-    insert_position, remove_position = _chopper_config_positions()
-    insert_flag = _chopper_msg_insert_flag(msg)
-
-    simulator_boolean_only = _chopper_simulator_uses_boolean_only_status()
-
-    if (
-        position is not None
-        and insert_position is not None
-        and position == insert_position
-        and insert_flag is not False
-    ):
-        state = "IN"
-    elif (
-        position is not None
-        and remove_position is not None
-        and position == remove_position
-        and insert_flag is not True
-    ):
-        state = "OUT"
-    elif simulator_boolean_only and position == 0 and insert_flag is True:
-        state = "IN"
-    elif simulator_boolean_only and position == 0 and insert_flag is False:
-        state = "OUT"
-    elif insert_flag is True:
-        state = "IN?"
-    elif insert_flag is False:
-        state = "OUT?"
-    else:
-        state = "UNKNOWN"
-
-    timestamp = getattr(msg, "time", None)
-    try:
-        age_sec = max(0.0, time.time() - float(timestamp))
-        age_text = f", age={age_sec:.1f}s"
-    except Exception:
-        age_text = ""
-
-    detail = f"position={position}, insert={insert_flag}{age_text}"
-    return state, detail
-
-
-def _wait_chopper_position(
-    com: Commander, target_position: int, target_insert: bool, timeout_sec: float
-) -> None:
-    """Wait for chopper status to reach target position/flag with a timeout."""
-    deadline = time.monotonic() + max(0.0, float(timeout_sec))
-    last_state = "UNKNOWN"
-    last_detail = "no status received"
-    while time.monotonic() <= deadline:
-        try:
-            msg = com.get_message("chopper", timeout_sec=0.2)
-            state, detail = _format_chopper_status(msg)
-            last_state, last_detail = state, detail
-            if _chopper_status_matches(msg, target_position, target_insert):
-                return
-        except Exception as exc:
-            last_state, last_detail = "UNKNOWN", str(exc)
-        time.sleep(0.1)
-    raise TimeoutError(
-        "chopper did not reach target position "
-        f"{target_position} within {timeout_sec:.1f}s "
-        f"(last: {last_state}, {last_detail})"
-    )
+    except OperatorActionError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    except Exception as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
 
 
 def main_chopper(argv: Optional[list[str]] = None) -> int:
@@ -465,48 +290,26 @@ def main_chopper(argv: Optional[list[str]] = None) -> int:
     elif command in {"zero", "zero-point"}:
         command = "home"
 
-    should_shutdown = _ensure_rclpy()
-    com = Commander()
     try:
-        if args.settle_sec > 0:
-            time.sleep(float(args.settle_sec))
-
         if command == "status":
-            try:
-                msg = com.get_message(
-                    "chopper", timeout_sec=max(0.0, float(args.timeout_sec))
-                )
-            except Exception as exc:
-                print(f"failed to read chopper status: {exc}", file=sys.stderr)
-                return 1
-            state, detail = _format_chopper_status(msg)
-            print(f"chopper {state}: {detail}")
+            result = chopper_status(
+                timeout_sec=args.timeout_sec,
+                settle_sec=args.settle_sec,
+            )
+            print(result.message)
             return 0
 
         if command in {"alarm-reset", "home", "recover"}:
             print(f"Chopper maintenance command: {command}")
-            if not com.get_privilege():
-                print("failed to acquire NECST privilege", file=sys.stderr)
-                return 2
-            try:
-                result = com.chopper_maintenance(command)
-            except Exception as exc:
-                print(f"failed to execute chopper {command}: {exc}", file=sys.stderr)
-                return 1
-            status = "completed" if bool(getattr(result, "success", False)) else "failed"
-            message = str(getattr(result, "message", "")).strip()
-            print(f"chopper {command} {status}" + (f": {message}" if message else ""))
-            return 0 if bool(getattr(result, "success", False)) else 1
+            result = chopper_maintenance(command, settle_sec=args.settle_sec)
+            print(result.message)
+            return 0 if result.success else 1
 
         if command == "in":
-            commander_cmd = "insert"
             label = "IN"
-            target_insert = True
             target_position = int(config.chopper_motor_position["insert"])
         elif command == "out":
-            commander_cmd = "remove"
             label = "OUT"
-            target_insert = False
             target_position = int(config.chopper_motor_position["remove"])
         else:
             parser.error(f"unknown command: {args.command!r}")
@@ -514,43 +317,26 @@ def main_chopper(argv: Optional[list[str]] = None) -> int:
         print(f"Chopper command: {label}")
         print(f"  target position = {target_position}")
 
-        if not com.get_privilege():
-            print("failed to acquire NECST privilege", file=sys.stderr)
-            return 2
-
-        repeat = max(1, int(args.repeat))
-        interval = max(0.0, float(args.interval_sec))
-        for i in range(repeat):
-            com.chopper(commander_cmd, wait=False)
-            if i + 1 < repeat:
-                time.sleep(interval)
-
+        result = chopper_move(
+            command,
+            wait=not args.no_wait,
+            timeout_sec=args.timeout_sec,
+            settle_sec=args.settle_sec,
+            repeat=args.repeat,
+            interval_sec=args.interval_sec,
+        )
         if not args.no_wait:
-            try:
-                _wait_chopper_position(
-                    com,
-                    target_position,
-                    target_insert,
-                    timeout_sec=max(0.0, float(args.timeout_sec)),
-                )
-                msg = com.get_message("chopper", timeout_sec=0.5)
-                state, detail = _format_chopper_status(msg)
-                print(f"chopper {state}: {detail}")
-            except KeyboardInterrupt:
-                print("interrupted while waiting for chopper status", file=sys.stderr)
-                return 130
+            print(result.message)
         return 0
-    except TimeoutError as exc:
+    except OperatorActionTimeout as exc:
         print(f"timeout: {exc}", file=sys.stderr)
         return 1
+    except OperatorActionError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
     except KeyboardInterrupt:
         print("interrupted", file=sys.stderr)
         return 130
-    finally:
-        try:
-            com.quit_privilege()
-        except Exception:
-            pass
-        com.destroy_node()
-        _shutdown_if_needed(should_shutdown)
-
+    except Exception as exc:
+        print(str(exc), file=sys.stderr)
+        return 1

--- a/necst/core/emergency.py
+++ b/necst/core/emergency.py
@@ -15,9 +15,7 @@ from .operator_actions import (
     chopper_maintenance,
     chopper_move,
     chopper_status,
-    format_chopper_status as _format_chopper_status,
     mount_move,
-    wait_chopper_position as _wait_chopper_position,
 )
 
 

--- a/necst/core/observation_check.py
+++ b/necst/core/observation_check.py
@@ -1,0 +1,539 @@
+"""Static observation-file check and dry-run planning helpers.
+
+The functions in this module are intentionally read-only.  They parse and
+inspect observation parameter files, but they never acquire NECST privilege,
+move the antenna, move the chopper, touch recorder/gate state, or apply SG
+settings.  They are shared by CLI-like operator actions and the web Operator
+Console so that Check / Dry run semantics stay consistent.
+"""
+
+from __future__ import annotations
+
+import builtins
+import math
+import os
+import re
+import tomllib
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, Mapping, Optional
+
+
+class ObservationCheckError(ValueError):
+    """Raised when an observation file cannot pass static validation."""
+
+
+@dataclass(frozen=True)
+class ObservationCheckReport:
+    """Machine-readable report returned by Check / Dry run."""
+
+    ok: bool
+    mode: str
+    file: str
+    channel: Optional[int]
+    summary: str
+    data: Dict[str, Any] = field(default_factory=dict)
+    warnings: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "mode": self.mode,
+            "file": self.file,
+            "channel": self.channel,
+            "summary": self.summary,
+            "warnings": list(self.warnings),
+            "errors": list(self.errors),
+            **dict(self.data),
+        }
+
+
+_ALLOWED_MODES = {
+    "otf": "OTF",
+    "psw": "PSW",
+    "grid": "Grid",
+    "radio_pointing": "Radio Pointing",
+    "radio-pointing": "Radio Pointing",
+    "radiopointing": "Radio Pointing",
+}
+
+_V16_DEFAULTS: Dict[str, Any] = {
+    "cos_correction": True,
+    "use_scan_block": True,
+    "sg_preflight_policy": "verify_only",
+    "sg_preflight_scope": "active_lo_chains",
+}
+
+_REFERENCE_FILE_KEYS = (
+    "lo_profile",
+    "lo_profile_path",
+    "recording_window_setup",
+    "recording_window_setup_path",
+    "beam_model",
+    "beam_model_path",
+    "analysis_stream_selection",
+    "analysis_stream_selection_path",
+    "converter_analysis",
+    "converter_analysis_path",
+    "recording_window",
+    "recording_window_path",
+    "pointing_param",
+    "pointing_param_path",
+)
+
+_DURATION_RE = re.compile(r"^\s*([+-]?\d+(?:\.\d*)?|[+-]?\.\d+)\s*([a-zA-Z]+)?\s*$")
+_ANGLE_RE = re.compile(r"^\s*([+-]?\d+(?:\.\d*)?|[+-]?\.\d+)\s*([a-zA-Z]+)?\s*$")
+
+
+def normalize_observation_mode(mode: Any) -> str:
+    normalized = str(mode or "").strip().lower().replace(" ", "_")
+    if normalized not in _ALLOWED_MODES:
+        raise ObservationCheckError(
+            "observation mode must be OTF, PSW, Grid, or Radio Pointing"
+        )
+    return normalized
+
+
+def optional_positive_int(value: Any, *, name: str) -> Optional[int]:
+    if value in (None, ""):
+        return None
+    try:
+        number = int(value)
+    except Exception as exc:
+        raise ObservationCheckError(f"{name} must be an integer") from exc
+    if number <= 0:
+        raise ObservationCheckError(f"{name} must be positive")
+    return number
+
+
+def validate_obs_file_path(file_path: Any, *, require_exists: bool) -> Path:
+    text = str(file_path or "").strip()
+    if not text:
+        raise ObservationCheckError("obs file path/name is empty")
+    path = Path(text).expanduser()
+    if path.suffix.lower() not in {".obs", ".toml"}:
+        raise ObservationCheckError("obs file extension must be .obs or .toml")
+    if require_exists:
+        if not path.exists():
+            raise ObservationCheckError(f"obs file does not exist on this computer: {path}")
+        if not path.is_file():
+            raise ObservationCheckError(f"obs file is not a regular file: {path}")
+        if not os.access(path, os.R_OK):
+            raise ObservationCheckError(f"obs file is not readable: {path}")
+    return path
+
+
+def _read_toml(path: Path) -> Dict[str, Any]:
+    try:
+        with path.open("rb") as fh:
+            data = tomllib.load(fh)
+    except tomllib.TOMLDecodeError as exc:
+        raise ObservationCheckError(f"obs file TOML parse failed: {exc}") from exc
+    except OSError as exc:
+        raise ObservationCheckError(f"obs file cannot be read: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ObservationCheckError("obs file did not parse to a TOML table")
+    return data
+
+
+def _mapping(value: Any) -> Dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _params_from_toml(data: Mapping[str, Any]) -> Dict[str, Any]:
+    params = _mapping(data.get("parameters"))
+    # Older observation files often put observation/scanning keys directly in
+    # dedicated sections rather than [parameters].  For static checking we keep
+    # [parameters] as the canonical default-expansion target, but later summary
+    # functions look at all sections.
+    return params
+
+
+def _apply_v16_defaults(params: Mapping[str, Any]) -> tuple[Dict[str, Any], Dict[str, bool]]:
+    expanded = dict(params)
+    explicit: Dict[str, bool] = {}
+    for key, value in _V16_DEFAULTS.items():
+        explicit[key] = key in expanded
+        expanded.setdefault(key, value)
+    return expanded, explicit
+
+
+def _format_default_summary(explicit: Mapping[str, bool]) -> str:
+    parts = []
+    for key, value in _V16_DEFAULTS.items():
+        source = "explicit" if explicit.get(key) else "default"
+        parts.append(f"{key}={value!r} ({source})")
+    return ", ".join(parts)
+
+
+def _iter_reference_files(params: Mapping[str, Any]) -> Iterable[tuple[str, str]]:
+    for key in _REFERENCE_FILE_KEYS:
+        value = params.get(key)
+        if value in (None, ""):
+            continue
+        if isinstance(value, (str, os.PathLike)):
+            yield key, os.fspath(value)
+
+
+def _resolve_reference_path(obs_path: Path, ref: str) -> Path:
+    p = Path(ref).expanduser()
+    if not p.is_absolute():
+        p = obs_path.parent / p
+    return p
+
+
+def _check_reference_files(obs_path: Path, params: Mapping[str, Any]) -> list[Dict[str, Any]]:
+    refs = []
+    for key, value in _iter_reference_files(params):
+        resolved = _resolve_reference_path(obs_path, value)
+        exists = resolved.exists()
+        readable = exists and resolved.is_file() and os.access(resolved, os.R_OK)
+        refs.append(
+            {
+                "key": key,
+                "value": value,
+                "path": str(resolved),
+                "exists": bool(exists),
+                "readable": bool(readable),
+            }
+        )
+    return refs
+
+
+def _parse_duration_sec(value: Any) -> Optional[float]:
+    if value in (None, "", {}):
+        return None
+    if isinstance(value, (int, float)) and math.isfinite(float(value)):
+        return float(value)
+    match = _DURATION_RE.match(str(value))
+    if not match:
+        return None
+    number = float(match.group(1))
+    unit = (match.group(2) or "s").strip().lower()
+    if unit in {"s", "sec", "secs", "second", "seconds"}:
+        return number
+    if unit in {"m", "min", "mins", "minute", "minutes"}:
+        return number * 60.0
+    if unit in {"h", "hr", "hour", "hours"}:
+        return number * 3600.0
+    return None
+
+
+def _parse_angle_arcsec(value: Any) -> Optional[float]:
+    if value in (None, "", {}):
+        return None
+    if isinstance(value, (int, float)) and math.isfinite(float(value)):
+        # Bare numeric values in observation TOML are rare; treat as degrees
+        # rather than arcsec because neclib coordinate specs generally use
+        # explicit strings for angular units.
+        return float(value) * 3600.0
+    match = _ANGLE_RE.match(str(value))
+    if not match:
+        return None
+    number = float(match.group(1))
+    unit = (match.group(2) or "deg").strip().lower()
+    if unit in {"arcsec", "asec", "as", "second", "seconds"}:
+        return number
+    if unit in {"arcmin", "amin", "am", "minute", "minutes"}:
+        return number * 60.0
+    if unit in {"deg", "degree", "degrees", "d"}:
+        return number * 3600.0
+    return None
+
+
+def _first_value(sections: Iterable[Mapping[str, Any]], *names: str) -> Any:
+    lower_names = {n.lower(): n for n in names}
+    for section in sections:
+        if not isinstance(section, Mapping):
+            continue
+        for key, value in section.items():
+            if str(key).lower() in lower_names:
+                return value
+    return None
+
+
+def _summarize_observation_properties(data: Mapping[str, Any]) -> Dict[str, Any]:
+    obs = _mapping(data.get("observation_property"))
+    coord = _mapping(data.get("coordinate"))
+    return {
+        "observer": obs.get("OBSERVER") or obs.get("observer"),
+        "object": obs.get("OBJECT") or obs.get("object") or obs.get("target"),
+        "molecule_1": obs.get("MOLECULE_1") or obs.get("molecule_1"),
+        "coord_sys": coord.get("COORD_SYS") or coord.get("coord_sys"),
+        "relative": coord.get("RELATIVE") if "RELATIVE" in coord else coord.get("relative"),
+    }
+
+
+def _mode_required_sections(mode: str) -> tuple[str, ...]:
+    if mode in {"otf", "grid", "psw"}:
+        return ("observation_property", "coordinate", "calibration")
+    if mode in {"radio_pointing", "radio-pointing", "radiopointing"}:
+        return ("observation_property", "coordinate", "pointing_property", "calibration")
+    return ("observation_property", "coordinate")
+
+
+def _section_names(data: Mapping[str, Any]) -> list[str]:
+    return [str(k) for k, v in data.items() if isinstance(v, Mapping)]
+
+
+def _static_section_warnings(mode: str, data: Mapping[str, Any]) -> list[str]:
+    warnings: list[str] = []
+    for section in _mode_required_sections(mode):
+        if section not in data:
+            warnings.append(f"section [{section}] is not present")
+    if mode == "otf" and "scan_property" not in data:
+        warnings.append("OTF usually needs [scan_property]")
+    if mode == "radio_pointing" and "pointing_property" not in data:
+        warnings.append("Radio Pointing usually needs [pointing_property]")
+    return warnings
+
+
+def _estimate_plan(mode: str, data: Mapping[str, Any], expanded_params: Mapping[str, Any]) -> Dict[str, Any]:
+    scan = _mapping(data.get("scan_property"))
+    pointing = _mapping(data.get("pointing_property"))
+    calib = _mapping(data.get("calibration"))
+    params = _mapping(expanded_params)
+    sections = (params, scan, pointing, calib)
+
+    n_value = _first_value(sections, "n", "N", "num", "repeat", "n_scan", "nscan")
+    try:
+        n = int(n_value) if n_value not in (None, "", {}) else None
+    except Exception:
+        n = None
+    if n is not None and n <= 0:
+        n = None
+
+    integ_on = _parse_duration_sec(_first_value(sections, "integ_on", "integ"))
+    integ_off = _parse_duration_sec(_first_value((calib, params), "integ_off"))
+    integ_hot = _parse_duration_sec(_first_value((calib, params), "integ_hot"))
+    off_interval = _first_value((calib, params), "off_interval")
+    load_interval = _first_value((calib, params), "load_interval")
+
+    scan_spacing_arcsec = _parse_angle_arcsec(_first_value((scan, params), "scan_spacing"))
+    scan_length_arcsec = _parse_angle_arcsec(_first_value((scan, params), "scan_length"))
+    scan_velocity_arcsec_s = _parse_angle_arcsec(_first_value((scan, params), "scan_velocity"))
+    scan_direction = _first_value((scan, params), "SCAN_DIRECTION", "scan_direction")
+
+    estimated_scan_sec = None
+    if scan_length_arcsec is not None and scan_velocity_arcsec_s not in (None, 0):
+        estimated_scan_sec = abs(scan_length_arcsec / scan_velocity_arcsec_s)
+    elif integ_on is not None:
+        estimated_scan_sec = integ_on
+
+    estimated_total_sec = None
+    if n is not None and estimated_scan_sec is not None:
+        estimated_total_sec = n * estimated_scan_sec
+        if integ_off is not None:
+            estimated_total_sec += integ_off
+        if integ_hot is not None:
+            estimated_total_sec += integ_hot
+
+    if mode == "radio_pointing":
+        plan_label = "radio pointing cross/grid plan"
+    elif mode == "grid":
+        plan_label = "grid point sequence"
+    elif mode == "psw":
+        plan_label = "position-switching sequence"
+    else:
+        plan_label = "OTF scan sequence"
+
+    return {
+        "plan_label": plan_label,
+        "n": n,
+        "scan_direction": scan_direction,
+        "scan_spacing_arcsec": scan_spacing_arcsec,
+        "scan_length_arcsec": scan_length_arcsec,
+        "scan_velocity_arcsec_s": scan_velocity_arcsec_s,
+        "integ_on_sec": integ_on,
+        "integ_off_sec": integ_off,
+        "integ_hot_sec": integ_hot,
+        "off_interval": off_interval,
+        "load_interval": load_interval,
+        "estimated_scan_sec": estimated_scan_sec,
+        "estimated_total_sec": estimated_total_sec,
+        "use_scan_block": bool(expanded_params.get("use_scan_block", True)),
+        "cos_correction": bool(expanded_params.get("cos_correction", True)),
+        "sg_preflight_policy": expanded_params.get("sg_preflight_policy"),
+        "sg_preflight_scope": expanded_params.get("sg_preflight_scope"),
+    }
+
+
+def _try_neclib_parser(mode: str, path: Path) -> Dict[str, Any]:
+    """Try the real neclib observation parser when dependencies are available."""
+
+    spec_names = {
+        "otf": "OTFSpec",
+        "psw": "PSWSpec",
+        "grid": "GridSpec",
+        "radio_pointing": "RadioPointingSpec",
+        "radio-pointing": "RadioPointingSpec",
+        "radiopointing": "RadioPointingSpec",
+    }
+    spec_name = spec_names.get(mode)
+    if spec_name is None:
+        return {"available": False, "ok": False, "reason": "unsupported mode"}
+    try:
+        module = __import__("neclib.coordinates.observations", fromlist=[spec_name])
+        spec_cls = getattr(module, spec_name)
+        spec = spec_cls.from_file(str(path))
+        target = getattr(spec, "target", None)
+        params = getattr(spec, "parameters", None)
+        return {
+            "available": True,
+            "ok": True,
+            "spec_class": spec_name,
+            "target": target,
+            "parameter_keys": sorted(params.keys()) if isinstance(params, Mapping) else [],
+        }
+    except Exception as exc:
+        return {
+            "available": False,
+            "ok": False,
+            "spec_class": spec_name,
+            "reason": str(exc),
+            "exception_type": exc.__class__.__name__,
+        }
+
+
+def check_observation_file(
+    mode: Any,
+    file_path: Any,
+    *,
+    channel: Any = None,
+    require_exists: bool = True,
+    use_neclib_parser: bool = True,
+) -> ObservationCheckReport:
+    """Perform read-only static observation-file validation."""
+
+    normalized_mode = normalize_observation_mode(mode)
+    ch = optional_positive_int(channel, name="channel override")
+    path = validate_obs_file_path(file_path, require_exists=require_exists)
+    if not require_exists and not path.exists():
+        return ObservationCheckReport(
+            ok=True,
+            mode=normalized_mode,
+            file=str(path),
+            channel=ch,
+            summary=(
+                f"Check OK for launcher selection only: mode={_ALLOWED_MODES[normalized_mode]}, "
+                f"file={path}. File was not parsed because it does not exist here."
+            ),
+            data={
+                "exists": False,
+                "parsed": False,
+                "v16_defaults": dict(_V16_DEFAULTS),
+                "default_sources": {k: "default" for k in _V16_DEFAULTS},
+            },
+            warnings=["obs file was not present; structural parse was skipped"],
+        )
+
+    data = _read_toml(path)
+    params = _params_from_toml(data)
+    expanded_params, explicit = _apply_v16_defaults(params)
+    references = _check_reference_files(path, expanded_params)
+    warnings = _static_section_warnings(normalized_mode, data)
+    missing_refs = [r for r in references if not r["readable"]]
+    for ref in missing_refs:
+        warnings.append(f"reference file for {ref['key']} is not readable: {ref['path']}")
+
+    neclib_parse = _try_neclib_parser(normalized_mode, path) if use_neclib_parser else {
+        "available": False,
+        "ok": False,
+        "reason": "disabled",
+    }
+    if use_neclib_parser and not neclib_parse.get("ok"):
+        warnings.append(
+            "neclib mode-specific parser was not available or did not complete; "
+            "TOML/static checks were still performed"
+        )
+
+    plan = _estimate_plan(normalized_mode, data, expanded_params)
+    obs_summary = _summarize_observation_properties(data)
+    line_count = len(path.read_text(encoding="utf-8", errors="replace").splitlines())
+    byte_size = path.stat().st_size
+    default_sources = {
+        key: "explicit" if explicit.get(key) else "default"
+        for key in _V16_DEFAULTS
+    }
+    summary = (
+        f"Check OK: mode={_ALLOWED_MODES[normalized_mode]}, file={path}, "
+        f"channel={ch if ch is not None else 'obs file/default'}, "
+        f"sections={len(_section_names(data))}, refs={len(references)}, "
+        f"v16 defaults: {_format_default_summary(explicit)}"
+    )
+    return ObservationCheckReport(
+        ok=True,
+        mode=normalized_mode,
+        file=str(path),
+        channel=ch,
+        summary=summary,
+        data={
+            "exists": True,
+            "parsed": True,
+            "size_bytes": byte_size,
+            "line_count": line_count,
+            "sections": _section_names(data),
+            "observation": obs_summary,
+            "parameters": dict(params),
+            "expanded_parameters": dict(expanded_params),
+            "v16_defaults": dict(_V16_DEFAULTS),
+            "default_sources": default_sources,
+            "reference_files": references,
+            "missing_reference_files": missing_refs,
+            "neclib_parse": neclib_parse,
+            "plan_preview": plan,
+        },
+        warnings=warnings,
+    )
+
+
+def dry_run_observation_plan(
+    mode: Any,
+    file_path: Any,
+    *,
+    channel: Any = None,
+    require_exists: bool = True,
+    use_neclib_parser: bool = True,
+) -> ObservationCheckReport:
+    """Build a read-only execution-plan preview for a file-based observation."""
+
+    report = check_observation_file(
+        mode,
+        file_path,
+        channel=channel,
+        require_exists=require_exists,
+        use_neclib_parser=use_neclib_parser,
+    )
+    plan = dict(report.data.get("plan_preview") or {})
+    refs = report.data.get("reference_files") or []
+    missing_refs = report.data.get("missing_reference_files") or []
+    duration = plan.get("estimated_total_sec")
+    duration_text = "unknown"
+    if isinstance(duration, (int, float)) and math.isfinite(float(duration)):
+        duration_text = f"{float(duration):.1f}s"
+    summary = (
+        f"Dry run OK: {_ALLOWED_MODES[report.mode]} plan={plan.get('plan_label')}, "
+        f"file={report.file}, channel={report.channel if report.channel is not None else 'obs file/default'}, "
+        f"estimated_total={duration_text}, refs={len(refs)}, missing_refs={len(missing_refs)}. "
+        "No mount/chopper/recording/gate/SG command was sent."
+    )
+    data = dict(report.data)
+    data["dry_run_semantics"] = {
+        "moves_antenna": False,
+        "moves_chopper": False,
+        "starts_recording": False,
+        "opens_gate": False,
+        "applies_sg": False,
+        "queues_observation": False,
+    }
+    return ObservationCheckReport(
+        ok=report.ok,
+        mode=report.mode,
+        file=report.file,
+        channel=report.channel,
+        summary=summary,
+        data=data,
+        warnings=list(report.warnings),
+        errors=list(report.errors),
+    )

--- a/necst/core/observation_check.py
+++ b/necst/core/observation_check.py
@@ -9,7 +9,6 @@ Console so that Check / Dry run semantics stay consistent.
 
 from __future__ import annotations
 
-import builtins
 import math
 import os
 import re
@@ -116,7 +115,9 @@ def validate_obs_file_path(file_path: Any, *, require_exists: bool) -> Path:
         raise ObservationCheckError("obs file extension must be .obs or .toml")
     if require_exists:
         if not path.exists():
-            raise ObservationCheckError(f"obs file does not exist on this computer: {path}")
+            raise ObservationCheckError(
+                f"obs file does not exist on this computer: {path}"
+            )
         if not path.is_file():
             raise ObservationCheckError(f"obs file is not a regular file: {path}")
         if not os.access(path, os.R_OK):
@@ -150,7 +151,9 @@ def _params_from_toml(data: Mapping[str, Any]) -> Dict[str, Any]:
     return params
 
 
-def _apply_v16_defaults(params: Mapping[str, Any]) -> tuple[Dict[str, Any], Dict[str, bool]]:
+def _apply_v16_defaults(
+    params: Mapping[str, Any],
+) -> tuple[Dict[str, Any], Dict[str, bool]]:
     expanded = dict(params)
     explicit: Dict[str, bool] = {}
     for key, value in _V16_DEFAULTS.items():
@@ -183,7 +186,9 @@ def _resolve_reference_path(obs_path: Path, ref: str) -> Path:
     return p
 
 
-def _check_reference_files(obs_path: Path, params: Mapping[str, Any]) -> list[Dict[str, Any]]:
+def _check_reference_files(
+    obs_path: Path, params: Mapping[str, Any]
+) -> list[Dict[str, Any]]:
     refs = []
     for key, value in _iter_reference_files(params):
         resolved = _resolve_reference_path(obs_path, value)
@@ -261,7 +266,9 @@ def _summarize_observation_properties(data: Mapping[str, Any]) -> Dict[str, Any]
         "object": obs.get("OBJECT") or obs.get("object") or obs.get("target"),
         "molecule_1": obs.get("MOLECULE_1") or obs.get("molecule_1"),
         "coord_sys": coord.get("COORD_SYS") or coord.get("coord_sys"),
-        "relative": coord.get("RELATIVE") if "RELATIVE" in coord else coord.get("relative"),
+        "relative": (
+            coord.get("RELATIVE") if "RELATIVE" in coord else coord.get("relative")
+        ),
     }
 
 
@@ -269,7 +276,12 @@ def _mode_required_sections(mode: str) -> tuple[str, ...]:
     if mode in {"otf", "grid", "psw"}:
         return ("observation_property", "coordinate", "calibration")
     if mode in {"radio_pointing", "radio-pointing", "radiopointing"}:
-        return ("observation_property", "coordinate", "pointing_property", "calibration")
+        return (
+            "observation_property",
+            "coordinate",
+            "pointing_property",
+            "calibration",
+        )
     return ("observation_property", "coordinate")
 
 
@@ -289,7 +301,9 @@ def _static_section_warnings(mode: str, data: Mapping[str, Any]) -> list[str]:
     return warnings
 
 
-def _estimate_plan(mode: str, data: Mapping[str, Any], expanded_params: Mapping[str, Any]) -> Dict[str, Any]:
+def _estimate_plan(
+    mode: str, data: Mapping[str, Any], expanded_params: Mapping[str, Any]
+) -> Dict[str, Any]:
     scan = _mapping(data.get("scan_property"))
     pointing = _mapping(data.get("pointing_property"))
     calib = _mapping(data.get("calibration"))
@@ -310,9 +324,15 @@ def _estimate_plan(mode: str, data: Mapping[str, Any], expanded_params: Mapping[
     off_interval = _first_value((calib, params), "off_interval")
     load_interval = _first_value((calib, params), "load_interval")
 
-    scan_spacing_arcsec = _parse_angle_arcsec(_first_value((scan, params), "scan_spacing"))
-    scan_length_arcsec = _parse_angle_arcsec(_first_value((scan, params), "scan_length"))
-    scan_velocity_arcsec_s = _parse_angle_arcsec(_first_value((scan, params), "scan_velocity"))
+    scan_spacing_arcsec = _parse_angle_arcsec(
+        _first_value((scan, params), "scan_spacing")
+    )
+    scan_length_arcsec = _parse_angle_arcsec(
+        _first_value((scan, params), "scan_length")
+    )
+    scan_velocity_arcsec_s = _parse_angle_arcsec(
+        _first_value((scan, params), "scan_velocity")
+    )
     scan_direction = _first_value((scan, params), "SCAN_DIRECTION", "scan_direction")
 
     estimated_scan_sec = None
@@ -384,7 +404,9 @@ def _try_neclib_parser(mode: str, path: Path) -> Dict[str, Any]:
             "ok": True,
             "spec_class": spec_name,
             "target": target,
-            "parameter_keys": sorted(params.keys()) if isinstance(params, Mapping) else [],
+            "parameter_keys": (
+                sorted(params.keys()) if isinstance(params, Mapping) else []
+            ),
         }
     except Exception as exc:
         return {
@@ -435,13 +457,19 @@ def check_observation_file(
     warnings = _static_section_warnings(normalized_mode, data)
     missing_refs = [r for r in references if not r["readable"]]
     for ref in missing_refs:
-        warnings.append(f"reference file for {ref['key']} is not readable: {ref['path']}")
+        warnings.append(
+            f"reference file for {ref['key']} is not readable: {ref['path']}"
+        )
 
-    neclib_parse = _try_neclib_parser(normalized_mode, path) if use_neclib_parser else {
-        "available": False,
-        "ok": False,
-        "reason": "disabled",
-    }
+    neclib_parse = (
+        _try_neclib_parser(normalized_mode, path)
+        if use_neclib_parser
+        else {
+            "available": False,
+            "ok": False,
+            "reason": "disabled",
+        }
+    )
     if use_neclib_parser and not neclib_parse.get("ok"):
         warnings.append(
             "neclib mode-specific parser was not available or did not complete; "
@@ -453,8 +481,7 @@ def check_observation_file(
     line_count = len(path.read_text(encoding="utf-8", errors="replace").splitlines())
     byte_size = path.stat().st_size
     default_sources = {
-        key: "explicit" if explicit.get(key) else "default"
-        for key in _V16_DEFAULTS
+        key: "explicit" if explicit.get(key) else "default" for key in _V16_DEFAULTS
     }
     summary = (
         f"Check OK: mode={_ALLOWED_MODES[normalized_mode]}, file={path}, "

--- a/necst/core/operator_actions.py
+++ b/necst/core/operator_actions.py
@@ -1,0 +1,1332 @@
+"""Shared operator action layer for NECST operator-facing tools.
+
+This module intentionally contains command semantics, not GUI or CLI formatting.
+Terminal commands and the future Operator Console should call these functions so
+that STOP, ABORT, mount move, and chopper actions use the same validation and
+Commander calls.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Literal, Optional, Sequence
+
+from .. import config
+from .commander import Commander
+from . import observation_check
+
+
+@dataclass(frozen=True)
+class OperatorActionResult:
+    """Result returned by an operator action.
+
+    Parameters
+    ----------
+    action
+        Stable action name, e.g. ``"antenna_stop"``.
+    success
+        True if the requested action completed or was accepted.
+    message
+        Operator-facing summary.
+    data
+        Machine-readable details for CLI/Web callers.
+    """
+
+    action: str
+    success: bool
+    message: str = ""
+    data: Dict[str, Any] = field(default_factory=dict)
+
+
+class OperatorActionError(RuntimeError):
+    """Raised when an operator action is rejected before it can be sent."""
+
+
+class OperatorActionTimeout(TimeoutError):
+    """Raised when an operator action was sent but completion was not observed."""
+
+
+class OperatorAuthoritySession:
+    """Hold NECST privilege for a long-lived operator console session.
+
+    This is intentionally small: it owns exactly one ``Commander`` instance and
+    releases/destroys it explicitly.  It is useful for direct Commander actions
+    such as mount move and chopper commands.  File-based observation launchers
+    run in separate processes and therefore must not be started while this
+    process is holding privilege for them.
+    """
+
+    def __init__(self, *, dry_run: bool = False) -> None:
+        self.dry_run = bool(dry_run)
+        self._commander: Optional[Commander] = None
+        self._should_shutdown = False
+        self._dry_run_held = False
+
+    @property
+    def commander(self) -> Commander:
+        if self._commander is None:
+            raise OperatorActionError("NECST privilege is not held by this session")
+        return self._commander
+
+    @property
+    def held(self) -> bool:
+        if self.dry_run:
+            return bool(self._dry_run_held)
+        if self._commander is None:
+            return False
+        try:
+            return bool(self._commander.has_privilege)
+        except Exception:
+            return False
+
+    @property
+    def identity(self) -> Optional[str]:
+        if self.dry_run:
+            return "dry-run-console-authority" if self._dry_run_held else None
+        try:
+            return str(getattr(self._commander, "identity"))
+        except Exception:
+            return None
+
+    def acquire(self) -> OperatorActionResult:
+        if self.held:
+            return OperatorActionResult(
+                action="acquire_authority",
+                success=True,
+                message="NECST privilege is already held by this session",
+                data={"held": True, "identity": self.identity, "dry_run": self.dry_run},
+            )
+        if self.dry_run:
+            self._dry_run_held = True
+            return OperatorActionResult(
+                action="acquire_authority",
+                success=True,
+                message="dry run: NECST privilege was not requested",
+                data={"held": True, "identity": self.identity, "dry_run": True},
+            )
+
+        self._should_shutdown = _ensure_rclpy()
+        self._commander = Commander()
+        try:
+            _acquire_privilege(self._commander)
+        except Exception:
+            try:
+                self._commander.destroy_node()
+            finally:
+                self._commander = None
+                _shutdown_if_needed(self._should_shutdown)
+                self._should_shutdown = False
+            raise
+        return OperatorActionResult(
+            action="acquire_authority",
+            success=True,
+            message="NECST privilege acquired for this console session",
+            data={"held": True, "identity": self.identity, "dry_run": False},
+        )
+
+    def release(self) -> OperatorActionResult:
+        identity = self.identity
+        if self.dry_run:
+            was_held = self._dry_run_held
+            self._dry_run_held = False
+            return OperatorActionResult(
+                action="release_authority",
+                success=True,
+                message=(
+                    "dry run: NECST privilege was not held"
+                    if not was_held
+                    else "dry run: NECST privilege release was simulated"
+                ),
+                data={"held": False, "identity": identity, "dry_run": True},
+            )
+
+        if self._commander is None:
+            return OperatorActionResult(
+                action="release_authority",
+                success=True,
+                message="NECST privilege was already free",
+                data={"held": False, "identity": identity, "dry_run": False},
+            )
+        try:
+            _safe_quit_privilege(self._commander)
+            return OperatorActionResult(
+                action="release_authority",
+                success=True,
+                message="NECST privilege released",
+                data={"held": False, "identity": identity, "dry_run": False},
+            )
+        finally:
+            try:
+                self._commander.destroy_node()
+            finally:
+                self._commander = None
+                _shutdown_if_needed(self._should_shutdown)
+                self._should_shutdown = False
+
+
+def _ensure_rclpy() -> bool:
+    """Initialize rclpy if needed and return whether this function did it."""
+    import rclpy
+
+    if rclpy.ok():
+        return False
+    rclpy.init()
+    return True
+
+
+def _shutdown_if_needed(should_shutdown: bool) -> None:
+    if not should_shutdown:
+        return
+    import rclpy
+
+    rclpy.shutdown()
+
+
+def _finite_float(value: Any, *, name: str) -> float:
+    try:
+        number = float(value)
+    except Exception as exc:
+        raise OperatorActionError(f"{name} is not a finite number") from exc
+    if not math.isfinite(number):
+        raise OperatorActionError(f"{name} is not a finite number")
+    return number
+
+
+def _bool_value(value: Any, *, name: str = "boolean value") -> bool:
+    if isinstance(value, bool):
+        return value
+    if value in (None, ""):
+        return False
+    text = str(value).strip().lower()
+    if text in {"1", "true", "yes", "on"}:
+        return True
+    if text in {"0", "false", "no", "off"}:
+        return False
+    raise OperatorActionError(f"{name} must be true or false")
+
+
+def _parse_sexagesimal_angle(value: Any, *, name: str, is_ra: bool) -> float:
+    """Parse decimal degrees or sexagesimal angle text into degrees.
+
+    RA accepts decimal degrees, HH:MM:SS.s, or 05h35m17.3s.  Dec accepts
+    decimal degrees, +/-DD:MM:SS.s, or -05d23m28s.
+    """
+
+    text = str(value or "").strip()
+    if not text:
+        raise OperatorActionError(f"{name} is empty")
+
+    lower = text.lower()
+    sexagesimal = any(ch in lower for ch in ":hmsd") or len(lower.split()) > 1
+    if not sexagesimal:
+        number = _finite_float(text, name=name)
+        return number
+
+    normalized = lower
+    for ch in "hmsd":
+        normalized = normalized.replace(ch, ":")
+    normalized = normalized.replace(" ", ":")
+    while "::" in normalized:
+        normalized = normalized.replace("::", ":")
+    normalized = normalized.strip(":")
+    parts = [p for p in normalized.split(":") if p != ""]
+    if not 1 <= len(parts) <= 3:
+        raise OperatorActionError(f"{name} must have 1 to 3 sexagesimal fields")
+
+    sign = 1.0
+    first = parts[0].strip()
+    if first.startswith("+"):
+        first = first[1:]
+    elif first.startswith("-"):
+        sign = -1.0
+        first = first[1:]
+    try:
+        a0 = float(first)
+        a1 = float(parts[1]) if len(parts) >= 2 else 0.0
+        a2 = float(parts[2]) if len(parts) >= 3 else 0.0
+    except Exception as exc:
+        raise OperatorActionError(f"{name} contains a non-numeric sexagesimal field") from exc
+    if not all(math.isfinite(x) for x in (a0, a1, a2)):
+        raise OperatorActionError(f"{name} is not finite")
+    if a1 < 0 or a1 >= 60 or a2 < 0 or a2 >= 60:
+        raise OperatorActionError(f"{name} minutes/seconds must satisfy 0 <= value < 60")
+    value_in_units = sign * (abs(a0) + a1 / 60.0 + a2 / 3600.0)
+    return value_in_units * 15.0 if is_ra else value_in_units
+
+
+def _validate_radec(ra_value: Any, dec_value: Any) -> tuple[float, float]:
+    ra_deg = _parse_sexagesimal_angle(ra_value, name="RA", is_ra=True)
+    dec_deg = _parse_sexagesimal_angle(dec_value, name="Dec", is_ra=False)
+    if not (0.0 <= ra_deg < 360.0):
+        raise OperatorActionError("RA must satisfy 0 <= value < 360 deg")
+    if not (-90.0 <= dec_deg <= 90.0):
+        raise OperatorActionError("Dec must satisfy -90 <= value <= 90 deg")
+    return ra_deg, dec_deg
+
+
+def _validate_galactic(l_value: Any, b_value: Any) -> tuple[float, float]:
+    l_deg = _finite_float(l_value, name="Galactic l")
+    b_deg = _finite_float(b_value, name="Galactic b")
+    if not (0.0 <= l_deg < 360.0):
+        raise OperatorActionError("Galactic l must satisfy 0 <= value < 360 deg")
+    if not (-90.0 <= b_deg <= 90.0):
+        raise OperatorActionError("Galactic b must satisfy -90 <= value <= 90 deg")
+    return l_deg, b_deg
+
+
+def _offset_arcsec_to_deg(value: Any, *, name: str) -> float:
+    arcsec = _finite_float(value, name=name)
+    if abs(arcsec) > 36000.0:
+        raise OperatorActionError(f"{name} must be within +/-36000 arcsec")
+    return arcsec / 3600.0
+
+
+def _normalize_offset_frame(value: Any, *, target_frame: Optional[str]) -> str:
+    frame = str(value or "target_frame").strip().lower().replace("-", "_")
+    aliases = {
+        "target": "target_frame",
+        "targetframe": "target_frame",
+        "target_frame": "target_frame",
+        "altaz": "altaz",
+        "azel": "altaz",
+        "az_el": "altaz",
+        "radec": "fk5",
+        "ra_dec": "fk5",
+        "fk5": "fk5",
+        "galactic": "galactic",
+    }
+    if frame not in aliases:
+        raise OperatorActionError(
+            "offset_frame must be target_frame, altaz, radec/fk5, or galactic"
+        )
+    resolved = aliases[frame]
+    if resolved == "target_frame":
+        return target_frame or "altaz"
+    return resolved
+
+
+def _tracking_request_payload(
+    kind: Any,
+    *,
+    name: Any = None,
+    coord1: Any = None,
+    coord2: Any = None,
+    offset_frame: Any = "target_frame",
+    offset_x_arcsec: Any = 0,
+    offset_y_arcsec: Any = 0,
+    cos_correction: Any = True,
+    wait: bool = False,
+    timeout_sec: Optional[float] = None,
+    dry_run: bool = False,
+    used_held_authority: bool = False,
+) -> tuple[Dict[str, Any], Dict[str, Any]]:
+    """Validate target-tracking inputs and return Commander kwargs + payload."""
+
+    normalized = str(kind or "").strip().lower().replace("-", "_")
+    if normalized not in {"sun", "moon", "name", "radec", "galactic"}:
+        raise OperatorActionError(
+            "target kind must be sun, moon, name, radec, or galactic"
+        )
+
+    target_frame: Optional[str] = None
+    target_label = normalized
+    commander_kwargs: Dict[str, Any] = {"unit": "deg", "wait": bool(wait)}
+    if timeout_sec is not None:
+        commander_kwargs["timeout_sec"] = max(0.0, _finite_float(timeout_sec, name="timeout_sec"))
+
+    if normalized in {"sun", "moon"}:
+        commander_kwargs["name"] = normalized
+        target_label = normalized
+    elif normalized == "name":
+        target_name = str(name or "").strip()
+        if not target_name:
+            raise OperatorActionError("object name is empty")
+        commander_kwargs["name"] = target_name
+        target_label = target_name
+    elif normalized == "radec":
+        ra_deg, dec_deg = _validate_radec(coord1, coord2)
+        target_frame = "fk5"
+        commander_kwargs["target"] = (ra_deg, dec_deg, target_frame)
+        target_label = f"RA={ra_deg:.9g} deg, Dec={dec_deg:.9g} deg"
+    else:
+        l_deg, b_deg = _validate_galactic(coord1, coord2)
+        target_frame = "galactic"
+        commander_kwargs["target"] = (l_deg, b_deg, target_frame)
+        target_label = f"l={l_deg:.9g} deg, b={b_deg:.9g} deg"
+
+    off_x_deg = _offset_arcsec_to_deg(offset_x_arcsec, name="offset X")
+    off_y_deg = _offset_arcsec_to_deg(offset_y_arcsec, name="offset Y")
+    resolved_offset_frame = _normalize_offset_frame(
+        offset_frame, target_frame=target_frame
+    )
+    if off_x_deg != 0.0 or off_y_deg != 0.0:
+        commander_kwargs["offset"] = (off_x_deg, off_y_deg, resolved_offset_frame)
+
+    cos = _bool_value(cos_correction, name="cos_correction")
+    commander_kwargs["cos_correction"] = cos
+    commander_kwargs["az_target_mode"] = "sky"
+
+    payload: Dict[str, Any] = {
+        "kind": normalized,
+        "target_label": target_label,
+        "target_frame": target_frame,
+        "offset_x_arcsec": off_x_deg * 3600.0,
+        "offset_y_arcsec": off_y_deg * 3600.0,
+        "offset_frame": resolved_offset_frame,
+        "cos_correction": cos,
+        "wait": bool(wait),
+        "timeout_sec": commander_kwargs.get("timeout_sec"),
+        "dry_run": bool(dry_run),
+        "used_held_authority": bool(used_held_authority),
+    }
+    if "name" in commander_kwargs:
+        payload["name"] = commander_kwargs["name"]
+    if "target" in commander_kwargs:
+        payload["target"] = commander_kwargs["target"]
+    if "offset" in commander_kwargs:
+        payload["offset"] = commander_kwargs["offset"]
+    return commander_kwargs, payload
+
+
+def _acquire_privilege(com: Commander) -> None:
+    if not com.get_privilege():
+        raise OperatorActionError("failed to acquire NECST privilege")
+
+
+def _safe_quit_privilege(com: Commander) -> None:
+    try:
+        com.quit_privilege()
+    except Exception:
+        pass
+
+
+def antenna_stop(
+    *,
+    confirm_timeout_sec: float = 1.0,
+    settle_sec: float = 0.0,
+    commander: Optional[Commander] = None,
+) -> OperatorActionResult:
+    """Send the bounded antenna STOP request.
+
+    This is the safety STOP path.  It does not perform observation cleanup.
+    """
+
+    timeout = max(0.0, _finite_float(confirm_timeout_sec, name="confirm_timeout_sec"))
+    settle = max(0.0, _finite_float(settle_sec, name="settle_sec"))
+
+    owns_commander = commander is None
+    should_shutdown = _ensure_rclpy() if owns_commander else False
+    com = Commander() if owns_commander else commander
+    assert com is not None
+    try:
+        com.antenna("stop", timeout_sec=timeout)
+        if settle > 0:
+            time.sleep(settle)
+        return OperatorActionResult(
+            action="antenna_stop",
+            success=True,
+            message="antenna stop request sent",
+            data={
+                "confirm_timeout_sec": timeout,
+                "settle_sec": settle,
+                "used_held_authority": not owns_commander,
+            },
+        )
+    finally:
+        if owns_commander:
+            com.destroy_node()
+            _shutdown_if_needed(should_shutdown)
+
+
+def abort_observation(
+    *,
+    reason: str = "operator requested abort",
+    requester: str = "necst abort",
+    antenna_stop_after_abort: bool = True,
+    repeat: int = 3,
+    interval_sec: float = 0.1,
+    settle_sec: float = 0.2,
+    commander: Optional[Commander] = None,
+) -> OperatorActionResult:
+    """Request cooperative observation abort.
+
+    This publishes the observation-abort request and, by default, also sends the
+    bounded antenna STOP request so blocking point/scan waits return promptly.
+    """
+
+    repeat = max(1, int(repeat))
+    interval = max(0.0, _finite_float(interval_sec, name="interval_sec"))
+    settle = max(0.0, _finite_float(settle_sec, name="settle_sec"))
+
+    owns_commander = commander is None
+    should_shutdown = _ensure_rclpy() if owns_commander else False
+    com = Commander() if owns_commander else commander
+    assert com is not None
+    try:
+        if settle > 0:
+            time.sleep(settle)
+        request_id = com.observation_abort(
+            reason=reason,
+            requester=requester,
+            repeat=repeat,
+            interval_sec=interval,
+        )
+        if antenna_stop_after_abort:
+            com.antenna("stop")
+        return OperatorActionResult(
+            action="abort_observation",
+            success=True,
+            message="abort request sent",
+            data={
+                "request_id": request_id,
+                "reason": str(reason or "operator requested abort"),
+                "requester": str(requester or "necst abort"),
+                "antenna_stop_after_abort": bool(antenna_stop_after_abort),
+                "repeat": repeat,
+                "interval_sec": interval,
+                "settle_sec": settle,
+                "used_held_authority": not owns_commander,
+            },
+        )
+    finally:
+        if owns_commander:
+            com.destroy_node()
+            _shutdown_if_needed(should_shutdown)
+
+
+def mount_move(
+    az_deg: Any,
+    el_deg: Any,
+    *,
+    wait: bool = True,
+    timeout_sec: Optional[float] = None,
+    dry_run: bool = False,
+    commander: Optional[Commander] = None,
+) -> OperatorActionResult:
+    """Move to explicit mount mechanical Az/El.
+
+    Definitions
+    -----------
+    Input Az/El are mount mechanical coordinates in degrees.  The command sent
+    to Commander is always ``direct_mode=True`` and ``az_target_mode="mount"``.
+    ``Az=360`` is therefore a mount angle, not automatically wrapped to zero.
+    """
+
+    az = _finite_float(az_deg, name="az_deg")
+    el = _finite_float(el_deg, name="el_deg")
+    if timeout_sec is None:
+        timeout = None
+    else:
+        timeout = max(0.0, _finite_float(timeout_sec, name="timeout_sec"))
+
+    payload: Dict[str, Any] = {
+        "az_deg": az,
+        "el_deg": el,
+        "frame": "altaz",
+        "unit": "deg",
+        "direct_mode": True,
+        "az_target_mode": "mount",
+        "wait": bool(wait),
+        "timeout_sec": timeout,
+        "dry_run": bool(dry_run),
+        "used_held_authority": commander is not None,
+    }
+    if dry_run:
+        return OperatorActionResult(
+            action="mount_move",
+            success=True,
+            message="dry run: mount move command was not sent",
+            data=payload,
+        )
+
+    owns_commander = commander is None
+    should_shutdown = _ensure_rclpy() if owns_commander else False
+    com = Commander() if owns_commander else commander
+    assert com is not None
+    try:
+        _acquire_privilege(com)
+        cmd_id = com.antenna(
+            "point",
+            target=(az, el, "altaz"),
+            unit="deg",
+            direct_mode=True,
+            az_target_mode="mount",
+            wait=False,
+        )
+        payload["command_id"] = cmd_id
+        if wait:
+            com.wait_mount_point(az, el, command_id=cmd_id, timeout_sec=timeout)
+        return OperatorActionResult(
+            action="mount_move",
+            success=True,
+            message="mount move command sent",
+            data=payload,
+        )
+    finally:
+        if owns_commander:
+            _safe_quit_privilege(com)
+            com.destroy_node()
+            _shutdown_if_needed(should_shutdown)
+
+
+def _chopper_config_positions() -> tuple[Optional[int], Optional[int]]:
+    try:
+        insert_position = int(config.chopper_motor_position["insert"])
+        remove_position = int(config.chopper_motor_position["remove"])
+        return insert_position, remove_position
+    except Exception:
+        return None, None
+
+
+def _chopper_msg_position(msg: Any) -> Optional[int]:
+    try:
+        return int(getattr(msg, "position"))
+    except Exception:
+        return None
+
+
+def _chopper_msg_insert_flag(msg: Any) -> Optional[bool]:
+    try:
+        value = getattr(msg, "insert")
+    except Exception:
+        return None
+    return None if value is None else bool(value)
+
+
+def _chopper_simulator_uses_boolean_only_status() -> bool:
+    """Return True when active chopper status is expected to be simulator-like."""
+    try:
+        return bool(getattr(config, "simulator", False))
+    except Exception:
+        return False
+
+
+def _chopper_zero_is_boolean_only_simulator_for_target(target_position: int) -> bool:
+    """Return True when position=0 may stand for simulator-only boolean state."""
+    return _chopper_simulator_uses_boolean_only_status() and int(target_position) != 0
+
+
+def chopper_status_matches(msg: Any, target_position: int, target_insert: bool) -> bool:
+    """Return True if chopper telemetry confirms the requested endpoint."""
+    position = _chopper_msg_position(msg)
+    insert_flag = _chopper_msg_insert_flag(msg)
+    target_position = int(target_position)
+
+    if position is not None and position == target_position:
+        return insert_flag is None or insert_flag == bool(target_insert)
+    if insert_flag is None or insert_flag != bool(target_insert):
+        return False
+    if position is None:
+        return True
+    if position == 0 and _chopper_zero_is_boolean_only_simulator_for_target(
+        target_position
+    ):
+        return True
+    return False
+
+
+def format_chopper_status(msg: Any) -> tuple[str, str]:
+    """Return operator-facing chopper state and detail string."""
+    position = _chopper_msg_position(msg)
+    insert_position, remove_position = _chopper_config_positions()
+    insert_flag = _chopper_msg_insert_flag(msg)
+    simulator_boolean_only = _chopper_simulator_uses_boolean_only_status()
+
+    if (
+        position is not None
+        and insert_position is not None
+        and position == insert_position
+        and insert_flag is not False
+    ):
+        state = "IN"
+    elif (
+        position is not None
+        and remove_position is not None
+        and position == remove_position
+        and insert_flag is not True
+    ):
+        state = "OUT"
+    elif simulator_boolean_only and position == 0 and insert_flag is True:
+        state = "IN"
+    elif simulator_boolean_only and position == 0 and insert_flag is False:
+        state = "OUT"
+    elif insert_flag is True:
+        state = "IN?"
+    elif insert_flag is False:
+        state = "OUT?"
+    else:
+        state = "UNKNOWN"
+
+    timestamp = getattr(msg, "time", None)
+    try:
+        age_sec = max(0.0, time.time() - float(timestamp))
+        age_text = f", age={age_sec:.1f}s"
+    except Exception:
+        age_text = ""
+
+    detail = f"position={position}, insert={insert_flag}{age_text}"
+    return state, detail
+
+
+def wait_chopper_position(
+    com: Commander, target_position: int, target_insert: bool, timeout_sec: float
+) -> Any:
+    """Wait for chopper status to reach target position/flag with a timeout."""
+    timeout = max(0.0, _finite_float(timeout_sec, name="timeout_sec"))
+    deadline = time.monotonic() + timeout
+    last_state = "UNKNOWN"
+    last_detail = "no status received"
+    while time.monotonic() <= deadline:
+        try:
+            msg = com.get_message("chopper", timeout_sec=0.2)
+            state, detail = format_chopper_status(msg)
+            last_state, last_detail = state, detail
+            if chopper_status_matches(msg, target_position, target_insert):
+                return msg
+        except Exception as exc:
+            last_state, last_detail = "UNKNOWN", str(exc)
+        time.sleep(0.1)
+    raise OperatorActionTimeout(
+        "chopper did not reach target position "
+        f"{target_position} within {timeout:.1f}s "
+        f"(last: {last_state}, {last_detail})"
+    )
+
+
+def chopper_status(
+    *,
+    timeout_sec: float = 10.0,
+    settle_sec: float = 0.2,
+    commander: Optional[Commander] = None,
+) -> OperatorActionResult:
+    """Read chopper telemetry without sending a command."""
+    timeout = max(0.0, _finite_float(timeout_sec, name="timeout_sec"))
+    settle = max(0.0, _finite_float(settle_sec, name="settle_sec"))
+
+    owns_commander = commander is None
+    should_shutdown = _ensure_rclpy() if owns_commander else False
+    com = Commander() if owns_commander else commander
+    assert com is not None
+    try:
+        if settle > 0:
+            time.sleep(settle)
+        msg = com.get_message("chopper", timeout_sec=timeout)
+        state, detail = format_chopper_status(msg)
+        return OperatorActionResult(
+            action="chopper_status",
+            success=True,
+            message=f"chopper {state}: {detail}",
+            data={"state": state, "detail": detail, "used_held_authority": not owns_commander},
+        )
+    finally:
+        if owns_commander:
+            com.destroy_node()
+            _shutdown_if_needed(should_shutdown)
+
+
+def chopper_move(
+    position: Literal["in", "out"],
+    *,
+    wait: bool = True,
+    timeout_sec: float = 10.0,
+    settle_sec: float = 0.2,
+    repeat: int = 3,
+    interval_sec: float = 0.1,
+    commander: Optional[Commander] = None,
+) -> OperatorActionResult:
+    """Move the chopper IN or OUT through the shared Commander path."""
+    command = str(position).strip().lower()
+    if command not in {"in", "out"}:
+        raise OperatorActionError("chopper position must be 'in' or 'out'")
+
+    if command == "in":
+        commander_cmd = "insert"
+        label = "IN"
+        target_insert = True
+        target_position = int(config.chopper_motor_position["insert"])
+    else:
+        commander_cmd = "remove"
+        label = "OUT"
+        target_insert = False
+        target_position = int(config.chopper_motor_position["remove"])
+
+    timeout = max(0.0, _finite_float(timeout_sec, name="timeout_sec"))
+    settle = max(0.0, _finite_float(settle_sec, name="settle_sec"))
+    interval = max(0.0, _finite_float(interval_sec, name="interval_sec"))
+    repeat = max(1, int(repeat))
+
+    owns_commander = commander is None
+    should_shutdown = _ensure_rclpy() if owns_commander else False
+    com = Commander() if owns_commander else commander
+    assert com is not None
+    try:
+        if settle > 0:
+            time.sleep(settle)
+        _acquire_privilege(com)
+        for i in range(repeat):
+            com.chopper(commander_cmd, wait=False)
+            if i + 1 < repeat:
+                time.sleep(interval)
+
+        state = label
+        detail = f"target_position={target_position}, wait={bool(wait)}"
+        if wait:
+            msg = wait_chopper_position(
+                com,
+                target_position,
+                target_insert,
+                timeout_sec=timeout,
+            )
+            state, detail = format_chopper_status(msg)
+        return OperatorActionResult(
+            action=f"chopper_{command}",
+            success=True,
+            message=f"chopper {state}: {detail}",
+            data={
+                "command": command,
+                "commander_cmd": commander_cmd,
+                "target_position": target_position,
+                "target_insert": target_insert,
+                "state": state,
+                "detail": detail,
+                "wait": bool(wait),
+                "timeout_sec": timeout,
+                "settle_sec": settle,
+                "repeat": repeat,
+                "interval_sec": interval,
+                "used_held_authority": not owns_commander,
+            },
+        )
+    finally:
+        if owns_commander:
+            _safe_quit_privilege(com)
+            com.destroy_node()
+            _shutdown_if_needed(should_shutdown)
+
+
+def chopper_maintenance(
+    command: Literal["alarm-reset", "home", "recover"],
+    *,
+    settle_sec: float = 0.2,
+    commander: Optional[Commander] = None,
+) -> OperatorActionResult:
+    """Run a chopper maintenance service request."""
+    normalized = str(command).strip().lower()
+    aliases = {
+        "alarm_reset": "alarm-reset",
+        "reset-alarm": "alarm-reset",
+        "zero": "home",
+        "zero-point": "home",
+    }
+    normalized = aliases.get(normalized, normalized)
+    if normalized not in {"alarm-reset", "home", "recover"}:
+        raise OperatorActionError(
+            "chopper maintenance command must be alarm-reset, home, or recover"
+        )
+    settle = max(0.0, _finite_float(settle_sec, name="settle_sec"))
+
+    owns_commander = commander is None
+    should_shutdown = _ensure_rclpy() if owns_commander else False
+    com = Commander() if owns_commander else commander
+    assert com is not None
+    try:
+        if settle > 0:
+            time.sleep(settle)
+        _acquire_privilege(com)
+        result = com.chopper_maintenance(normalized)  # type: ignore[arg-type]
+        success = bool(getattr(result, "success", False))
+        message = str(getattr(result, "message", "")).strip()
+        status = "completed" if success else "failed"
+        return OperatorActionResult(
+            action=f"chopper_{normalized.replace('-', '_')}",
+            success=success,
+            message=f"chopper {normalized} {status}" + (f": {message}" if message else ""),
+            data={
+                "command": normalized,
+                "service_success": success,
+                "service_message": message,
+                "settle_sec": settle,
+                "used_held_authority": not owns_commander,
+            },
+        )
+    finally:
+        if owns_commander:
+            _safe_quit_privilege(com)
+            com.destroy_node()
+            _shutdown_if_needed(should_shutdown)
+
+
+def start_target_tracking(
+    kind: Any,
+    *,
+    name: Any = None,
+    coord1: Any = None,
+    coord2: Any = None,
+    offset_frame: Any = "target_frame",
+    offset_x_arcsec: Any = 0,
+    offset_y_arcsec: Any = 0,
+    cos_correction: Any = True,
+    wait: bool = False,
+    timeout_sec: Optional[float] = None,
+    dry_run: bool = False,
+    commander: Optional[Commander] = None,
+) -> OperatorActionResult:
+    """Start target tracking through the shared Commander path.
+
+    Definitions
+    -----------
+    ``kind`` selects one of: ``sun``, ``moon``, ``name``, ``radec``,
+    ``galactic``.  RA/Dec and Galactic coordinates are validated in degrees;
+    RA also accepts sexagesimal hour notation.  Offsets are accepted in arcsec
+    and converted to degrees before calling Commander.
+    """
+
+    commander_kwargs, payload = _tracking_request_payload(
+        kind,
+        name=name,
+        coord1=coord1,
+        coord2=coord2,
+        offset_frame=offset_frame,
+        offset_x_arcsec=offset_x_arcsec,
+        offset_y_arcsec=offset_y_arcsec,
+        cos_correction=cos_correction,
+        wait=wait,
+        timeout_sec=timeout_sec,
+        dry_run=dry_run,
+        used_held_authority=commander is not None,
+    )
+    if dry_run:
+        return OperatorActionResult(
+            action="start_target_tracking",
+            success=True,
+            message=(
+                "dry run: target tracking command was not sent "
+                f"({payload['target_label']})"
+            ),
+            data=payload,
+        )
+
+    owns_commander = commander is None
+    should_shutdown = _ensure_rclpy() if owns_commander else False
+    com = Commander() if owns_commander else commander
+    assert com is not None
+    try:
+        _acquire_privilege(com)
+        cmd_id = com.antenna("point", **commander_kwargs)
+        payload["command_id"] = cmd_id
+        return OperatorActionResult(
+            action="start_target_tracking",
+            success=True,
+            message=f"target tracking command sent: {payload['target_label']}",
+            data=payload,
+        )
+    finally:
+        if owns_commander:
+            _safe_quit_privilege(com)
+            com.destroy_node()
+            _shutdown_if_needed(should_shutdown)
+
+
+def stop_tracking(
+    *,
+    confirm_timeout_sec: float = 1.0,
+    settle_sec: float = 0.0,
+    commander: Optional[Commander] = None,
+) -> OperatorActionResult:
+    """Stop target tracking by using the same bounded antenna STOP path."""
+
+    result = antenna_stop(
+        confirm_timeout_sec=confirm_timeout_sec,
+        settle_sec=settle_sec,
+        commander=commander,
+    )
+    return OperatorActionResult(
+        action="stop_tracking",
+        success=result.success,
+        message=(
+            "target tracking stop requested via antenna STOP"
+            if result.success
+            else result.message
+        ),
+        data=dict(result.data),
+    )
+
+
+_OBSERVATION_MODE_SCRIPTS: Dict[str, str] = {
+    "otf": "otf.py",
+    "psw": "psw_file.py",
+    "grid": "grid.py",
+    "radio_pointing": "radio_pointing.py",
+    "radio-pointing": "radio_pointing.py",
+    "radiopointing": "radio_pointing.py",
+}
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _script_path(script_name: str) -> Path:
+    path = _repo_root() / "bin" / script_name
+    if not path.exists():
+        raise OperatorActionError(f"NECST launcher script is missing: {path}")
+    return path
+
+
+def _python_env_for_source_tree() -> Dict[str, str]:
+    env = os.environ.copy()
+    root = str(_repo_root())
+    current = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = root if not current else f"{root}{os.pathsep}{current}"
+    return env
+
+
+def _positive_int_or_none(value: Any, *, name: str) -> Optional[int]:
+    if value in (None, ""):
+        return None
+    try:
+        number = int(value)
+    except Exception as exc:
+        raise OperatorActionError(f"{name} must be an integer") from exc
+    if number <= 0:
+        raise OperatorActionError(f"{name} must be positive")
+    return number
+
+
+def _positive_float(value: Any, *, name: str) -> float:
+    number = _finite_float(value, name=name)
+    if number <= 0:
+        raise OperatorActionError(f"{name} must be positive")
+    return number
+
+
+def _validate_obs_path(
+    file_path: Any,
+    *,
+    check_exists: bool,
+    name: str = "obs file",
+) -> str:
+    path = str(file_path or "").strip()
+    if not path:
+        raise OperatorActionError(f"{name} path/name is empty")
+    if not path.lower().endswith((".obs", ".toml")):
+        raise OperatorActionError(f"{name} extension must be .obs or .toml")
+    if check_exists:
+        p = Path(path)
+        if not p.exists():
+            raise OperatorActionError(f"{name} does not exist on this computer: {path}")
+        if not p.is_file():
+            raise OperatorActionError(f"{name} is not a regular file: {path}")
+        if not os.access(p, os.R_OK):
+            raise OperatorActionError(f"{name} is not readable: {path}")
+    return path
+
+
+def _run_launcher_command(
+    action: str,
+    argv: Sequence[str],
+    *,
+    background: bool,
+    dry_run: bool,
+    stdout_path: Any = None,
+    stderr_path: Any = None,
+) -> OperatorActionResult:
+    command = [str(x) for x in argv]
+    stdout_file = str(stdout_path) if stdout_path not in (None, "") else None
+    stderr_file = str(stderr_path) if stderr_path not in (None, "") else None
+    data: Dict[str, Any] = {
+        "command": command,
+        "background": bool(background),
+        "dry_run": bool(dry_run),
+        "cwd": str(_repo_root()),
+        "stdout_path": stdout_file,
+        "stderr_path": stderr_file,
+    }
+    if dry_run:
+        return OperatorActionResult(
+            action=action,
+            success=True,
+            message=f"dry run: {action} launcher was not started",
+            data=data,
+        )
+
+    if background:
+        stdout_handle = None
+        stderr_handle = None
+        try:
+            if stdout_file is not None:
+                Path(stdout_file).parent.mkdir(parents=True, exist_ok=True)
+                stdout_handle = open(stdout_file, "ab", buffering=0)
+            if stderr_file is not None:
+                Path(stderr_file).parent.mkdir(parents=True, exist_ok=True)
+                stderr_handle = open(stderr_file, "ab", buffering=0)
+            proc = subprocess.Popen(
+                command,
+                cwd=str(_repo_root()),
+                env=_python_env_for_source_tree(),
+                stdout=stdout_handle if stdout_handle is not None else None,
+                stderr=stderr_handle if stderr_handle is not None else None,
+                start_new_session=True,
+            )
+        finally:
+            if stdout_handle is not None:
+                stdout_handle.close()
+            if stderr_handle is not None:
+                stderr_handle.close()
+        data["pid"] = proc.pid
+        # Keep the Popen object for the web console process registry.  The key
+        # is private and must be removed before any JSON response is emitted.
+        data["_popen"] = proc
+        return OperatorActionResult(
+            action=action,
+            success=True,
+            message=f"{action} launcher started in background (pid={proc.pid})",
+            data=data,
+        )
+
+    run_kwargs: Dict[str, Any] = {}
+    stdout_handle = None
+    stderr_handle = None
+    try:
+        if stdout_file is not None:
+            Path(stdout_file).parent.mkdir(parents=True, exist_ok=True)
+            stdout_handle = open(stdout_file, "ab", buffering=0)
+            run_kwargs["stdout"] = stdout_handle
+        if stderr_file is not None:
+            Path(stderr_file).parent.mkdir(parents=True, exist_ok=True)
+            stderr_handle = open(stderr_file, "ab", buffering=0)
+            run_kwargs["stderr"] = stderr_handle
+        completed = subprocess.run(
+            command,
+            cwd=str(_repo_root()),
+            env=_python_env_for_source_tree(),
+            check=False,
+            **run_kwargs,
+        )
+    finally:
+        if stdout_handle is not None:
+            stdout_handle.close()
+        if stderr_handle is not None:
+            stderr_handle.close()
+    data["returncode"] = completed.returncode
+    return OperatorActionResult(
+        action=action,
+        success=completed.returncode == 0,
+        message=f"{action} launcher exited with return code {completed.returncode}",
+        data=data,
+    )
+
+
+def check_obs_file(
+    mode: Any,
+    file_path: Any,
+    *,
+    channel: Any = None,
+    require_exists: bool = True,
+    use_neclib_parser: bool = True,
+) -> OperatorActionResult:
+    """Check an observation file without touching telescope hardware.
+
+    This performs static validation, v16 default expansion, reference-file
+    checks, and an optional neclib mode-specific parser pass.  It never moves
+    the antenna/chopper, starts recorder/gate, applies SG settings, or queues
+    an observation.
+    """
+
+    report = observation_check.check_observation_file(
+        mode,
+        file_path,
+        channel=channel,
+        require_exists=require_exists,
+        use_neclib_parser=use_neclib_parser,
+    )
+    return OperatorActionResult(
+        action="check_observation",
+        success=report.ok,
+        message=report.summary,
+        data=report.to_dict(),
+    )
+
+
+def dry_run_observation(
+    mode: Any,
+    file_path: Any,
+    *,
+    channel: Any = None,
+    require_exists: bool = True,
+    use_neclib_parser: bool = True,
+) -> OperatorActionResult:
+    """Build a read-only observation execution-plan preview.
+
+    The dry run is intentionally static: it returns the likely sequence, v16
+    defaults, reference-file status, and rough timing information, but sends no
+    mount/chopper/recording/gate/SG commands and does not queue observation
+    execution.
+    """
+
+    report = observation_check.dry_run_observation_plan(
+        mode,
+        file_path,
+        channel=channel,
+        require_exists=require_exists,
+        use_neclib_parser=use_neclib_parser,
+    )
+    return OperatorActionResult(
+        action="dry_run_observation",
+        success=report.ok,
+        message=report.summary,
+        data=report.to_dict(),
+    )
+
+
+def start_observation(
+    mode: Any,
+    file_path: Any,
+    *,
+    channel: Any = None,
+    background: bool = True,
+    dry_run: bool = False,
+    check_exists: bool = True,
+    stdout_path: Any = None,
+    stderr_path: Any = None,
+) -> OperatorActionResult:
+    """Start a file-based observation through the existing NECST launcher.
+
+    Inputs
+    ------
+    mode
+        One of ``otf``, ``psw``, ``grid``, or ``radio_pointing``.
+    file_path
+        Path on the NECST computer.  In live mode this must exist and be readable.
+    channel
+        Optional positive integer spectral-channel override.
+    background
+        True starts a separate process and returns immediately.  This is the
+        intended mode for the web Operator Console so the HTTP request is not
+        held until the observation finishes.
+    dry_run
+        Validate and report the exact command without starting a process.
+    check_exists
+        File existence/readability validation.  Keep True for live start; tests
+        and UI dry-runs may set False only when no command is sent.
+    """
+
+    normalized_mode = str(mode or "").strip().lower()
+    if normalized_mode not in _OBSERVATION_MODE_SCRIPTS:
+        raise OperatorActionError(
+            "observation mode must be OTF, PSW, Grid, or Radio Pointing"
+        )
+    if not dry_run and not check_exists:
+        raise OperatorActionError("live observation start requires obs file existence check")
+    obs_path = _validate_obs_path(
+        file_path,
+        check_exists=bool(check_exists),
+        name="obs file",
+    )
+    ch = _positive_int_or_none(channel, name="channel override")
+    script = _script_path(_OBSERVATION_MODE_SCRIPTS[normalized_mode])
+    argv = [sys.executable, str(script), "--file", obs_path]
+    if ch is not None:
+        argv.extend(["--channel", str(ch)])
+    result = _run_launcher_command(
+        "start_observation",
+        argv,
+        background=background,
+        dry_run=dry_run,
+        stdout_path=stdout_path,
+        stderr_path=stderr_path,
+    )
+    result.data.update({"mode": normalized_mode, "file": obs_path, "channel": ch})
+    return result
+
+
+def run_rsky(
+    *,
+    n: Any = 1,
+    integ: Any = 2,
+    channel: Any = None,
+    background: bool = True,
+    dry_run: bool = False,
+    stdout_path: Any = None,
+    stderr_path: Any = None,
+) -> OperatorActionResult:
+    """Run an RSky calibration action through the existing launcher."""
+
+    n_int = _positive_int_or_none(n, name="RSky n") or 1
+    integ_sec = _positive_float(integ, name="RSky integ")
+    ch = _positive_int_or_none(channel, name="RSky channel")
+    script = _script_path("rsky.py")
+    argv = [sys.executable, str(script), "-n", str(n_int), "--integ", f"{integ_sec:g}"]
+    if ch is not None:
+        argv.extend(["--channel", str(ch)])
+    result = _run_launcher_command(
+        "run_rsky",
+        argv,
+        background=background,
+        dry_run=dry_run,
+        stdout_path=stdout_path,
+        stderr_path=stderr_path,
+    )
+    result.data.update({"n": n_int, "integ_sec": integ_sec, "channel": ch})
+    return result
+
+
+def _parse_tp_range(value: Any) -> list[int]:
+    if value in (None, ""):
+        return []
+    if isinstance(value, str):
+        tokens = value.replace(",", " ").split()
+    else:
+        try:
+            tokens = list(value)
+        except TypeError as exc:
+            raise OperatorActionError("SkyDip tp_range must be a string or sequence") from exc
+    try:
+        out = [int(x) for x in tokens]
+    except Exception as exc:
+        raise OperatorActionError("SkyDip tp_range must contain integers") from exc
+    if len(out) % 2 != 0:
+        raise OperatorActionError("SkyDip tp_range must contain START END pairs")
+    return out
+
+
+def run_skydip(
+    *,
+    integ: Any = 2,
+    channel: Any = None,
+    tp_range: Any = None,
+    background: bool = True,
+    dry_run: bool = False,
+    stdout_path: Any = None,
+    stderr_path: Any = None,
+) -> OperatorActionResult:
+    """Run a SkyDip calibration action through the existing launcher."""
+
+    integ_sec = _positive_float(integ, name="SkyDip integ")
+    ch = _positive_int_or_none(channel, name="SkyDip channel")
+    tp_values = _parse_tp_range(tp_range)
+    script = _script_path("skydip.py")
+    argv = [sys.executable, str(script), "--integ", f"{integ_sec:g}"]
+    if ch is not None:
+        argv.extend(["--channel", str(ch)])
+    if tp_values:
+        argv.append("--tp_range")
+        argv.extend(str(x) for x in tp_values)
+    result = _run_launcher_command(
+        "run_skydip",
+        argv,
+        background=background,
+        dry_run=dry_run,
+        stdout_path=stdout_path,
+        stderr_path=stderr_path,
+    )
+    result.data.update(
+        {"integ_sec": integ_sec, "channel": ch, "tp_range": tp_values}
+    )
+    return result

--- a/necst/core/operator_actions.py
+++ b/necst/core/operator_actions.py
@@ -19,7 +19,7 @@ from typing import Any, Dict, Literal, Optional, Sequence
 
 from .. import config
 from .commander import Commander
-from ..ctrl.antenna.az_unwrap import assert_mount_az_allowed_when_unwrap_disabled
+from ..az_unwrap_limits import assert_mount_az_allowed_when_unwrap_disabled
 from . import observation_check
 
 

--- a/necst/core/operator_actions.py
+++ b/necst/core/operator_actions.py
@@ -19,6 +19,7 @@ from typing import Any, Dict, Literal, Optional, Sequence
 
 from .. import config
 from .commander import Commander
+from ..ctrl.antenna.az_unwrap import assert_mount_az_allowed_when_unwrap_disabled
 from . import observation_check
 
 
@@ -520,6 +521,12 @@ def mount_move(
 
     az = _finite_float(az_deg, name="az_deg")
     el = _finite_float(el_deg, name="el_deg")
+    try:
+        unwrap_disabled_limit = assert_mount_az_allowed_when_unwrap_disabled(
+            az, action_label="mount_move"
+        )
+    except ValueError as exc:
+        raise OperatorActionError(str(exc)) from exc
     if timeout_sec is None:
         timeout = None
     else:
@@ -537,6 +544,8 @@ def mount_move(
         "dry_run": bool(dry_run),
         "used_held_authority": commander is not None,
     }
+    if unwrap_disabled_limit is not None:
+        payload["az_unwrap_disabled_raw_limit"] = unwrap_disabled_limit
     if dry_run:
         return OperatorActionResult(
             action="mount_move",

--- a/necst/core/operator_actions.py
+++ b/necst/core/operator_actions.py
@@ -252,11 +252,15 @@ def _parse_sexagesimal_angle(value: Any, *, name: str, is_ra: bool) -> float:
         a1 = float(parts[1]) if len(parts) >= 2 else 0.0
         a2 = float(parts[2]) if len(parts) >= 3 else 0.0
     except Exception as exc:
-        raise OperatorActionError(f"{name} contains a non-numeric sexagesimal field") from exc
+        raise OperatorActionError(
+            f"{name} contains a non-numeric sexagesimal field"
+        ) from exc
     if not all(math.isfinite(x) for x in (a0, a1, a2)):
         raise OperatorActionError(f"{name} is not finite")
     if a1 < 0 or a1 >= 60 or a2 < 0 or a2 >= 60:
-        raise OperatorActionError(f"{name} minutes/seconds must satisfy 0 <= value < 60")
+        raise OperatorActionError(
+            f"{name} minutes/seconds must satisfy 0 <= value < 60"
+        )
     value_in_units = sign * (abs(a0) + a1 / 60.0 + a2 / 3600.0)
     return value_in_units * 15.0 if is_ra else value_in_units
 
@@ -339,7 +343,9 @@ def _tracking_request_payload(
     target_label = normalized
     commander_kwargs: Dict[str, Any] = {"unit": "deg", "wait": bool(wait)}
     if timeout_sec is not None:
-        commander_kwargs["timeout_sec"] = max(0.0, _finite_float(timeout_sec, name="timeout_sec"))
+        commander_kwargs["timeout_sec"] = max(
+            0.0, _finite_float(timeout_sec, name="timeout_sec")
+        )
 
     if normalized in {"sun", "moon"}:
         commander_kwargs["name"] = normalized
@@ -731,7 +737,11 @@ def chopper_status(
             action="chopper_status",
             success=True,
             message=f"chopper {state}: {detail}",
-            data={"state": state, "detail": detail, "used_held_authority": not owns_commander},
+            data={
+                "state": state,
+                "detail": detail,
+                "used_held_authority": not owns_commander,
+            },
         )
     finally:
         if owns_commander:
@@ -855,7 +865,8 @@ def chopper_maintenance(
         return OperatorActionResult(
             action=f"chopper_{normalized.replace('-', '_')}",
             success=success,
-            message=f"chopper {normalized} {status}" + (f": {message}" if message else ""),
+            message=f"chopper {normalized} {status}"
+            + (f": {message}" if message else ""),
             data={
                 "command": normalized,
                 "service_success": success,
@@ -1232,7 +1243,9 @@ def start_observation(
             "observation mode must be OTF, PSW, Grid, or Radio Pointing"
         )
     if not dry_run and not check_exists:
-        raise OperatorActionError("live observation start requires obs file existence check")
+        raise OperatorActionError(
+            "live observation start requires obs file existence check"
+        )
     obs_path = _validate_obs_path(
         file_path,
         check_exists=bool(check_exists),
@@ -1295,7 +1308,9 @@ def _parse_tp_range(value: Any) -> list[int]:
         try:
             tokens = list(value)
         except TypeError as exc:
-            raise OperatorActionError("SkyDip tp_range must be a string or sequence") from exc
+            raise OperatorActionError(
+                "SkyDip tp_range must be a string or sequence"
+            ) from exc
     try:
         out = [int(x) for x in tokens]
     except Exception as exc:
@@ -1335,7 +1350,5 @@ def run_skydip(
         stdout_path=stdout_path,
         stderr_path=stderr_path,
     )
-    result.data.update(
-        {"integ_sec": integ_sec, "channel": ch, "tp_range": tp_values}
-    )
+    result.data.update({"integ_sec": integ_sec, "channel": ch, "tp_range": tp_values})
     return result

--- a/necst/core/operator_actions.py
+++ b/necst/core/operator_actions.py
@@ -518,8 +518,6 @@ def mount_move(
 ) -> OperatorActionResult:
     """Move to explicit mount mechanical Az/El.
 
-    Definitions
-    -----------
     Input Az/El are mount mechanical coordinates in degrees.  The command sent
     to Commander is always ``direct_mode=True`` and ``az_target_mode="mount"``.
     ``Az=360`` is therefore a mount angle, not automatically wrapped to zero.
@@ -899,8 +897,6 @@ def start_target_tracking(
 ) -> OperatorActionResult:
     """Start target tracking through the shared Commander path.
 
-    Definitions
-    -----------
     ``kind`` selects one of: ``sun``, ``moon``, ``name``, ``radec``,
     ``galactic``.  RA/Dec and Galactic coordinates are validated in degrees;
     RA also accepts sexagesimal hour notation.  Offsets are accepted in arcsec

--- a/necst/core/operator_actions.py
+++ b/necst/core/operator_actions.py
@@ -1214,8 +1214,6 @@ def start_observation(
 ) -> OperatorActionResult:
     """Start a file-based observation through the existing NECST launcher.
 
-    Inputs
-    ------
     mode
         One of ``otf``, ``psw``, ``grid``, or ``radio_pointing``.
     file_path

--- a/necst/ctrl/antenna/az_unwrap.py
+++ b/necst/ctrl/antenna/az_unwrap.py
@@ -87,6 +87,117 @@ def _drive_range_deg() -> Tuple[float, float]:
     return float(_to_float(lo, "deg", 0.0)), float(_to_float(hi, "deg", 360.0))
 
 
+
+
+def _az_unwrap_az_section() -> Optional[Any]:
+    """Return the configured Az unwrap subsection, if any exists.
+
+    A missing ``antenna_encoder_unwrap`` section means this telescope is not
+    configured for absolute-modulo Az unwrap and must keep the legacy behavior.
+    A present section with ``enabled=false`` means an absolute-modulo encoder is
+    configured but the software unwrap is disabled; in that state commands must
+    not exceed the raw absolute encoder range.
+    """
+
+    root = getattr(config, "antenna_encoder_unwrap", None)
+    if root is None:
+        return None
+    az = _cfg_get(root, "az", None)
+    return root if az is None else az
+
+
+def load_unwrap_disabled_mount_az_limit() -> Optional[dict]:
+    """Return raw-Az command limits when absolute unwrap is configured off.
+
+    When an absolute-modulo Az encoder is configured but
+    ``antenna_encoder_unwrap.az.enabled`` is false, the control system has no
+    branch information.  In that state Az commands must be confined to the raw
+    absolute encoder range (normally 0..360 deg).  If no unwrap section exists,
+    return ``None`` so NANTEN2/incremental-encoder configurations are unchanged.
+    """
+
+    az = _az_unwrap_az_section()
+    if az is None:
+        return None
+    enabled = _to_bool(_cfg_get(az, "enabled", False), False)
+    if enabled:
+        return None
+    mode = str(_cfg_get(az, "mode", "absolute_modulo") or "").strip().lower()
+    if mode not in {"absolute_modulo", "absolute-modulo"}:
+        return None
+    raw_min = float(
+        _to_float(
+            _cfg_get(az, "raw_min", _cfg_get(az, "raw_min_deg", 0.0)),
+            "deg",
+            0.0,
+        )
+    )
+    raw_max = float(
+        _to_float(
+            _cfg_get(az, "raw_max", _cfg_get(az, "raw_max_deg", 360.0)),
+            "deg",
+            360.0,
+        )
+    )
+    if not (math.isfinite(raw_min) and math.isfinite(raw_max)) or raw_min >= raw_max:
+        raise ValueError(
+            "antenna_encoder_unwrap.az raw_min/raw_max are invalid: "
+            f"raw_min={raw_min!r}, raw_max={raw_max!r}"
+        )
+    return {
+        "enabled": False,
+        "mode": mode,
+        "raw_min_deg": raw_min,
+        "raw_max_deg": raw_max,
+    }
+
+
+def _flatten_degree_values(value: Any) -> list[float]:
+    if hasattr(value, "to_value"):
+        value = value.to_value("deg")
+    if hasattr(value, "tolist"):
+        value = value.tolist()
+    if isinstance(value, (str, bytes)):
+        return [float(value)]
+    try:
+        iterator = iter(value)
+    except TypeError:
+        return [float(value)]
+    values: list[float] = []
+    for item in iterator:
+        values.extend(_flatten_degree_values(item))
+    return values
+
+
+def assert_mount_az_allowed_when_unwrap_disabled(
+    az_deg: Any, *, action_label: str = "Az target"
+) -> Optional[dict]:
+    """Reject Az commands outside raw range when unwrap is configured off.
+
+    This is a fail-closed guard for absolute-modulo encoders.  It intentionally
+    uses the configured raw absolute encoder range, not the wider continuous
+    drive range, because without unwrap the controller cannot distinguish e.g.
+    10 deg from 370 deg.
+    """
+
+    limit = load_unwrap_disabled_mount_az_limit()
+    if limit is None:
+        return None
+    raw_min = float(limit["raw_min_deg"])
+    raw_max = float(limit["raw_max_deg"])
+    values = _flatten_degree_values(az_deg)
+    for value in values:
+        if not math.isfinite(value) or value < raw_min or value > raw_max:
+            raise ValueError(
+                f"{action_label}: Az={value:g} deg is outside raw absolute "
+                f"encoder range {raw_min:g}..{raw_max:g} deg while "
+                "antenna_encoder_unwrap.az.enabled=false; enable Az unwrap "
+                "or keep Az commands within raw_min/raw_max."
+            )
+    checked = dict(limit)
+    checked["checked_value_count"] = len(values)
+    return checked
+
 def load_az_unwrap_config() -> (
     tuple[
         AbsoluteModuloUnwrapConfig, Optional[Path], float, float, float, str, str, int
@@ -577,6 +688,137 @@ class AzUnwrapRuntime:
         self._last_status = status
         raise RuntimeError(status.reason)
 
+
+    def get_state_report(self) -> dict:
+        """Return runtime/state-file information for ROS service responses.
+
+        The report is generated inside the encoder node process.  Therefore the
+        reported state_path and state-file content refer to the path that
+        encoder_readout actually uses, not to a caller's local ~/.necst.
+        """
+        status = self._last_status
+        payload = self._load_previous_payload() if self.enabled else None
+        if status is not None:
+            return {
+                "success": True,
+                "enabled": bool(status.enabled),
+                "valid": bool(status.valid),
+                "state": str(status.state),
+                "reason": str(status.reason),
+                "state_path": "" if self.state_path is None else str(self.state_path),
+                "raw_az_deg": float(status.raw_az_deg),
+                "modulo_az_deg": float(status.modulo_az_deg),
+                "continuous_az_deg": float(status.continuous_az_deg),
+                "branch": int(status.branch),
+                "period_deg": float(status.period_deg),
+                "drive_min_deg": float(status.drive_min_deg),
+                "drive_max_deg": float(status.drive_max_deg),
+                "state_age_sec": float(status.state_age_sec),
+                "persist_age_sec": float(status.persist_age_sec),
+            }
+        if payload is not None:
+            age = self._state_payload_age_sec(payload)
+            state = str(payload.get("state", "state-file"))
+            reason = "state file loaded; no encoder status has been published yet"
+            if age is not None and age > self.state_warn_age_sec:
+                state = "old"
+                reason = (
+                    "old state file loaded; "
+                    "no encoder status has been published yet"
+                )
+            return {
+                "success": True,
+                "enabled": bool(self.enabled),
+                "valid": True,
+                "state": state,
+                "reason": reason,
+                "state_path": "" if self.state_path is None else str(self.state_path),
+                "raw_az_deg": float(payload.get("raw_az_deg")),
+                "modulo_az_deg": float(payload.get("modulo_az_deg")),
+                "continuous_az_deg": float(payload.get("continuous_az_deg")),
+                "branch": int(payload.get("branch")),
+                "period_deg": float(self.cfg.period_deg),
+                "drive_min_deg": float(self.cfg.drive_min_deg),
+                "drive_max_deg": float(self.cfg.drive_max_deg),
+                "state_age_sec": 0.0 if age is None else float(age),
+                "persist_age_sec": 0.0 if age is None else float(age),
+            }
+        return {
+            "success": True,
+            "enabled": bool(self.enabled),
+            "valid": False,
+            "state": "no-state",
+            "reason": (
+                "state file does not exist and "
+                "no encoder status has been published yet"
+            ),
+            "state_path": "" if self.state_path is None else str(self.state_path),
+            "raw_az_deg": -1.0,
+            "modulo_az_deg": -1.0,
+            "continuous_az_deg": -1.0,
+            "branch": 0,
+            "period_deg": float(self.cfg.period_deg),
+            "drive_min_deg": float(self.cfg.drive_min_deg),
+            "drive_max_deg": float(self.cfg.drive_max_deg),
+            "state_age_sec": -1.0,
+            "persist_age_sec": -1.0,
+        }
+
+    def manual_initialize(
+        self,
+        *,
+        raw_az: Optional[float],
+        continuous_az: Optional[float],
+        branch: Optional[int],
+        reason: str = "manual state set via encoder service",
+    ) -> AntennaAzUnwrapStatus:
+        """Validate and persist a manual unwrap state inside encoder_readout.
+
+        This is the service-side equivalent of the old local-file CLI.  The
+        validation rules and JSON schema are shared with the local fallback, but
+        the write happens in the encoder node process, so Docker/HOME differences
+        cannot redirect the state file to the wrong computer.
+        """
+        if not self.enabled:
+            raise ValueError("az unwrap is not enabled in the encoder node config")
+        if self.state_path is None:
+            raise ValueError(
+                "antenna_encoder_unwrap.az.state_path is not configured "
+                "in the encoder node config"
+            )
+        payload = _manual_state_payload(
+            self.cfg,
+            self.mode,
+            raw_az=raw_az,
+            continuous_az=continuous_az,
+            branch=branch,
+        )
+        self.writer._write(payload)
+        self._previous_payload = payload
+        self._previous_payload_age_sec = 0.0
+        self._previous_payload_old = False
+        self.unwrapper = AbsoluteModuloUnwrapper(
+            self.cfg, previous_continuous_deg=float(payload["continuous_az_deg"])
+        )
+        self._startup_initialized = True
+        self._startup_state_note = "manual"
+        now = time.time()
+        status = self._make_status(
+            now=now,
+            encoder_time=now,
+            raw_az=float(payload["raw_az_deg"]),
+            modulo_az=float(payload["modulo_az_deg"]),
+            continuous_az=float(payload["continuous_az_deg"]),
+            branch=int(payload["branch"]),
+            branch_changed=False,
+            valid=True,
+            state="manual",
+            reason=reason,
+        )
+        self._last_status = status
+        self._last_state_time = now
+        return status
+
     def close(self) -> None:
         if self._last_status is not None and self.enabled and self._last_status.valid:
             self._persist(self._last_status, force_sync=True)
@@ -772,40 +1014,8 @@ def _manual_state_payload(
     }
 
 
-def main(argv=None) -> int:
-    """Small CLI for manual Az unwrap state inspection/initialization."""
-    import argparse
 
-    parser = argparse.ArgumentParser(
-        description="Inspect or initialize NECST Az unwrap state file."
-    )
-    sub = parser.add_subparsers(dest="cmd", required=True)
-    sub.add_parser("status", help="show current configured state file")
-    setp = sub.add_parser("set", help="write a manual unwrap state")
-
-    def _deg_arg(text: str) -> float:
-        return float(str(text).strip().removesuffix("deg").removesuffix("°"))
-
-    setp.add_argument(
-        "--raw-az",
-        type=_deg_arg,
-        default=None,
-        help="current absolute modulo raw Az [deg]",
-    )
-    setp.add_argument(
-        "--continuous-az",
-        type=_deg_arg,
-        default=None,
-        help="desired continuous Az [deg]",
-    )
-    setp.add_argument(
-        "--branch",
-        type=int,
-        default=None,
-        help="desired branch; requires --raw-az when --continuous-az is omitted",
-    )
-    args = parser.parse_args(argv)
-
+def _local_cli(args) -> int:
     (
         cfg,
         state_path,
@@ -839,10 +1049,239 @@ def main(argv=None) -> int:
         writer._write(payload)
         writer.close()
         print(
-            f"wrote {state_path}: continuous={payload['continuous_az_deg']:.6f} deg branch={payload['branch']} raw={payload['raw_az_deg']:.6f} deg"
+            f"wrote {state_path}: continuous={payload['continuous_az_deg']:.6f} deg "
+            f"branch={payload['branch']} raw={payload['raw_az_deg']:.6f} deg"
         )
         return 0
     return 2
+
+
+def _copy_report_to_response(response: Any, report: Mapping[str, Any]) -> Any:
+    for key, value in report.items():
+        if hasattr(response, key):
+            setattr(response, key, value)
+    return response
+
+
+def fill_get_response(response: Any, report: Mapping[str, Any]) -> Any:
+    """Fill GetAzUnwrapState.Response-like objects from a runtime report."""
+    return _copy_report_to_response(response, report)
+
+
+def fill_set_response(
+    response: Any,
+    *,
+    success: bool,
+    state: str,
+    reason: str,
+    state_path: str,
+    enabled: bool,
+    valid: bool,
+    raw_az_deg: float,
+    modulo_az_deg: float,
+    continuous_az_deg: float,
+    branch: int,
+    period_deg: float,
+    drive_min_deg: float,
+    drive_max_deg: float,
+) -> Any:
+    """Fill SetAzUnwrapState.Response-like objects without importing ROS types."""
+    values = {
+        "success": bool(success),
+        "state": str(state),
+        "reason": str(reason),
+        "state_path": str(state_path),
+        "enabled": bool(enabled),
+        "valid": bool(valid),
+        "raw_az_deg": float(raw_az_deg),
+        "modulo_az_deg": float(modulo_az_deg),
+        "continuous_az_deg": float(continuous_az_deg),
+        "branch": int(branch),
+        "period_deg": float(period_deg),
+        "drive_min_deg": float(drive_min_deg),
+        "drive_max_deg": float(drive_max_deg),
+    }
+    return _copy_report_to_response(response, values)
+
+
+def report_from_status(
+    runtime: AzUnwrapRuntime,
+    status: AntennaAzUnwrapStatus,
+    *,
+    success: bool = True,
+) -> dict:
+    """Convert a status message to a response/report dictionary."""
+    return {
+        "success": bool(success),
+        "enabled": bool(status.enabled),
+        "valid": bool(status.valid),
+        "state": str(status.state),
+        "reason": str(status.reason),
+        "state_path": "" if runtime.state_path is None else str(runtime.state_path),
+        "raw_az_deg": float(status.raw_az_deg),
+        "modulo_az_deg": float(status.modulo_az_deg),
+        "continuous_az_deg": float(status.continuous_az_deg),
+        "branch": int(status.branch),
+        "period_deg": float(status.period_deg),
+        "drive_min_deg": float(status.drive_min_deg),
+        "drive_max_deg": float(status.drive_max_deg),
+        "state_age_sec": float(status.state_age_sec),
+        "persist_age_sec": float(status.persist_age_sec),
+    }
+
+
+def _ros_wait_for_future(rclpy, node, future, *, timeout_sec: float):
+    end_time = time.monotonic() + float(timeout_sec)
+    while rclpy.ok() and not future.done():
+        remaining = end_time - time.monotonic()
+        if remaining <= 0:
+            break
+        rclpy.spin_once(node, timeout_sec=min(0.1, remaining))
+    return future.done()
+
+
+def _response_to_report(response: Any) -> dict:
+    return {
+        name: getattr(response, name)
+        for name in response.get_fields_and_field_types()
+    }
+
+
+def _print_state_report(report: Mapping[str, Any]) -> None:
+    print(
+        "enabled={enabled} valid={valid} state={state} branch={branch} "
+        "raw={raw:.6f} continuous={continuous:.6f} state_path={state_path}".format(
+            enabled=bool(report.get("enabled", False)),
+            valid=bool(report.get("valid", False)),
+            state=str(report.get("state", "")),
+            branch=int(report.get("branch", 0)),
+            raw=float(report.get("raw_az_deg", -1.0)),
+            continuous=float(report.get("continuous_az_deg", -1.0)),
+            state_path=str(report.get("state_path", "")),
+        )
+    )
+    reason = str(report.get("reason", ""))
+    if reason:
+        print(f"reason={reason}")
+
+
+def _ros_cli(args) -> int:
+    import rclpy
+
+    from necst import service
+    from necst_msgs.srv import GetAzUnwrapState, SetAzUnwrapState
+
+    rclpy.init(args=None)
+    node = rclpy.create_node("az_unwrap_state_cli", namespace="/")
+    try:
+        if args.cmd == "status":
+            client = service.az_unwrap_state_get.client(node)
+            if not client.wait_for_service(timeout_sec=args.timeout):
+                raise SystemExit(
+                    "az unwrap get service is not available. "
+                    "Start encoder_readout, or use --local only when "
+                    "intentionally reading the local state_path."
+                )
+            request = GetAzUnwrapState.Request()
+            future = client.call_async(request)
+            if not _ros_wait_for_future(rclpy, node, future, timeout_sec=args.timeout):
+                raise SystemExit("timed out waiting for az unwrap get service response")
+            response = future.result()
+            if response is None:
+                raise SystemExit("az unwrap get service failed without a response")
+            report = _response_to_report(response)
+            _print_state_report(report)
+            return 0 if bool(response.success) else 1
+        if args.cmd == "set":
+            client = service.az_unwrap_state_set.client(node)
+            if not client.wait_for_service(timeout_sec=args.timeout):
+                raise SystemExit(
+                    "az unwrap set service is not available. "
+                    "Start encoder_readout, or run on the encoder node with "
+                    "--local only as an emergency fallback."
+                )
+            request = SetAzUnwrapState.Request()
+            request.use_raw_az = args.raw_az is not None
+            request.raw_az_deg = 0.0 if args.raw_az is None else float(args.raw_az)
+            request.use_continuous_az = args.continuous_az is not None
+            request.continuous_az_deg = (
+                0.0 if args.continuous_az is None else float(args.continuous_az)
+            )
+            request.use_branch = args.branch is not None
+            request.branch = 0 if args.branch is None else int(args.branch)
+            future = client.call_async(request)
+            if not _ros_wait_for_future(rclpy, node, future, timeout_sec=args.timeout):
+                raise SystemExit("timed out waiting for az unwrap set service response")
+            response = future.result()
+            if response is None:
+                raise SystemExit("az unwrap set service failed without a response")
+            report = _response_to_report(response)
+            _print_state_report(report)
+            return 0 if bool(response.success) else 1
+        return 2
+    finally:
+        node.destroy_node()
+        rclpy.try_shutdown()
+
+
+def main(argv=None) -> int:
+    """Inspect or initialize Az unwrap state.
+
+    Default mode uses ROS services served by encoder_readout, so the state is
+    written to the encoder node's actual state_path.  Use --local only as a
+    deliberate emergency fallback on the encoder PC/container.
+    """
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Inspect or initialize NECST Az unwrap state "
+            "via encoder_readout service."
+        )
+    )
+    parser.add_argument(
+        "--local",
+        action="store_true",
+        help=(
+            "read/write the local state_path directly; "
+            "use only on the encoder PC/container"
+        ),
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=3.0,
+        help="ROS service wait/response timeout [s]",
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("status", help="show encoder_readout unwrap state")
+    setp = sub.add_parser("set", help="set encoder_readout unwrap state")
+
+    def _deg_arg(text: str) -> float:
+        return float(str(text).strip().removesuffix("deg").removesuffix("°"))
+
+    setp.add_argument(
+        "--raw-az",
+        type=_deg_arg,
+        default=None,
+        help="current absolute modulo raw Az [deg]",
+    )
+    setp.add_argument(
+        "--continuous-az",
+        type=_deg_arg,
+        default=None,
+        help="desired continuous Az [deg]",
+    )
+    setp.add_argument(
+        "--branch",
+        type=int,
+        default=None,
+        help="desired branch; requires --raw-az when --continuous-az is omitted",
+    )
+    args = parser.parse_args(argv)
+    if args.local:
+        return _local_cli(args)
+    return _ros_cli(args)
 
 
 if __name__ == "__main__":

--- a/necst/ctrl/antenna/az_unwrap.py
+++ b/necst/ctrl/antenna/az_unwrap.py
@@ -87,8 +87,6 @@ def _drive_range_deg() -> Tuple[float, float]:
     return float(_to_float(lo, "deg", 0.0)), float(_to_float(hi, "deg", 360.0))
 
 
-
-
 def _az_unwrap_az_section() -> Optional[Any]:
     """Return the configured Az unwrap subsection, if any exists.
 
@@ -197,6 +195,7 @@ def assert_mount_az_allowed_when_unwrap_disabled(
     checked = dict(limit)
     checked["checked_value_count"] = len(values)
     return checked
+
 
 def load_az_unwrap_config() -> (
     tuple[
@@ -688,7 +687,6 @@ class AzUnwrapRuntime:
         self._last_status = status
         raise RuntimeError(status.reason)
 
-
     def get_state_report(self) -> dict:
         """Return runtime/state-file information for ROS service responses.
 
@@ -723,8 +721,7 @@ class AzUnwrapRuntime:
             if age is not None and age > self.state_warn_age_sec:
                 state = "old"
                 reason = (
-                    "old state file loaded; "
-                    "no encoder status has been published yet"
+                    "old state file loaded; " "no encoder status has been published yet"
                 )
             return {
                 "success": True,
@@ -1014,7 +1011,6 @@ def _manual_state_payload(
     }
 
 
-
 def _local_cli(args) -> int:
     (
         cfg,
@@ -1142,8 +1138,7 @@ def _ros_wait_for_future(rclpy, node, future, *, timeout_sec: float):
 
 def _response_to_report(response: Any) -> dict:
     return {
-        name: getattr(response, name)
-        for name in response.get_fields_and_field_types()
+        name: getattr(response, name) for name in response.get_fields_and_field_types()
     }
 
 

--- a/necst/ctrl/antenna/encoder.py
+++ b/necst/ctrl/antenna/encoder.py
@@ -3,9 +3,14 @@ import time
 from neclib.devices import AntennaEncoder
 from necst_msgs.msg import CoordMsg
 
-from .az_unwrap import AzUnwrapRuntime
+from .az_unwrap import (
+    AzUnwrapRuntime,
+    fill_get_response,
+    fill_set_response,
+    report_from_status,
+)
 
-from ... import namespace, topic, config
+from ... import namespace, topic, service, config
 from ...core import DeviceNode
 
 
@@ -19,7 +24,83 @@ class AntennaEncoderController(DeviceNode):
         self.unwrap_publisher = topic.antenna_az_unwrap_status.publisher(self)
         self.encoder = AntennaEncoder()
         self.az_unwrap = AzUnwrapRuntime()
+        self.az_unwrap_state_get_service = service.az_unwrap_state_get.service(
+            self, self.get_az_unwrap_state
+        )
+        self.az_unwrap_state_set_service = service.az_unwrap_state_set.service(
+            self, self.set_az_unwrap_state
+        )
         self.create_timer(1 / config.antenna_enc_frequency, self.stream)
+
+
+    def get_az_unwrap_state(self, _request, response):
+        """Return Az unwrap state from the encoder node process."""
+        report = self.az_unwrap.get_state_report()
+        return fill_get_response(response, report)
+
+    def set_az_unwrap_state(self, request, response):
+        """Set Az unwrap state in the encoder node process.
+
+        The service intentionally writes through self.az_unwrap so the JSON goes
+        to the state_path used by encoder_readout, not to the caller's ~/.necst.
+        """
+        raw_az = float(request.raw_az_deg) if bool(request.use_raw_az) else None
+        continuous_az = (
+            float(request.continuous_az_deg)
+            if bool(request.use_continuous_az)
+            else None
+        )
+        branch = int(request.branch) if bool(request.use_branch) else None
+        try:
+            status = self.az_unwrap.manual_initialize(
+                raw_az=raw_az,
+                continuous_az=continuous_az,
+                branch=branch,
+                reason="manual state set via encoder service",
+            )
+            try:
+                self.unwrap_publisher.publish(status)
+            except Exception as exc:
+                self.get_logger().error(
+                    f"Az unwrap status publish after service set failed: {exc}",
+                    throttle_duration_sec=1,
+                )
+            report = report_from_status(self.az_unwrap, status)
+            return fill_set_response(
+                response,
+                success=report["success"],
+                state=report["state"],
+                reason=report["reason"],
+                state_path=report["state_path"],
+                enabled=report["enabled"],
+                valid=report["valid"],
+                raw_az_deg=report["raw_az_deg"],
+                modulo_az_deg=report["modulo_az_deg"],
+                continuous_az_deg=report["continuous_az_deg"],
+                branch=report["branch"],
+                period_deg=report["period_deg"],
+                drive_min_deg=report["drive_min_deg"],
+                drive_max_deg=report["drive_max_deg"],
+            )
+        except Exception as exc:
+            self.get_logger().error(f"Az unwrap service set rejected: {exc}")
+            report = self.az_unwrap.get_state_report()
+            return fill_set_response(
+                response,
+                success=False,
+                state="rejected",
+                reason=str(exc),
+                state_path=report.get("state_path", ""),
+                enabled=report.get("enabled", False),
+                valid=report.get("valid", False),
+                raw_az_deg=report.get("raw_az_deg", -1.0),
+                modulo_az_deg=report.get("modulo_az_deg", -1.0),
+                continuous_az_deg=report.get("continuous_az_deg", -1.0),
+                branch=report.get("branch", 0),
+                period_deg=report.get("period_deg", 360.0),
+                drive_min_deg=report.get("drive_min_deg", 0.0),
+                drive_max_deg=report.get("drive_max_deg", 360.0),
+            )
 
     def stream(self) -> None:
         record_time = time.time()

--- a/necst/ctrl/antenna/encoder.py
+++ b/necst/ctrl/antenna/encoder.py
@@ -32,7 +32,6 @@ class AntennaEncoderController(DeviceNode):
         )
         self.create_timer(1 / config.antenna_enc_frequency, self.stream)
 
-
     def get_az_unwrap_state(self, _request, response):
         """Return Az unwrap state from the encoder node process."""
         report = self.az_unwrap.get_state_report()

--- a/necst/ctrl/antenna/horizontal_coord.py
+++ b/necst/ctrl/antenna/horizontal_coord.py
@@ -30,7 +30,7 @@ from necst_msgs.srv import CoordinateCommand, ScanBlockCommand
 
 from ... import config, namespace, service, topic
 from ...core import AlertHandlerNode
-from .az_unwrap import assert_mount_az_allowed_when_unwrap_disabled
+from ...az_unwrap_limits import assert_mount_az_allowed_when_unwrap_disabled
 
 
 class HorizontalCoord(AlertHandlerNode):

--- a/necst/ctrl/antenna/horizontal_coord.py
+++ b/necst/ctrl/antenna/horizontal_coord.py
@@ -30,6 +30,7 @@ from necst_msgs.srv import CoordinateCommand, ScanBlockCommand
 
 from ... import config, namespace, service, topic
 from ...core import AlertHandlerNode
+from .az_unwrap import assert_mount_az_allowed_when_unwrap_disabled
 
 
 class HorizontalCoord(AlertHandlerNode):
@@ -1153,11 +1154,22 @@ class HorizontalCoord(AlertHandlerNode):
             _az = self._validate_mount_az_target(az)
         else:
             _az = self.optimizer["az"].optimize(enc_az, az.to_value("deg"), unit="deg")
+            _az = self._validate_az_unwrap_disabled_raw_limit(
+                _az, action_label="generated Az command"
+            )
         _el = self.optimizer["el"].optimize(enc_el, el.to_value("deg"), unit="deg")
 
         if (_az is not None) and (_el is not None):
             return _az, _el
         return [], []
+
+    def _validate_az_unwrap_disabled_raw_limit(self, az, *, action_label: str):
+        try:
+            assert_mount_az_allowed_when_unwrap_disabled(az, action_label=action_label)
+        except ValueError as exc:
+            self.logger.warning(str(exc))
+            return None
+        return az
 
     def _validate_mount_az_target(self, az):
         """Validate explicit mount azimuth without modulo candidate selection.
@@ -1182,6 +1194,10 @@ class HorizontalCoord(AlertHandlerNode):
                 "Mount Az target is out of critical drive range: "
                 f"target={az_q}, limit={critical}"
             )
+            return None
+        if self._validate_az_unwrap_disabled_raw_limit(
+            az_q, action_label="mount Az target"
+        ) is None:
             return None
         if not bool(((warning_lower <= az_deg) & (az_deg <= warning_upper)).all()):
             self.logger.warning("Mount Az target nears drive range limit.")

--- a/necst/ctrl/antenna/horizontal_coord.py
+++ b/necst/ctrl/antenna/horizontal_coord.py
@@ -1195,9 +1195,12 @@ class HorizontalCoord(AlertHandlerNode):
                 f"target={az_q}, limit={critical}"
             )
             return None
-        if self._validate_az_unwrap_disabled_raw_limit(
-            az_q, action_label="mount Az target"
-        ) is None:
+        if (
+            self._validate_az_unwrap_disabled_raw_limit(
+                az_q, action_label="mount Az target"
+            )
+            is None
+        ):
             return None
         if not bool(((warning_lower <= az_deg) & (az_deg <= warning_upper)).all()):
             self.logger.warning("Mount Az target nears drive range limit.")

--- a/necst/ctrl/antenna/tracking_status.py
+++ b/necst/ctrl/antenna/tracking_status.py
@@ -28,6 +28,8 @@ class AntennaTrackingStatus(Node):
         self.cmd = ParameterList.new(2, CoordMsg)
         self.enc = ParameterList.new(1, CoordMsg)
         self.az_unwrap_status = None
+        self._last_cmd_receipt_time = float("nan")
+        self._last_enc_receipt_time = float("nan")
 
         self.threshold = config.antenna_pointing_accuracy.to_value("deg").item()
         self.coord_ext = LinearExtrapolate(
@@ -38,12 +40,20 @@ class AntennaTrackingStatus(Node):
         self.pointing_pub = topic.antenna_pointing_status.publisher(self)
         self._pointing_status_period = 0.2
         self._last_pointing_status_publish = 0.0
-        topic.antenna_encoder.subscription(self, lambda msg: self.enc.push(msg))
+        topic.antenna_encoder.subscription(self, self._update_encoder)
         topic.antenna_az_unwrap_status.subscription(self, self._update_az_unwrap_status)
-        topic.altaz_cmd.subscription(self, lambda msg: self.cmd.push(msg))
+        topic.altaz_cmd.subscription(self, self._update_command)
         self.create_timer(
             1 / config.antenna_command_frequency, self.antenna_tracking_status
         )
+
+    def _update_command(self, msg: CoordMsg) -> None:
+        self.cmd.push(msg)
+        self._last_cmd_receipt_time = time.time()
+
+    def _update_encoder(self, msg: CoordMsg) -> None:
+        self.enc.push(msg)
+        self._last_enc_receipt_time = time.time()
 
     def _update_az_unwrap_status(self, msg: AntennaAzUnwrapStatus) -> None:
         self.az_unwrap_status = msg
@@ -63,8 +73,11 @@ class AntennaTrackingStatus(Node):
         )
 
     @staticmethod
-    def _nan() -> float:
-        return float("nan")
+    def _finite_float(value: float) -> bool:
+        try:
+            return math.isfinite(float(value))
+        except Exception:
+            return False
 
     @staticmethod
     def _rate_deg_per_sec(newer: CoordMsg, older: CoordMsg, attr: str) -> float:
@@ -76,55 +89,69 @@ class AntennaTrackingStatus(Node):
         except Exception:
             return float("nan")
 
-    def _publish_pointing_unavailable(self, *, now: float, basis: str) -> None:
+    @staticmethod
+    def _fresh_age_sec(receipt_time: float, now: float) -> float:
+        try:
+            age = now - float(receipt_time)
+        except Exception:
+            return float("inf")
+        return age if math.isfinite(age) and age >= 0.0 else float("inf")
+
+    @staticmethod
+    def _tracking_freshness_limit_sec() -> float:
+        # Keep this consistent with the progress/operator display freshness.
+        # The check is based on local callback receipt time, not on CoordMsg.time,
+        # because CoordMsg.time may be a planned command time in the future.
+        return max(2.0, 2.0 / max(float(config.antenna_command_frequency), 1.0))
+
+    def _samples_have_finite_times(self) -> bool:
+        return all(self._finite_float(p.time) for p in self.cmd) and all(
+            self._finite_float(p.time) for p in self.enc
+        )
+
+    def _tracking_input_ready(self, *, now: float) -> bool:
+        """Return True only while live command and encoder samples are fresh.
+
+        When the antenna command stream stops after STOP/ABORT or observation end,
+        the two latest command samples remain in ``self.cmd``.  LinearExtrapolate
+        can then continue making diagnostic values, which made Progress/Console
+        show a continuing tracking error even though no command is active.  Use
+        callback receipt ages here so stale command history is not published as a
+        fresh tracking status.
+        """
+
+        if not self._samples_have_finite_times():
+            return False
+        limit = self._tracking_freshness_limit_sec()
+        return (
+            self._fresh_age_sec(self._last_cmd_receipt_time, now) <= limit
+            and self._fresh_age_sec(self._last_enc_receipt_time, now) <= limit
+        )
+
+    def _publish_pointing_status(self, *, now: float, **kwargs) -> None:
         if (now - self._last_pointing_status_publish) < self._pointing_status_period:
             return
         self._last_pointing_status_publish = now
-        self.pointing_pub.publish(
-            AntennaPointingStatus(
-                valid=False,
-                publish_time_unix=now,
-                command_time_unix=float("nan"),
-                encoder_time_unix=float("nan"),
-                cmd_az_deg=float("nan"),
-                cmd_el_deg=float("nan"),
-                enc_az_deg=float("nan"),
-                enc_el_deg=float("nan"),
-                delta_az_deg=float("nan"),
-                delta_el_deg=float("nan"),
-                delta_az_cos_el_deg=float("nan"),
-                tracking_error_deg=9999.0,
-                tracking_threshold_deg=float(self.threshold),
-                tracking_ok=False,
-                cmd_age_sec=float("nan"),
-                enc_age_sec=float("nan"),
-                command_stale=True,
-                encoder_stale=True,
-                cmd_az_rate_deg_per_sec=float("nan"),
-                cmd_el_rate_deg_per_sec=float("nan"),
-                enc_az_rate_deg_per_sec=float("nan"),
-                enc_el_rate_deg_per_sec=float("nan"),
-                basis=basis[:32],
-            )
-        )
+        self.pointing_pub.publish(AntennaPointingStatus(**kwargs))
 
     def antenna_tracking_status(self) -> None:
         now = time.time()
-        if any(not isinstance(p.time, float) for p in self.cmd):
+        if not self._tracking_input_ready(now=now):
+            # No publish here by design.  A fresh /ctrl/antenna/tracking_status or
+            # /ctrl/antenna/pointing_status message means there is a fresh command
+            # basis.  After STOP/ABORT, displays should see the old samples become
+            # stale instead of receiving new extrapolated diagnostics.
             self.tracking_checker.check(False)
-            msg = TrackingStatus(ok=False, error=9999.0, time=now)
-            self.pub.publish(msg)
-            self._publish_pointing_unavailable(now=now, basis="missing-command")
-            return
-        if any(not isinstance(p.time, float) for p in self.enc):
-            self.tracking_checker.check(False)
-            msg = TrackingStatus(ok=False, error=9999.0, time=now)
-            self.pub.publish(msg)
-            self._publish_pointing_unavailable(now=now, basis="missing-encoder")
             return
 
         enc = self.enc[0]
         cmd = self.coord_ext(CoordMsg(time=enc.time), self.cmd)
+        if not all(
+            self._finite_float(v)
+            for v in (cmd.lon, cmd.lat, enc.lon, enc.lat, cmd.time, enc.time)
+        ):
+            self.tracking_checker.check(False)
+            return
 
         if self._az_unwrap_active_for(enc.time, now):
             daz = enc.lon - cmd.lon
@@ -141,36 +168,32 @@ class AntennaTrackingStatus(Node):
 
         cmd_rate_az = self._rate_deg_per_sec(self.cmd[0], self.cmd[1], "lon")
         cmd_rate_el = self._rate_deg_per_sec(self.cmd[0], self.cmd[1], "lat")
-        cmd_age = max(0.0, now - float(cmd.time))
-        enc_age = max(0.0, now - float(enc.time))
-        stale_sec = max(2.0, 2.0 / max(float(config.antenna_command_frequency), 1.0))
-        if (now - self._last_pointing_status_publish) < self._pointing_status_period:
-            return
-        self._last_pointing_status_publish = now
-        self.pointing_pub.publish(
-            AntennaPointingStatus(
-                valid=True,
-                publish_time_unix=now,
-                command_time_unix=float(cmd.time),
-                encoder_time_unix=float(enc.time),
-                cmd_az_deg=float(cmd.lon),
-                cmd_el_deg=float(cmd.lat),
-                enc_az_deg=float(enc.lon),
-                enc_el_deg=float(enc.lat),
-                delta_az_deg=float(daz),
-                delta_el_deg=float(del_),
-                delta_az_cos_el_deg=float(daz_cos_el),
-                tracking_error_deg=float(error),
-                tracking_threshold_deg=float(self.threshold),
-                tracking_ok=bool(ok),
-                cmd_age_sec=float(cmd_age),
-                enc_age_sec=float(enc_age),
-                command_stale=bool(cmd_age > stale_sec),
-                encoder_stale=bool(enc_age > stale_sec),
-                cmd_az_rate_deg_per_sec=float(cmd_rate_az),
-                cmd_el_rate_deg_per_sec=float(cmd_rate_el),
-                enc_az_rate_deg_per_sec=float("nan"),
-                enc_el_rate_deg_per_sec=float("nan"),
-                basis="interpolated",
-            )
+        cmd_age = self._fresh_age_sec(self._last_cmd_receipt_time, now)
+        enc_age = self._fresh_age_sec(self._last_enc_receipt_time, now)
+        stale_sec = self._tracking_freshness_limit_sec()
+        self._publish_pointing_status(
+            now=now,
+            valid=True,
+            publish_time_unix=now,
+            command_time_unix=float(cmd.time),
+            encoder_time_unix=float(enc.time),
+            cmd_az_deg=float(cmd.lon),
+            cmd_el_deg=float(cmd.lat),
+            enc_az_deg=float(enc.lon),
+            enc_el_deg=float(enc.lat),
+            delta_az_deg=float(daz),
+            delta_el_deg=float(del_),
+            delta_az_cos_el_deg=float(daz_cos_el),
+            tracking_error_deg=float(error),
+            tracking_threshold_deg=float(self.threshold),
+            tracking_ok=bool(ok),
+            cmd_age_sec=float(cmd_age),
+            enc_age_sec=float(enc_age),
+            command_stale=bool(cmd_age > stale_sec),
+            encoder_stale=bool(enc_age > stale_sec),
+            cmd_az_rate_deg_per_sec=float(cmd_rate_az),
+            cmd_el_rate_deg_per_sec=float(cmd_rate_el),
+            enc_az_rate_deg_per_sec=float("nan"),
+            enc_el_rate_deg_per_sec=float("nan"),
+            basis="interpolated",
         )

--- a/necst/ctrl/calibrator/chopper.py
+++ b/necst/ctrl/calibrator/chopper.py
@@ -1,9 +1,10 @@
 import time
 
 from neclib.devices import ChopperMotor
+from std_srvs.srv import Trigger
 from necst_msgs.msg import ChopperMsg
 
-from ... import config, namespace, topic
+from ... import config, namespace, service, topic
 from ...core import DeviceNode
 
 
@@ -18,8 +19,81 @@ class ChopperController(DeviceNode):
         self.motor = ChopperMotor()
 
         topic.chopper_cmd.subscription(self, self.move)
+        service.chopper_alarm_reset.service(self, self.alarm_reset)
+        service.chopper_home.service(self, self.home)
+        service.chopper_recover.service(self, self.recover)
         self.pub = topic.chopper_status.publisher(self)
         self.create_timer(1, self.telemetry)
+
+    @staticmethod
+    def _maintenance_unsupported_reason() -> str | None:
+        """Return a reason string when maintenance I/O is unsupported here."""
+        observatory = str(getattr(config, "observatory", "")).upper()
+        if "NANTEN2" in observatory:
+            return (
+                "chopper maintenance is not supported for NANTEN2 "
+                "(サポートしていません)"
+            )
+        if "OMU1P85M" not in observatory:
+            return (
+                "chopper maintenance is supported only for OMU1p85m in this "
+                f"implementation (current observatory={observatory or 'unknown'})"
+            )
+        return None
+
+    def _run_maintenance_operation(
+        self,
+        response: Trigger.Response,
+        operation: str,
+    ) -> Trigger.Response:
+        unsupported = self._maintenance_unsupported_reason()
+        if unsupported is not None:
+            self.logger.warning(unsupported)
+            response.success = False
+            response.message = unsupported
+            return response
+
+        try:
+            if operation == "alarm-reset":
+                self.motor.remove_alarm()
+                message = "chopper alarm reset completed"
+            elif operation == "home":
+                self.motor.chopper_zero_point()
+                message = "chopper home completed; counter was reset to 0"
+            elif operation == "recover":
+                self.motor.remove_alarm()
+                self.motor.chopper_zero_point()
+                message = "chopper recover completed; alarm reset and home finished"
+            else:
+                raise ValueError(f"unknown chopper maintenance operation: {operation}")
+
+            self.telemetry()
+            response.success = True
+            response.message = message
+            self.logger.info(message)
+        except Exception as exc:
+            response.success = False
+            response.message = f"chopper {operation} failed: {exc}"
+            self.logger.error(response.message)
+        return response
+
+    def alarm_reset(
+        self, request: Trigger.Request, response: Trigger.Response
+    ) -> Trigger.Response:
+        del request
+        return self._run_maintenance_operation(response, "alarm-reset")
+
+    def home(
+        self, request: Trigger.Request, response: Trigger.Response
+    ) -> Trigger.Response:
+        del request
+        return self._run_maintenance_operation(response, "home")
+
+    def recover(
+        self, request: Trigger.Request, response: Trigger.Response
+    ) -> Trigger.Response:
+        del request
+        return self._run_maintenance_operation(response, "recover")
 
     def move(self, msg: ChopperMsg) -> None:
         self.telemetry()

--- a/necst/ctrl/calibrator/sim_devices.py
+++ b/necst/ctrl/calibrator/sim_devices.py
@@ -2,10 +2,11 @@ import time
 
 import rclpy
 from neclib.simulators.chopper import ChopperEmulator
+from std_srvs.srv import Trigger
 from necst_msgs.msg import ChopperMsg
 from rclpy.node import Node
 
-from necst import namespace, topic
+from necst import config, namespace, service, topic
 
 
 class ChopperSimulator(Node):
@@ -15,9 +16,60 @@ class ChopperSimulator(Node):
     def __init__(self):
         super().__init__(self.NodeName, namespace=self.Namespace)
         topic.chopper_cmd.subscription(self, self.move)
+        service.chopper_alarm_reset.service(self, self.alarm_reset)
+        service.chopper_home.service(self, self.home)
+        service.chopper_recover.service(self, self.recover)
         self.pub = topic.chopper_status.publisher(self)
         self.motor = ChopperEmulator()
         self.create_timer(1, self.telemetry)
+
+    @staticmethod
+    def _maintenance_unsupported_reason() -> str | None:
+        observatory = str(getattr(config, "observatory", "")).upper()
+        if "NANTEN2" in observatory:
+            return (
+                "chopper maintenance is not supported for NANTEN2 "
+                "(サポートしていません)"
+            )
+        return None
+
+    def _maintenance_noop(
+        self, response: Trigger.Response, operation: str
+    ) -> Trigger.Response:
+        unsupported = self._maintenance_unsupported_reason()
+        if unsupported is not None:
+            response.success = False
+            response.message = unsupported
+            return response
+        response.success = True
+        response.message = f"simulator chopper {operation} completed as no-op"
+        return response
+
+    def alarm_reset(
+        self, request: Trigger.Request, response: Trigger.Response
+    ) -> Trigger.Response:
+        del request
+        return self._maintenance_noop(response, "alarm-reset")
+
+    def home(
+        self, request: Trigger.Request, response: Trigger.Response
+    ) -> Trigger.Response:
+        del request
+        result = self._maintenance_noop(response, "home")
+        if result.success:
+            self.motor.set_step("insert", "chopper")
+            self.telemetry()
+        return result
+
+    def recover(
+        self, request: Trigger.Request, response: Trigger.Response
+    ) -> Trigger.Response:
+        del request
+        result = self._maintenance_noop(response, "recover")
+        if result.success:
+            self.motor.set_step("insert", "chopper")
+            self.telemetry()
+        return result
 
     def move(self, msg):
         self.telemetry()

--- a/necst/definitions.py
+++ b/necst/definitions.py
@@ -315,7 +315,7 @@ class service:
         ScanBlockCommand,
         SetSpectralRecordingGate,
     )
-    from std_srvs.srv import Empty
+    from std_srvs.srv import Empty, Trigger
 
     from .utils import Service
 
@@ -330,6 +330,9 @@ class service:
     ccd_cmd = Service(CCDCommand, "ccd_cmd", namespace.rx)
     dome_sync = Service(DomeSync, "dome_sync", namespace.dome)
     dome_pid_sync = Service(DomeSync, "dome_pid_sync", namespace.dome)
+    chopper_alarm_reset = Service(Trigger, "chopper/alarm_reset", namespace.calib)
+    chopper_home = Service(Trigger, "chopper/home", namespace.calib)
+    chopper_recover = Service(Trigger, "chopper/recover", namespace.calib)
     apply_spectral_recording_setup = Service(
         ApplySpectralRecordingSetup, "apply_spectral_recording_setup", namespace.rx
     )

--- a/necst/definitions.py
+++ b/necst/definitions.py
@@ -309,6 +309,8 @@ class service:
         CCDCommand,
         ComDelaySrv,
         CoordinateCommand,
+        GetAzUnwrapState,
+        SetAzUnwrapState,
         DomeSync,
         File,
         ObservationMode,
@@ -324,6 +326,12 @@ class service:
     record_file = Service(File, "record_file", namespace.core)
     com_delay = Service(ComDelaySrv, "com_delay", namespace.core)
     raw_coord = Service(CoordinateCommand, "raw_coord", namespace.antenna)
+    az_unwrap_state_get = Service(
+        GetAzUnwrapState, "az_unwrap_state/get", namespace.antenna
+    )
+    az_unwrap_state_set = Service(
+        SetAzUnwrapState, "az_unwrap_state/set", namespace.antenna
+    )
     scan_block = Service(ScanBlockCommand, "scan_block", namespace.antenna)
     dome_coord = Service(CoordinateCommand, "dome_coord", namespace.dome)
     obsmode = Service(ObservationMode, "obsmode", namespace.ctrl)

--- a/necst/procedures/observations/file_based.py
+++ b/necst/procedures/observations/file_based.py
@@ -39,6 +39,76 @@ from .pointing_reference_beam import (
 )
 
 
+def _parameter_bool(value, default=False) -> bool:
+    """Return a boolean for `.obs` parameters while preserving explicit false.
+
+    TOML booleans normally arrive as Python bool, but accepting common string
+    spellings makes fallback/mock tests and hand-written parameter fragments safer.
+    """
+    if value is None:
+        return bool(default)
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    text = str(value).strip().lower()
+    if text in {"", "0", "false", "off", "no", "disable", "disabled", "none"}:
+        return False
+    if text in {"1", "true", "on", "yes", "enable", "enabled"}:
+        return True
+    return bool(value)
+
+
+def _obsspec_parameters(obsspec) -> dict:
+    """Return a mutable parameter mapping for an ObservationSpec when possible."""
+    params = getattr(obsspec, "_parameters", None)
+    if isinstance(params, dict):
+        return params
+    return getattr(obsspec, "parameters", {}) or {}
+
+
+def _apply_file_based_obs_defaults(obsspec) -> frozenset:
+    """Apply NECST file-observation defaults above individual Spec classes.
+
+    The defaults are injected immediately after parsing the `.obs` file so that
+    all file-based observation types, including GridSpec which generates its own
+    waypoints from its parameters, see a consistent parameter set without
+    changing the individual neclib observation-spec implementations.
+
+    Returns
+    -------
+    frozenset
+        Parameter names that were present in the original `.obs` parameter set.
+        This is used to distinguish an explicit user request from an implicit
+        default, for example when deciding whether to warn about unsupported
+        scan-block operation for an observation type.
+    """
+    params = _obsspec_parameters(obsspec)
+    explicit_keys = frozenset(params.keys())
+
+    # Defaulted and canonicalized booleans.  `cos_correction` is injected here,
+    # rather than in neclib.coordinates.observations.grid.GridSpec, so Grid, OTF,
+    # PSW, and RadioPointing share the same `.obs` default policy.
+    if "cos_correction" not in params:
+        params["cos_correction"] = True
+    else:
+        params["cos_correction"] = _parameter_bool(params.get("cos_correction"), True)
+
+    for key in ("scan_cos_correction", "point_cos_correction", "use_scan_block"):
+        if key in params:
+            params[key] = _parameter_bool(params.get(key), False)
+
+    # `use_scan_block` defaults to True at execution time.  Do not inject it
+    # into `params`: leaving it absent allows us to suppress warnings for
+    # unsupported observation types unless the user explicitly requested it.
+
+    # Spectral generator preflight defaults for file-based `.obs` observations.
+    params.setdefault("sg_preflight_policy", "verify_only")
+    params.setdefault("sg_preflight_scope", "active_lo_chains")
+
+    return explicit_keys
+
+
 class FileBasedObservation(Observation):
     SpecParser: Type[ObservationSpec]
 
@@ -46,6 +116,7 @@ class FileBasedObservation(Observation):
         file = kwargs["file"]
         self._obs_file = file
         self.obsspec = self.SpecParser.from_file(file)
+        self._obs_parameter_explicit_keys = _apply_file_based_obs_defaults(self.obsspec)
         # Keep the user-facing target name in progress snapshots.
         # FileBasedObservation historically used obsspec.target only for the
         # default record name, so Web/terminal progress displays could show
@@ -690,15 +761,18 @@ class FileBasedObservation(Observation):
         margin = config.antenna.scan_margin.value
 
         params = getattr(self.obsspec, "parameters", {}) or {}
-        cos_global = bool(params.get("cos_correction", False))
-        cos_scan = bool(params.get("scan_cos_correction", cos_global))
-        cos_point = bool(params.get("point_cos_correction", cos_global))
-        requested_use_scan_block = bool(params.get("use_scan_block", False))
+        cos_global = _parameter_bool(params.get("cos_correction", True))
+        cos_scan = _parameter_bool(params.get("scan_cos_correction", cos_global))
+        cos_point = _parameter_bool(params.get("point_cos_correction", cos_global))
+        use_scan_block_explicit = "use_scan_block" in getattr(
+            self, "_obs_parameter_explicit_keys", set()
+        )
+        requested_use_scan_block = _parameter_bool(params.get("use_scan_block", True))
         scan_block_supported_obstypes = {"OTF", "RadioPointing"}
         use_scan_block = requested_use_scan_block and (
             self.observation_type in scan_block_supported_obstypes
         )
-        if requested_use_scan_block and not use_scan_block:
+        if use_scan_block_explicit and requested_use_scan_block and not use_scan_block:
             supported = ", ".join(sorted(scan_block_supported_obstypes))
             self.logger.warning(
                 "use_scan_block is currently supported only for "

--- a/necst/procedures/observations/observation_base.py
+++ b/necst/procedures/observations/observation_base.py
@@ -65,6 +65,7 @@ class Observation(ABC):
         self._abort_reason = ""
         self._abort_request_id = ""
         self._abort_subscription = None
+        self._legacy_binning_changed_specs = set()
         self.progress = NullProgressReporter()
 
     def _reset_abort_state(self) -> None:
@@ -178,6 +179,8 @@ class Observation(ABC):
                         )
                         for spec_name in specnames:
                             self.binning(ch, spec_name)
+                        if ch is not None:
+                            self._legacy_binning_changed_specs.update(specnames)
                     elif ch is not None:
                         raise ValueError(
                             "spectral recording setup cannot be combined with legacy "
@@ -276,10 +279,12 @@ class Observation(ABC):
                 _cleanup_step("antenna stop", lambda: self.com.antenna("stop"))
 
                 def _reset_binning():
+                    changed_specs = set(self._legacy_binning_changed_specs)
                     for _key, val in config.spectrometer.items():
                         spec_name, key = _key.split(".", 1)
-                        if key == "max_ch":
+                        if (key == "max_ch") and (spec_name in changed_specs):
                             self.binning(val, spec_name)  # set max channel number
+                    self._legacy_binning_changed_specs.difference_update(changed_specs)
 
                 if legacy_cleanup_allowed:
                     _cleanup_step("reset channel binning", _reset_binning)

--- a/necst/rx/spectrometer.py
+++ b/necst/rx/spectrometer.py
@@ -530,6 +530,22 @@ class SpectralData(DeviceNode):
             except Exception as exc:
                 saving_enabled = False
                 warning = str(exc)
+
+        driver_warnings = []
+        for key, io in self.io.items():
+            last_exception = str(getattr(io, "last_exception", "") or "")
+            if last_exception:
+                driver_warnings.append(f"{key}: {last_exception.splitlines()[0]}")
+            try:
+                thread = getattr(io, "thread", None)
+                if thread is not None and not thread.is_alive():
+                    driver_warnings.append(f"{key}: reader thread is not alive")
+            except Exception:
+                pass
+        if driver_warnings:
+            joined = "; ".join(driver_warnings)
+            warning = f"{warning}; {joined}" if warning else joined
+
         if not getattr(self.recorder, "is_recording", False):
             saving_enabled = False
         tp_start = -1

--- a/necst/rx/spectrometer.py
+++ b/necst/rx/spectrometer.py
@@ -353,7 +353,11 @@ class SpectralData(DeviceNode):
                 self.spectral_recording_runtime.latch_fatal_error(message)
             return
 
+        requested = str(getattr(msg, "spectrometer", "") or "").replace("_", "").lower()
         for key, io in self.io.items():
+            key_norm = str(key).replace("_", "").lower()
+            if requested and requested != key_norm:
+                continue
             record_chan = msg.ch
             io.change_spec_ch(record_chan)
             self.logger.info(

--- a/necst/web/__init__.py
+++ b/necst/web/__init__.py
@@ -1,1 +1,3 @@
-"""Web/status helpers for NECST operator-facing interfaces."""
+"""Web helpers for the NECST operator/progress console."""
+
+__all__ = []

--- a/necst/web/__init__.py
+++ b/necst/web/__init__.py
@@ -1,0 +1,1 @@
+"""Web/status helpers for NECST operator-facing interfaces."""

--- a/necst/web/console_entry.py
+++ b/necst/web/console_entry.py
@@ -1,69 +1,21 @@
-#!/usr/bin/env python3
-"""Serve the NECST Operator Console.
+"""Installable entry point for the NECST Operator Console.
 
-This is the first real-console entry point.  It reuses the approved v7 browser
-layout from ``bin/console-demo.py``, reads status through ``necst.web.status_model``,
-and dispatches supported write actions through ``necst.core.operator_actions``.
+This module mirrors ``bin/console.py`` so the GUI can be started after a normal
+ROS/colcon installation without relying on the source-tree ``bin`` directory.
 """
 
 from __future__ import annotations
 
 import argparse
-import importlib.util
 import signal
-import sys
 import threading
 from pathlib import Path
 from typing import Any, Optional
 
-
-def _load_operator_console_module() -> Any:
-    """Import necst.web.operator_console, with a file fallback for reduced envs."""
-
-    try:
-        from necst.web import operator_console  # type: ignore
-
-        return operator_console
-    except Exception:
-        module_path = (
-            Path(__file__).resolve().parents[1]
-            / "necst"
-            / "web"
-            / "operator_console.py"
-        )
-        package_path = module_path.parent
-
-        # Create minimal package placeholders so operator_console's relative
-        # imports work without importing necst/__init__.py and therefore without
-        # requiring ROS/neclib for read-only smoke tests.
-        import types
-
-        necst_pkg = sys.modules.setdefault("necst", types.ModuleType("necst"))
-        web_pkg = sys.modules.setdefault("necst.web", types.ModuleType("necst.web"))
-        setattr(necst_pkg, "web", web_pkg)
-
-        for mod_name in ("process_manager", "progress_manager", "status_model", "site_config", "self_check", "log_reader", "live_telemetry"):
-            mod_path = package_path / f"{mod_name}.py"
-            spec = importlib.util.spec_from_file_location(f"necst.web.{mod_name}", mod_path)
-            if spec is None or spec.loader is None:
-                raise RuntimeError(f"failed to load {mod_name}.py from {mod_path}")
-            module = importlib.util.module_from_spec(spec)
-            sys.modules.setdefault(f"necst.web.{mod_name}", module)
-            spec.loader.exec_module(module)
-            setattr(web_pkg, mod_name, module)
-
-        spec = importlib.util.spec_from_file_location(
-            "necst.web.operator_console", module_path
-        )
-        if spec is None or spec.loader is None:
-            raise RuntimeError(f"failed to load operator_console.py from {module_path}")
-        module = importlib.util.module_from_spec(spec)
-        sys.modules.setdefault("necst.web.operator_console", module)
-        spec.loader.exec_module(module)
-        return module
+from . import operator_console
 
 
-def main(argv: Optional[list[str]] = None) -> int:
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Serve the NECST Operator Console")
     parser.add_argument("--host", default="127.0.0.1", help="web bind address")
     parser.add_argument("--port", type=int, default=8092, help="web bind port")
@@ -177,10 +129,13 @@ def main(argv: Optional[list[str]] = None) -> int:
     parser.add_argument("--az-max", type=float, default=None, help="fallback mount Az upper limit [deg]")
     parser.add_argument("--el-min", type=float, default=None, help="fallback mount El lower limit [deg]")
     parser.add_argument("--el-max", type=float, default=None, help="fallback mount El upper limit [deg]")
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = build_parser()
     args = parser.parse_args(argv)
     progress_url = str(args.progress_url or f"http://{args.progress_host}:{int(args.progress_port)}/")
-
-    operator_console = _load_operator_console_module()
     stop_event = threading.Event()
 
     def _signal_handler(_signum: int, _frame: Any) -> None:

--- a/necst/web/console_entry.py
+++ b/necst/web/console_entry.py
@@ -79,6 +79,17 @@ def build_parser() -> argparse.ArgumentParser:
         help="directory for launcher stdout/stderr logs; default is <operator-log-dir>/launcher_logs",
     )
     parser.add_argument(
+        "--obs-root",
+        action="append",
+        default=None,
+        help=(
+            "NECST-side file chooser start location; may be repeated. "
+            "Usually optional: without this, Home, common obs/data directories, and / are offered. "
+            "If console runs in Docker, this is a Docker/container path. "
+            "Use this to restrict or add chooser locations; also configurable with NECST_CONSOLE_OBS_ROOTS."
+        ),
+    )
+    parser.add_argument(
         "--shutdown-terminate-launchers",
         dest="shutdown_terminate_launchers",
         action="store_true",
@@ -157,6 +168,7 @@ def main(argv: Optional[list[str]] = None) -> int:
                 status_refresh_ms=int(args.status_refresh_ms),
                 progress_no_ros=bool(args.progress_no_ros),
                 progress_log_dir=args.progress_log_dir,
+                obs_roots=args.obs_root,
                 status_no_ros=bool(args.no_ros),
                 action_mode=str(args.action_mode),
                 live_actions_enabled=(str(args.action_mode) == "live" and not bool(args.guard_live_actions)),

--- a/necst/web/console_entry.py
+++ b/necst/web/console_entry.py
@@ -83,7 +83,8 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help=(
             "directory for observer-facing CSV observation logs; default is "
-            "$NECST_OBSLOG_DIR, then <record root>/obslogs, then ~/.necst/observation_logs. "
+            "$NECST_OBSLOG_DIR, then [console.observation_log].directory in the site TOML, "
+            "then <record root>/obslogs, then ~/.necst/observation_logs. "
             "If console runs in Docker, this is a Docker/container path."
         ),
     )

--- a/necst/web/console_entry.py
+++ b/necst/web/console_entry.py
@@ -79,6 +79,25 @@ def build_parser() -> argparse.ArgumentParser:
         help="directory for launcher stdout/stderr logs; default is <operator-log-dir>/launcher_logs",
     )
     parser.add_argument(
+        "--obslog-dir",
+        default=None,
+        help=(
+            "directory for observer-facing CSV observation logs; default is "
+            "$NECST_OBSLOG_DIR, then <record root>/obslogs, then ~/.necst/observation_logs. "
+            "If console runs in Docker, this is a Docker/container path."
+        ),
+    )
+    parser.add_argument(
+        "--obslog-prefix",
+        default=None,
+        help="filename prefix for observer-facing CSV observation logs; default is $NECST_OBSLOG_PREFIX or obslog",
+    )
+    parser.add_argument(
+        "--obslog-user",
+        default=None,
+        help="initial observer/user name written to CSV observation logs; default is $NECST_OBSLOG_USER or User",
+    )
+    parser.add_argument(
         "--obs-root",
         action="append",
         default=None,
@@ -178,6 +197,9 @@ def main(argv: Optional[list[str]] = None) -> int:
                 site_config_path=args.site_config,
                 operator_log_dir=args.operator_log_dir,
                 launcher_log_dir=args.launcher_log_dir,
+                obslog_dir=args.obslog_dir,
+                obslog_prefix=args.obslog_prefix,
+                obslog_user=args.obslog_user,
                 shutdown_terminate_launchers=bool(args.shutdown_terminate_launchers),
                 shutdown_launcher_timeout_sec=float(args.shutdown_launcher_timeout),
                 shutdown_launcher_kill_timeout_sec=float(args.shutdown_launcher_kill_timeout),

--- a/necst/web/console_entry.py
+++ b/necst/web/console_entry.py
@@ -147,6 +147,27 @@ def build_parser() -> argparse.ArgumentParser:
             "--action-mode dry-run is the recommended no-hardware mode"
         ),
     )
+    parser.add_argument(
+        "--safe-start",
+        action="store_true",
+        help=(
+            "start the console in a conservative recovery-friendly mode. "
+            "No hardware command is sent automatically; previous local state is not trusted for startup checks."
+        ),
+    )
+    parser.add_argument(
+        "--reset-local-state",
+        action="store_true",
+        help=(
+            "archive local console/progress pointer files before startup. "
+            "This does not send telescope, recorder, or XFFTS commands."
+        ),
+    )
+    parser.add_argument(
+        "--rescue",
+        action="store_true",
+        help="equivalent to --safe-start --reset-local-state; use when the console cannot recover normally",
+    )
     parser.add_argument("--open", action="store_true", help="open the URL in a browser")
     parser.add_argument("--quiet", action="store_true", help="suppress HTTP request logs")
     parser.add_argument("--events-limit", type=int, default=12, help="number of recent events in status model")
@@ -203,6 +224,9 @@ def main(argv: Optional[list[str]] = None) -> int:
                 shutdown_terminate_launchers=bool(args.shutdown_terminate_launchers),
                 shutdown_launcher_timeout_sec=float(args.shutdown_launcher_timeout),
                 shutdown_launcher_kill_timeout_sec=float(args.shutdown_launcher_kill_timeout),
+                safe_start=bool(args.safe_start),
+                reset_local_state=bool(args.reset_local_state),
+                rescue=bool(args.rescue),
                 az_min=args.az_min,
                 az_max=args.az_max,
                 el_min=args.el_min,

--- a/necst/web/console_entry.py
+++ b/necst/web/console_entry.py
@@ -19,7 +19,9 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Serve the NECST Operator Console")
     parser.add_argument("--host", default="127.0.0.1", help="web bind address")
     parser.add_argument("--port", type=int, default=8092, help="web bind port")
-    parser.add_argument("--telescope", default="NECST", help="telescope label shown in the UI")
+    parser.add_argument(
+        "--telescope", default="NECST", help="telescope label shown in the UI"
+    )
     parser.add_argument(
         "--progress-root",
         default="/tmp/necst_progress",
@@ -170,24 +172,41 @@ def build_parser() -> argparse.ArgumentParser:
         help="equivalent to --safe-start --reset-local-state; use when the console cannot recover normally",
     )
     parser.add_argument("--open", action="store_true", help="open the URL in a browser")
-    parser.add_argument("--quiet", action="store_true", help="suppress HTTP request logs")
-    parser.add_argument("--events-limit", type=int, default=12, help="number of recent events in status model")
+    parser.add_argument(
+        "--quiet", action="store_true", help="suppress HTTP request logs"
+    )
+    parser.add_argument(
+        "--events-limit",
+        type=int,
+        default=12,
+        help="number of recent events in status model",
+    )
     parser.add_argument(
         "--site-config",
         default=None,
         help="explicit site TOML path for console validation; defaults to active necst.config",
     )
-    parser.add_argument("--az-min", type=float, default=None, help="fallback mount Az lower limit [deg]")
-    parser.add_argument("--az-max", type=float, default=None, help="fallback mount Az upper limit [deg]")
-    parser.add_argument("--el-min", type=float, default=None, help="fallback mount El lower limit [deg]")
-    parser.add_argument("--el-max", type=float, default=None, help="fallback mount El upper limit [deg]")
+    parser.add_argument(
+        "--az-min", type=float, default=None, help="fallback mount Az lower limit [deg]"
+    )
+    parser.add_argument(
+        "--az-max", type=float, default=None, help="fallback mount Az upper limit [deg]"
+    )
+    parser.add_argument(
+        "--el-min", type=float, default=None, help="fallback mount El lower limit [deg]"
+    )
+    parser.add_argument(
+        "--el-max", type=float, default=None, help="fallback mount El upper limit [deg]"
+    )
     return parser
 
 
 def main(argv: Optional[list[str]] = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
-    progress_url = str(args.progress_url or f"http://{args.progress_host}:{int(args.progress_port)}/")
+    progress_url = str(
+        args.progress_url or f"http://{args.progress_host}:{int(args.progress_port)}/"
+    )
     stop_event = threading.Event()
 
     def _signal_handler(_signum: int, _frame: Any) -> None:
@@ -212,7 +231,10 @@ def main(argv: Optional[list[str]] = None) -> int:
                 obs_roots=args.obs_root,
                 status_no_ros=bool(args.no_ros),
                 action_mode=str(args.action_mode),
-                live_actions_enabled=(str(args.action_mode) == "live" and not bool(args.guard_live_actions)),
+                live_actions_enabled=(
+                    str(args.action_mode) == "live"
+                    and not bool(args.guard_live_actions)
+                ),
                 quiet=bool(args.quiet),
                 open_browser=bool(args.open),
                 events_limit=int(args.events_limit),
@@ -224,7 +246,9 @@ def main(argv: Optional[list[str]] = None) -> int:
                 obslog_user=args.obslog_user,
                 shutdown_terminate_launchers=bool(args.shutdown_terminate_launchers),
                 shutdown_launcher_timeout_sec=float(args.shutdown_launcher_timeout),
-                shutdown_launcher_kill_timeout_sec=float(args.shutdown_launcher_kill_timeout),
+                shutdown_launcher_kill_timeout_sec=float(
+                    args.shutdown_launcher_kill_timeout
+                ),
                 safe_start=bool(args.safe_start),
                 reset_local_state=bool(args.reset_local_state),
                 rescue=bool(args.rescue),

--- a/necst/web/console_log_cli.py
+++ b/necst/web/console_log_cli.py
@@ -1,0 +1,91 @@
+"""CLI helpers for reading the persistent NECST Operator Console log."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Any, Optional
+
+from . import log_reader
+
+
+def default_operator_log_dir() -> Path:
+    override = os.environ.get("NECST_OPERATOR_LOG_DIR")
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".necst" / "operator_console"
+
+
+def default_operator_log_path(log_dir: Optional[str | os.PathLike[str]] = None) -> Path:
+    base = Path(log_dir).expanduser() if log_dir not in (None, "") else default_operator_log_dir()
+    return base / "operator_console.jsonl"
+
+
+def _print_text_tail(payload: dict[str, Any]) -> int:
+    path = payload.get("path")
+    if path:
+        print(f"operator log: {path}")
+    if payload.get("ok") is False:
+        print(payload.get("reason") or "operator log read failed")
+        return 1
+    entries = payload.get("entries") or []
+    if not entries:
+        print(payload.get("reason") or "operator log is empty")
+        return 0
+    for entry in entries:
+        when = entry.get("time_iso") or entry.get("time") or ""
+        mark = "NG" if entry.get("ok") is False else "OK"
+        action = entry.get("action") or ""
+        message = entry.get("message") or entry.get("reason") or ""
+        print(f"{when} {mark} {action}: {message}".rstrip())
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Read NECST Operator Console logs")
+    parser.add_argument(
+        "command",
+        nargs="?",
+        default="tail",
+        choices=["tail", "path", "cat"],
+        help="tail parsed JSONL entries, print path, or print raw JSONL tail",
+    )
+    parser.add_argument("--operator-log-dir", default=None, help="operator log directory; default is $NECST_OPERATOR_LOG_DIR or ~/.necst/operator_console")
+    parser.add_argument("--path", default=None, help="explicit operator_console.jsonl path")
+    parser.add_argument("--limit", type=int, default=80, help="number of JSONL records/lines to show")
+    parser.add_argument("--json", action="store_true", help="print parsed payload as JSON")
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+    log_path = Path(args.path).expanduser() if args.path else default_operator_log_path(args.operator_log_dir)
+    if args.command == "path":
+        print(str(log_path))
+        return 0
+    payload = log_reader.read_operator_log(log_path, limit=args.limit)
+    if args.json:
+        print(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True))
+        return 0 if payload.get("ok") is not False else 1
+    if args.command == "cat":
+        if not log_path.exists():
+            print(f"operator log does not exist yet: {log_path}")
+            return 0
+        text_payload = log_reader.read_text_log(
+            str(log_path),
+            launcher_log_dir=None,
+            operator_log_path=log_path,
+            max_bytes=262144,
+        )
+        if text_payload.get("ok") is False:
+            print(text_payload.get("reason") or "log read failed")
+            return 1
+        print(text_payload.get("text") or "", end="")
+        return 0
+    return _print_text_tail(payload)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/necst/web/console_log_cli.py
+++ b/necst/web/console_log_cli.py
@@ -19,7 +19,11 @@ def default_operator_log_dir() -> Path:
 
 
 def default_operator_log_path(log_dir: Optional[str | os.PathLike[str]] = None) -> Path:
-    base = Path(log_dir).expanduser() if log_dir not in (None, "") else default_operator_log_dir()
+    base = (
+        Path(log_dir).expanduser()
+        if log_dir not in (None, "")
+        else default_operator_log_dir()
+    )
     return base / "operator_console.jsonl"
 
 
@@ -52,16 +56,30 @@ def build_parser() -> argparse.ArgumentParser:
         choices=["tail", "path", "cat"],
         help="tail parsed JSONL entries, print path, or print raw JSONL tail",
     )
-    parser.add_argument("--operator-log-dir", default=None, help="operator log directory; default is $NECST_OPERATOR_LOG_DIR or ~/.necst/operator_console")
-    parser.add_argument("--path", default=None, help="explicit operator_console.jsonl path")
-    parser.add_argument("--limit", type=int, default=80, help="number of JSONL records/lines to show")
-    parser.add_argument("--json", action="store_true", help="print parsed payload as JSON")
+    parser.add_argument(
+        "--operator-log-dir",
+        default=None,
+        help="operator log directory; default is $NECST_OPERATOR_LOG_DIR or ~/.necst/operator_console",
+    )
+    parser.add_argument(
+        "--path", default=None, help="explicit operator_console.jsonl path"
+    )
+    parser.add_argument(
+        "--limit", type=int, default=80, help="number of JSONL records/lines to show"
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="print parsed payload as JSON"
+    )
     return parser
 
 
 def main(argv: Optional[list[str]] = None) -> int:
     args = build_parser().parse_args(argv)
-    log_path = Path(args.path).expanduser() if args.path else default_operator_log_path(args.operator_log_dir)
+    log_path = (
+        Path(args.path).expanduser()
+        if args.path
+        else default_operator_log_path(args.operator_log_dir)
+    )
     if args.command == "path":
         print(str(log_path))
         return 0

--- a/necst/web/console_smoke.py
+++ b/necst/web/console_smoke.py
@@ -205,6 +205,41 @@ def _check_status(base_url: str, timeout: float) -> Tuple[List[SmokeItem], JsonD
             )
         )
 
+    live_telemetry = _mapping(data.get("live_telemetry"))
+    live_requested = bool(live_telemetry.get("requested"))
+    live_available = bool(live_telemetry.get("available"))
+    if live_requested and live_available:
+        items.append(
+            _item(
+                "status_live_telemetry",
+                True,
+                f"console live telemetry available ({live_telemetry.get('spin_mode') or 'unknown spin mode'})",
+                severity="info",
+                data={"live_telemetry": dict(live_telemetry)},
+            )
+        )
+    elif live_requested:
+        live_mode = str(data.get("action_mode")) == "live"
+        items.append(
+            _item(
+                "status_live_telemetry",
+                not live_mode,
+                f"console live telemetry unavailable: {live_telemetry.get('error') or 'unknown reason'}",
+                severity="error" if live_mode else "warning",
+                data={"live_telemetry": dict(live_telemetry)},
+            )
+        )
+    else:
+        items.append(
+            _item(
+                "status_live_telemetry",
+                True,
+                "console live telemetry disabled",
+                severity="warning" if str(data.get("action_mode")) == "live" else "info",
+                data={"live_telemetry": dict(live_telemetry)},
+            )
+        )
+
     process_counts = _mapping(data.get("process_counts"))
     items.append(
         _item(

--- a/necst/web/console_smoke.py
+++ b/necst/web/console_smoke.py
@@ -209,12 +209,17 @@ def _check_status(base_url: str, timeout: float) -> Tuple[List[SmokeItem], JsonD
     live_requested = bool(live_telemetry.get("requested"))
     live_available = bool(live_telemetry.get("available"))
     if live_requested and live_available:
+        live_mode = str(data.get("action_mode")) == "live"
+        has_position = bool(live_telemetry.get("has_position"))
         items.append(
             _item(
                 "status_live_telemetry",
-                True,
-                f"console live telemetry available ({live_telemetry.get('spin_mode') or 'unknown spin mode'})",
-                severity="info",
+                has_position or not live_mode,
+                (
+                    f"console live telemetry available ({live_telemetry.get('spin_mode') or 'unknown spin mode'}); "
+                    + ("position sample received" if has_position else "waiting for encoder/pointing position sample")
+                ),
+                severity="info" if has_position else ("error" if live_mode else "warning"),
                 data={"live_telemetry": dict(live_telemetry)},
             )
         )

--- a/necst/web/console_smoke.py
+++ b/necst/web/console_smoke.py
@@ -1,0 +1,404 @@
+"""HTTP smoke-test helpers for the NECST Operator Console.
+
+The smoke test is intentionally read-only by default.  It talks to an already
+running console server and verifies that the operator-facing status, process,
+and self-check endpoints are wired together.  It does not move the telescope,
+does not move the chopper, and does not start observation launchers.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
+
+JsonDict = Dict[str, Any]
+
+
+@dataclass
+class SmokeItem:
+    """One smoke-test item."""
+
+    name: str
+    ok: bool
+    message: str
+    severity: str = "error"
+    data: JsonDict = field(default_factory=dict)
+
+    def to_dict(self) -> JsonDict:
+        return {
+            "name": self.name,
+            "ok": bool(self.ok),
+            "severity": self.severity,
+            "message": self.message,
+            "data": dict(self.data),
+        }
+
+
+def _normalise_base_url(url: str) -> str:
+    url = str(url or "").strip()
+    if not url:
+        raise ValueError("console URL is empty")
+    if not url.startswith(("http://", "https://")):
+        url = "http://" + url
+    return url.rstrip("/") + "/"
+
+
+def _endpoint_url(base_url: str, path: str) -> str:
+    return urllib.parse.urljoin(base_url, path.lstrip("/"))
+
+
+def _json_request(
+    base_url: str,
+    path: str,
+    *,
+    method: str = "GET",
+    payload: Optional[Mapping[str, Any]] = None,
+    timeout: float = 3.0,
+) -> JsonDict:
+    url = _endpoint_url(base_url, path)
+    data: Optional[bytes] = None
+    headers = {"Accept": "application/json"}
+    if payload is not None:
+        data = json.dumps(payload).encode("utf-8")
+        headers["Content-Type"] = "application/json; charset=utf-8"
+    request = urllib.request.Request(url, data=data, headers=headers, method=method)
+    with urllib.request.urlopen(request, timeout=float(timeout)) as response:
+        body = response.read().decode("utf-8")
+        if int(response.status) < 200 or int(response.status) >= 300:
+            raise RuntimeError(f"{method} {path} returned HTTP {response.status}")
+    try:
+        parsed = json.loads(body or "{}")
+    except Exception as exc:
+        raise RuntimeError(f"{method} {path} did not return JSON: {exc}") from exc
+    if not isinstance(parsed, dict):
+        raise RuntimeError(f"{method} {path} returned non-object JSON")
+    return parsed
+
+
+def _item(
+    name: str,
+    ok: bool,
+    message: str,
+    *,
+    severity: str = "error",
+    data: Optional[Mapping[str, Any]] = None,
+) -> SmokeItem:
+    return SmokeItem(name=name, ok=bool(ok), message=str(message), severity=str(severity), data=dict(data or {}))
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _list(value: Any) -> List[Any]:
+    return list(value) if isinstance(value, list) else []
+
+
+def _check_health(base_url: str, timeout: float) -> Tuple[SmokeItem, JsonDict]:
+    try:
+        data = _json_request(base_url, "/health", timeout=timeout)
+    except Exception as exc:
+        return _item("health", False, f"/health failed: {exc}"), {}
+    ok = bool(data.get("ok"))
+    return _item("health", ok, "/health OK" if ok else "/health did not report ok", data=data), data
+
+
+def _check_status(base_url: str, timeout: float) -> Tuple[List[SmokeItem], JsonDict]:
+    try:
+        data = _json_request(base_url, "/api/status", timeout=timeout)
+    except Exception as exc:
+        return [_item("api_status", False, f"/api/status failed: {exc}")], {}
+
+    items: List[SmokeItem] = [
+        _item("api_status", True, "/api/status returned JSON", severity="info")
+    ]
+    mount_limits = _mapping(data.get("mount_limits"))
+    missing_limits = [k for k in ("az_min", "az_max", "el_min", "el_max") if k not in mount_limits]
+    items.append(
+        _item(
+            "status_mount_limits",
+            not missing_limits,
+            "mount limits present" if not missing_limits else "mount limits are incomplete",
+            data={"missing": missing_limits, "mount_limits": dict(mount_limits)},
+        )
+    )
+    capabilities = _mapping(data.get("capabilities"))
+    required_caps = (
+        "mount_move",
+        "target_tracking",
+        "observation_start",
+        "rsky",
+        "skydip",
+        "chopper_status",
+        "chopper_move",
+        "chopper_maintenance",
+    )
+    missing_caps = [k for k in required_caps if k not in capabilities]
+    non_bool_caps = [k for k, v in capabilities.items() if not isinstance(v, bool)]
+    items.append(
+        _item(
+            "status_capabilities",
+            not missing_caps and not non_bool_caps,
+            "capabilities present" if not missing_caps and not non_bool_caps else "capabilities are incomplete or non-boolean",
+            data={"missing": missing_caps, "non_bool": non_bool_caps, "capabilities": dict(capabilities)},
+        )
+    )
+    self_check_endpoint = data.get("self_check_endpoint")
+    items.append(
+        _item(
+            "status_self_check_endpoint",
+            self_check_endpoint == "/api/self-check",
+            "self-check endpoint advertised" if self_check_endpoint == "/api/self-check" else "self-check endpoint is missing",
+            data={"self_check_endpoint": self_check_endpoint},
+        )
+    )
+
+    try:
+        status_refresh_ms = int(data.get("status_refresh_ms"))
+    except Exception:
+        status_refresh_ms = 0
+    items.append(
+        _item(
+            "status_refresh_interval",
+            status_refresh_ms >= 200,
+            f"console status refresh interval = {status_refresh_ms} ms" if status_refresh_ms else "console status refresh interval is missing",
+            severity="info" if status_refresh_ms >= 200 else "warning",
+            data={"status_refresh_ms": status_refresh_ms},
+        )
+    )
+
+    live_actions = _mapping(data.get("live_actions"))
+    if str(data.get("action_mode")) == "live" and live_actions.get("guarded"):
+        items.append(
+            _item(
+                "status_live_write_guard",
+                True,
+                "live write actions are guarded by --guard-live-actions",
+                severity="warning",
+                data={"live_actions": dict(live_actions)},
+            )
+        )
+    elif str(data.get("action_mode")) == "live" and live_actions.get("enabled"):
+        items.append(
+            _item(
+                "status_live_write_guard",
+                True,
+                "live write actions are enabled by default in live mode",
+                severity="info",
+                data={"live_actions": dict(live_actions)},
+            )
+        )
+    else:
+        items.append(
+            _item(
+                "status_live_write_guard",
+                True,
+                "dry-run mode or live writes enabled by default",
+                severity="info",
+                data={"live_actions": dict(live_actions)},
+            )
+        )
+
+    process_counts = _mapping(data.get("process_counts"))
+    items.append(
+        _item(
+            "status_process_counts",
+            isinstance(process_counts, Mapping),
+            "process counts present",
+            severity="info",
+            data={"process_counts": dict(process_counts)},
+        )
+    )
+    return items, data
+
+
+def _check_self_check(base_url: str, timeout: float) -> Tuple[List[SmokeItem], JsonDict]:
+    try:
+        data = _json_request(base_url, "/api/self-check", timeout=timeout)
+    except Exception as exc:
+        return [_item("self_check_endpoint", False, f"/api/self-check failed: {exc}")], {}
+
+    summary = _mapping(data.get("summary"))
+    error_count = int(summary.get("error_count", 0) or 0)
+    warning_count = int(summary.get("warning_count", 0) or 0)
+    status = str(data.get("status") or summary.get("status") or "unknown")
+    items = [
+        _item(
+            "self_check_endpoint",
+            error_count == 0,
+            f"self-check status={status}, errors={error_count}, warnings={warning_count}",
+            severity="warning" if error_count == 0 and warning_count else "error",
+            data={"summary": dict(summary)},
+        )
+    ]
+    checks = _list(data.get("checks"))
+    for check in checks:
+        if not isinstance(check, Mapping):
+            continue
+        ok = bool(check.get("ok"))
+        severity = str(check.get("severity") or "error")
+        if not ok or severity == "warning":
+            items.append(
+                _item(
+                    "self_check." + str(check.get("name") or "unknown"),
+                    ok,
+                    str(check.get("message") or ""),
+                    severity=severity,
+                    data={"check": dict(check)},
+                )
+            )
+    return items, data
+
+
+def _check_processes(base_url: str, timeout: float) -> Tuple[List[SmokeItem], JsonDict]:
+    try:
+        data = _json_request(base_url, "/api/processes", timeout=timeout)
+    except Exception as exc:
+        return [_item("processes_endpoint", False, f"/api/processes failed: {exc}")], {}
+    counts = _mapping(data.get("process_counts"))
+    items = [
+        _item(
+            "processes_endpoint",
+            bool(counts) or "processes" in data,
+            "/api/processes returned process state",
+            severity="info",
+            data={"process_counts": dict(counts)},
+        )
+    ]
+    return items, data
+
+
+def _check_operator_log(base_url: str, timeout: float) -> Tuple[List[SmokeItem], JsonDict]:
+    try:
+        data = _json_request(base_url, "/api/operator-log?limit=5", timeout=timeout)
+    except Exception as exc:
+        return [_item("operator_log_endpoint", False, f"/api/operator-log failed: {exc}")], {}
+    ok = bool(data.get("ok", True)) and isinstance(data.get("entries", []), list)
+    return [
+        _item(
+            "operator_log_endpoint",
+            ok,
+            "/api/operator-log returned JSONL tail" if ok else str(data.get("reason") or "operator log endpoint returned not-ok"),
+            severity="info" if ok else "error",
+            data={"path": data.get("path"), "returned_count": data.get("returned_count")},
+        )
+    ], data
+
+
+def _check_action_self_check(base_url: str, timeout: float) -> Tuple[List[SmokeItem], JsonDict]:
+    payload = {"action": "self_check", "params": {}, "session_id": "console-check"}
+    try:
+        data = _json_request(base_url, "/api/action", method="POST", payload=payload, timeout=timeout)
+    except Exception as exc:
+        return [_item("action_self_check", False, f"action=self_check failed: {exc}")], {}
+    ok = bool(data.get("ok"))
+    action_data = _mapping(data.get("data"))
+    self_data = _mapping(action_data.get("self_check"))
+    summary = _mapping(self_data.get("summary"))
+    error_count = int(summary.get("error_count", 0) or 0) if summary else 0
+    item_ok = ok and error_count == 0
+    return [
+        _item(
+            "action_self_check",
+            item_ok,
+            "action=self_check OK" if item_ok else str(data.get("reason") or "action=self_check reported errors"),
+            severity="warning" if ok and not item_ok else "error",
+            data={"response": data},
+        )
+    ], data
+
+
+def run_smoke_test(
+    *,
+    url: str = "http://127.0.0.1:8092/",
+    timeout: float = 3.0,
+    include_action_self_check: bool = True,
+    fail_on_warning: bool = False,
+) -> JsonDict:
+    """Run a read-only smoke test against an already running console server."""
+
+    base_url = _normalise_base_url(url)
+    started_at = time.time()
+    items: List[SmokeItem] = []
+    raw: JsonDict = {}
+
+    health_item, raw_health = _check_health(base_url, timeout)
+    items.append(health_item)
+    raw["health"] = raw_health
+
+    status_items, raw_status = _check_status(base_url, timeout)
+    items.extend(status_items)
+    raw["status"] = raw_status
+
+    self_items, raw_self = _check_self_check(base_url, timeout)
+    items.extend(self_items)
+    raw["self_check"] = raw_self
+
+    process_items, raw_processes = _check_processes(base_url, timeout)
+    items.extend(process_items)
+    raw["processes"] = raw_processes
+
+    log_items, raw_log = _check_operator_log(base_url, timeout)
+    items.extend(log_items)
+    raw["operator_log"] = raw_log
+
+    if include_action_self_check:
+        action_items, raw_action = _check_action_self_check(base_url, timeout)
+        items.extend(action_items)
+        raw["action_self_check"] = raw_action
+
+    error_count = sum(1 for item in items if not item.ok and item.severity == "error")
+    warning_count = sum(1 for item in items if item.severity == "warning" or (not item.ok and item.severity != "error"))
+    ok = error_count == 0 and (warning_count == 0 or not bool(fail_on_warning))
+    status = "ok" if ok and warning_count == 0 else ("warning" if ok else "error")
+    finished_at = time.time()
+    return {
+        "ok": ok,
+        "status": status,
+        "summary": {
+            "ok": ok,
+            "status": status,
+            "url": base_url,
+            "error_count": error_count,
+            "warning_count": warning_count,
+            "check_count": len(items),
+            "duration_sec": round(finished_at - started_at, 3),
+            "fail_on_warning": bool(fail_on_warning),
+        },
+        "items": [item.to_dict() for item in items],
+        "raw": raw,
+    }
+
+
+def print_smoke_report(result: Mapping[str, Any], *, stream: Any = None) -> None:
+    """Print a compact human-readable smoke-test report."""
+
+    stream = stream or sys.stdout
+    summary = _mapping(result.get("summary"))
+    print(
+        "NECST Operator Console smoke check: "
+        f"{summary.get('status')} "
+        f"({summary.get('error_count')} error, {summary.get('warning_count')} warning, "
+        f"{summary.get('duration_sec')} s)",
+        file=stream,
+    )
+    print(f"URL: {summary.get('url')}", file=stream)
+    for item in result.get("items", []):
+        if not isinstance(item, Mapping):
+            continue
+        ok = bool(item.get("ok"))
+        severity = str(item.get("severity") or "error")
+        marker = "OK" if ok and severity != "warning" else ("WARN" if severity == "warning" else "FAIL")
+        print(f"  [{marker}] {item.get('name')}: {item.get('message')}", file=stream)
+
+
+__all__ = [
+    "run_smoke_test",
+    "print_smoke_report",
+]

--- a/necst/web/console_smoke.py
+++ b/necst/web/console_smoke.py
@@ -15,7 +15,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from dataclasses import dataclass, field
-from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
+from typing import Any, Dict, List, Mapping, Optional, Tuple
 
 JsonDict = Dict[str, Any]
 
@@ -89,7 +89,13 @@ def _item(
     severity: str = "error",
     data: Optional[Mapping[str, Any]] = None,
 ) -> SmokeItem:
-    return SmokeItem(name=name, ok=bool(ok), message=str(message), severity=str(severity), data=dict(data or {}))
+    return SmokeItem(
+        name=name,
+        ok=bool(ok),
+        message=str(message),
+        severity=str(severity),
+        data=dict(data or {}),
+    )
 
 
 def _mapping(value: Any) -> Mapping[str, Any]:
@@ -106,7 +112,12 @@ def _check_health(base_url: str, timeout: float) -> Tuple[SmokeItem, JsonDict]:
     except Exception as exc:
         return _item("health", False, f"/health failed: {exc}"), {}
     ok = bool(data.get("ok"))
-    return _item("health", ok, "/health OK" if ok else "/health did not report ok", data=data), data
+    return (
+        _item(
+            "health", ok, "/health OK" if ok else "/health did not report ok", data=data
+        ),
+        data,
+    )
 
 
 def _check_status(base_url: str, timeout: float) -> Tuple[List[SmokeItem], JsonDict]:
@@ -119,12 +130,18 @@ def _check_status(base_url: str, timeout: float) -> Tuple[List[SmokeItem], JsonD
         _item("api_status", True, "/api/status returned JSON", severity="info")
     ]
     mount_limits = _mapping(data.get("mount_limits"))
-    missing_limits = [k for k in ("az_min", "az_max", "el_min", "el_max") if k not in mount_limits]
+    missing_limits = [
+        k for k in ("az_min", "az_max", "el_min", "el_max") if k not in mount_limits
+    ]
     items.append(
         _item(
             "status_mount_limits",
             not missing_limits,
-            "mount limits present" if not missing_limits else "mount limits are incomplete",
+            (
+                "mount limits present"
+                if not missing_limits
+                else "mount limits are incomplete"
+            ),
             data={"missing": missing_limits, "mount_limits": dict(mount_limits)},
         )
     )
@@ -145,8 +162,16 @@ def _check_status(base_url: str, timeout: float) -> Tuple[List[SmokeItem], JsonD
         _item(
             "status_capabilities",
             not missing_caps and not non_bool_caps,
-            "capabilities present" if not missing_caps and not non_bool_caps else "capabilities are incomplete or non-boolean",
-            data={"missing": missing_caps, "non_bool": non_bool_caps, "capabilities": dict(capabilities)},
+            (
+                "capabilities present"
+                if not missing_caps and not non_bool_caps
+                else "capabilities are incomplete or non-boolean"
+            ),
+            data={
+                "missing": missing_caps,
+                "non_bool": non_bool_caps,
+                "capabilities": dict(capabilities),
+            },
         )
     )
     self_check_endpoint = data.get("self_check_endpoint")
@@ -154,7 +179,11 @@ def _check_status(base_url: str, timeout: float) -> Tuple[List[SmokeItem], JsonD
         _item(
             "status_self_check_endpoint",
             self_check_endpoint == "/api/self-check",
-            "self-check endpoint advertised" if self_check_endpoint == "/api/self-check" else "self-check endpoint is missing",
+            (
+                "self-check endpoint advertised"
+                if self_check_endpoint == "/api/self-check"
+                else "self-check endpoint is missing"
+            ),
             data={"self_check_endpoint": self_check_endpoint},
         )
     )
@@ -167,7 +196,11 @@ def _check_status(base_url: str, timeout: float) -> Tuple[List[SmokeItem], JsonD
         _item(
             "status_refresh_interval",
             status_refresh_ms >= 200,
-            f"console status refresh interval = {status_refresh_ms} ms" if status_refresh_ms else "console status refresh interval is missing",
+            (
+                f"console status refresh interval = {status_refresh_ms} ms"
+                if status_refresh_ms
+                else "console status refresh interval is missing"
+            ),
             severity="info" if status_refresh_ms >= 200 else "warning",
             data={"status_refresh_ms": status_refresh_ms},
         )
@@ -217,9 +250,15 @@ def _check_status(base_url: str, timeout: float) -> Tuple[List[SmokeItem], JsonD
                 has_position or not live_mode,
                 (
                     f"console live telemetry available ({live_telemetry.get('spin_mode') or 'unknown spin mode'}); "
-                    + ("position sample received" if has_position else "waiting for encoder/pointing position sample")
+                    + (
+                        "position sample received"
+                        if has_position
+                        else "waiting for encoder/pointing position sample"
+                    )
                 ),
-                severity="info" if has_position else ("error" if live_mode else "warning"),
+                severity=(
+                    "info" if has_position else ("error" if live_mode else "warning")
+                ),
                 data={"live_telemetry": dict(live_telemetry)},
             )
         )
@@ -240,7 +279,9 @@ def _check_status(base_url: str, timeout: float) -> Tuple[List[SmokeItem], JsonD
                 "status_live_telemetry",
                 True,
                 "console live telemetry disabled",
-                severity="warning" if str(data.get("action_mode")) == "live" else "info",
+                severity=(
+                    "warning" if str(data.get("action_mode")) == "live" else "info"
+                ),
                 data={"live_telemetry": dict(live_telemetry)},
             )
         )
@@ -258,11 +299,15 @@ def _check_status(base_url: str, timeout: float) -> Tuple[List[SmokeItem], JsonD
     return items, data
 
 
-def _check_self_check(base_url: str, timeout: float) -> Tuple[List[SmokeItem], JsonDict]:
+def _check_self_check(
+    base_url: str, timeout: float
+) -> Tuple[List[SmokeItem], JsonDict]:
     try:
         data = _json_request(base_url, "/api/self-check", timeout=timeout)
     except Exception as exc:
-        return [_item("self_check_endpoint", False, f"/api/self-check failed: {exc}")], {}
+        return [
+            _item("self_check_endpoint", False, f"/api/self-check failed: {exc}")
+        ], {}
 
     summary = _mapping(data.get("summary"))
     error_count = int(summary.get("error_count", 0) or 0)
@@ -314,29 +359,46 @@ def _check_processes(base_url: str, timeout: float) -> Tuple[List[SmokeItem], Js
     return items, data
 
 
-def _check_operator_log(base_url: str, timeout: float) -> Tuple[List[SmokeItem], JsonDict]:
+def _check_operator_log(
+    base_url: str, timeout: float
+) -> Tuple[List[SmokeItem], JsonDict]:
     try:
         data = _json_request(base_url, "/api/operator-log?limit=5", timeout=timeout)
     except Exception as exc:
-        return [_item("operator_log_endpoint", False, f"/api/operator-log failed: {exc}")], {}
+        return [
+            _item("operator_log_endpoint", False, f"/api/operator-log failed: {exc}")
+        ], {}
     ok = bool(data.get("ok", True)) and isinstance(data.get("entries", []), list)
     return [
         _item(
             "operator_log_endpoint",
             ok,
-            "/api/operator-log returned JSONL tail" if ok else str(data.get("reason") or "operator log endpoint returned not-ok"),
+            (
+                "/api/operator-log returned JSONL tail"
+                if ok
+                else str(data.get("reason") or "operator log endpoint returned not-ok")
+            ),
             severity="info" if ok else "error",
-            data={"path": data.get("path"), "returned_count": data.get("returned_count")},
+            data={
+                "path": data.get("path"),
+                "returned_count": data.get("returned_count"),
+            },
         )
     ], data
 
 
-def _check_action_self_check(base_url: str, timeout: float) -> Tuple[List[SmokeItem], JsonDict]:
+def _check_action_self_check(
+    base_url: str, timeout: float
+) -> Tuple[List[SmokeItem], JsonDict]:
     payload = {"action": "self_check", "params": {}, "session_id": "console-check"}
     try:
-        data = _json_request(base_url, "/api/action", method="POST", payload=payload, timeout=timeout)
+        data = _json_request(
+            base_url, "/api/action", method="POST", payload=payload, timeout=timeout
+        )
     except Exception as exc:
-        return [_item("action_self_check", False, f"action=self_check failed: {exc}")], {}
+        return [
+            _item("action_self_check", False, f"action=self_check failed: {exc}")
+        ], {}
     ok = bool(data.get("ok"))
     action_data = _mapping(data.get("data"))
     self_data = _mapping(action_data.get("self_check"))
@@ -347,7 +409,11 @@ def _check_action_self_check(base_url: str, timeout: float) -> Tuple[List[SmokeI
         _item(
             "action_self_check",
             item_ok,
-            "action=self_check OK" if item_ok else str(data.get("reason") or "action=self_check reported errors"),
+            (
+                "action=self_check OK"
+                if item_ok
+                else str(data.get("reason") or "action=self_check reported errors")
+            ),
             severity="warning" if ok and not item_ok else "error",
             data={"response": data},
         )
@@ -394,7 +460,11 @@ def run_smoke_test(
         raw["action_self_check"] = raw_action
 
     error_count = sum(1 for item in items if not item.ok and item.severity == "error")
-    warning_count = sum(1 for item in items if item.severity == "warning" or (not item.ok and item.severity != "error"))
+    warning_count = sum(
+        1
+        for item in items
+        if item.severity == "warning" or (not item.ok and item.severity != "error")
+    )
     ok = error_count == 0 and (warning_count == 0 or not bool(fail_on_warning))
     status = "ok" if ok and warning_count == 0 else ("warning" if ok else "error")
     finished_at = time.time()
@@ -434,7 +504,11 @@ def print_smoke_report(result: Mapping[str, Any], *, stream: Any = None) -> None
             continue
         ok = bool(item.get("ok"))
         severity = str(item.get("severity") or "error")
-        marker = "OK" if ok and severity != "warning" else ("WARN" if severity == "warning" else "FAIL")
+        marker = (
+            "OK"
+            if ok and severity != "warning"
+            else ("WARN" if severity == "warning" else "FAIL")
+        )
         print(f"  [{marker}] {item.get('name')}: {item.get('message')}", file=stream)
 
 

--- a/necst/web/live_telemetry.py
+++ b/necst/web/live_telemetry.py
@@ -13,7 +13,9 @@ import sys
 import threading
 import time
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
+
+from . import node_health
 
 
 ENCODER_MOTION_DEADBAND_DEG = 5.0e-4
@@ -475,6 +477,28 @@ class LiveTelemetryCache:
         except Exception as exc:
             self.error = str(exc)
             self.available = False
+
+    def ros_node_names(self) -> List[str]:
+        """Return fully qualified ROS node names from the current graph.
+
+        This is read-only and uses the same rclpy node/context as the live
+        telemetry subscriptions so the operator console does not create another
+        ROS node just for health monitoring.
+        """
+
+        if not (self.available and self._node is not None):
+            raise RuntimeError(self.error or "live telemetry ROS node is unavailable")
+        self.spin_once(timeout_sec=0.0)
+        try:
+            pairs = self._node.get_node_names_and_namespaces()
+        except Exception as exc:
+            self.error = f"failed to read ROS graph node list: {exc}"
+            raise
+        names = [
+            node_health.full_node_name(name, namespace)
+            for name, namespace in pairs
+        ]
+        return sorted(name for name in names if name)
 
     def snapshot(self) -> Dict[str, Any]:
         if self.available:

--- a/necst/web/live_telemetry.py
+++ b/necst/web/live_telemetry.py
@@ -128,7 +128,6 @@ class LiveTelemetryCache:
             return
 
         previous = self._previous_encoder_sample
-        anchor = self._encoder_motion_anchor or previous
         delta_az = None
         delta_el = None
         anchor_delta_az = None
@@ -146,7 +145,25 @@ class LiveTelemetryCache:
                 delta_az > ENCODER_MOTION_DEADBAND_DEG
                 or delta_el > ENCODER_MOTION_DEADBAND_DEG
             )
-        if anchor is not None and not was_recently_moving:
+
+        # Important: once a real move has stopped and the hysteresis hold has
+        # expired, reset the cumulative-motion anchor to the current encoder
+        # sample before testing the cumulative threshold again.  The previous
+        # implementation kept the anchor at the pre-move position.  After a STOP
+        # or after arrival at a new Az/El, the large distance from that stale
+        # anchor made ``cumulative_start_significant`` true forever, so the UI
+        # stayed in MOUNT MOVING even while the encoder had settled.
+        just_settled = bool(
+            self._last_significant_encoder_motion_unix is not None
+            and not was_recently_moving
+            and not per_sample_significant
+        )
+        if just_settled:
+            self._last_significant_encoder_motion_unix = None
+            self._encoder_motion_anchor = {"lon": lon, "lat": lat, "time_unix": now}
+
+        anchor = self._encoder_motion_anchor or previous
+        if anchor is not None and not was_recently_moving and not just_settled:
             anchor_delta_az = abs(lon - anchor.get("lon", lon))
             anchor_delta_el = abs(lat - anchor.get("lat", lat))
             cumulative_start_significant = bool(
@@ -174,6 +191,7 @@ class LiveTelemetryCache:
             "deadband_deg": ENCODER_MOTION_DEADBAND_DEG,
             "start_cumulative_deg": ENCODER_MOTION_START_CUMULATIVE_DEG,
             "hold_sec": ENCODER_MOTION_HOLD_SEC,
+            "just_settled": just_settled,
             "time_unix": now,
         }
         self._previous_encoder_sample = {"lon": lon, "lat": lat, "time_unix": now}

--- a/necst/web/live_telemetry.py
+++ b/necst/web/live_telemetry.py
@@ -16,8 +16,9 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 
-ENCODER_MOTION_DEADBAND_DEG = 1.0e-4
-ENCODER_MOTION_HOLD_SEC = 1.0
+ENCODER_MOTION_DEADBAND_DEG = 5.0e-4
+ENCODER_MOTION_START_CUMULATIVE_DEG = 8.0e-4
+ENCODER_MOTION_HOLD_SEC = 0.8
 
 
 def _finite_float(value: Any) -> Optional[float]:
@@ -85,6 +86,7 @@ class LiveTelemetryCache:
         self.encoder: Dict[str, Any] = {}
         self.encoder_motion: Dict[str, Any] = {}
         self._previous_encoder_sample: Optional[Dict[str, float]] = None
+        self._encoder_motion_anchor: Optional[Dict[str, float]] = None
         self._last_significant_encoder_motion_unix: Optional[float] = None
         self.tracking: Dict[str, Any] = {}
         self.pointing_status: Dict[str, Any] = {}
@@ -107,9 +109,10 @@ class LiveTelemetryCache:
         """Estimate actual antenna motion from encoder samples with deadband.
 
         Encoder readout often jitters in the low-order digits even when the
-        antenna is physically stopped.  This fallback therefore ignores changes
-        at or below 1e-4 deg and is used only as a secondary source when no
-        fresher explicit motion/section status is available.
+        antenna is physically stopped.  Field tests showed sample-to-sample
+        noise of about 2e-4 deg, so this fallback uses a larger deadband and a
+        small hysteresis.  It is only a secondary source when no fresher
+        explicit motion/section status is available.
         """
 
         now = time.time()
@@ -125,17 +128,33 @@ class LiveTelemetryCache:
             return
 
         previous = self._previous_encoder_sample
+        anchor = self._encoder_motion_anchor or previous
         delta_az = None
         delta_el = None
-        significant = False
+        anchor_delta_az = None
+        anchor_delta_el = None
+        per_sample_significant = False
+        cumulative_start_significant = False
+        was_recently_moving = bool(
+            self._last_significant_encoder_motion_unix is not None
+            and now - self._last_significant_encoder_motion_unix <= ENCODER_MOTION_HOLD_SEC
+        )
         if previous is not None:
             delta_az = abs(lon - previous.get("lon", lon))
             delta_el = abs(lat - previous.get("lat", lat))
-            significant = bool(
+            per_sample_significant = bool(
                 delta_az > ENCODER_MOTION_DEADBAND_DEG
                 or delta_el > ENCODER_MOTION_DEADBAND_DEG
             )
+        if anchor is not None and not was_recently_moving:
+            anchor_delta_az = abs(lon - anchor.get("lon", lon))
+            anchor_delta_el = abs(lat - anchor.get("lat", lat))
+            cumulative_start_significant = bool(
+                anchor_delta_az > ENCODER_MOTION_START_CUMULATIVE_DEG
+                or anchor_delta_el > ENCODER_MOTION_START_CUMULATIVE_DEG
+            )
 
+        significant = bool(per_sample_significant or cumulative_start_significant)
         if significant:
             self._last_significant_encoder_motion_unix = now
         held = bool(
@@ -143,12 +162,17 @@ class LiveTelemetryCache:
             and now - self._last_significant_encoder_motion_unix <= ENCODER_MOTION_HOLD_SEC
         )
         moving = bool(significant or held)
+        if self._encoder_motion_anchor is None or (was_recently_moving and not moving):
+            self._encoder_motion_anchor = {"lon": lon, "lat": lat, "time_unix": now}
         self.encoder_motion = {
             "moving": moving,
             "source": "encoder_delta" if moving else "encoder_delta_deadband",
             "delta_az_deg": delta_az,
             "delta_el_deg": delta_el,
+            "anchor_delta_az_deg": anchor_delta_az,
+            "anchor_delta_el_deg": anchor_delta_el,
             "deadband_deg": ENCODER_MOTION_DEADBAND_DEG,
+            "start_cumulative_deg": ENCODER_MOTION_START_CUMULATIVE_DEG,
             "hold_sec": ENCODER_MOTION_HOLD_SEC,
             "time_unix": now,
         }

--- a/necst/web/live_telemetry.py
+++ b/necst/web/live_telemetry.py
@@ -98,11 +98,7 @@ class LiveTelemetryCache:
     def _has_position_locked(self) -> bool:
         enc_lon = _finite_float(self.encoder.get("encoder_lon_deg"))
         enc_lat = _finite_float(self.encoder.get("encoder_lat_deg"))
-        if enc_lon is not None and enc_lat is not None:
-            return True
-        pointing_az = _finite_float(self.pointing_status.get("enc_az_deg"))
-        pointing_el = _finite_float(self.pointing_status.get("enc_el_deg"))
-        return pointing_az is not None and pointing_el is not None
+        return enc_lon is not None and enc_lat is not None
 
     def has_position(self) -> bool:
         with self._lock:
@@ -286,7 +282,6 @@ class LiveTelemetryCache:
             except Exception:
                 pass
             for topic_obj, callback in (
-                (getattr(topic, "antenna_pointing_status", None), pointing_status_cb),
                 (getattr(topic, "antenna_az_unwrap_status", None), az_unwrap_status_cb),
                 (getattr(topic, "antenna_command_queue_status", None), queue_status_cb),
                 (getattr(topic, "spectrometer_status", None), spectrometer_status_cb),
@@ -386,8 +381,9 @@ class LiveTelemetryCache:
                 payload["encoder"] = dict(self.encoder)
             if self.tracking:
                 payload["tracking"] = dict(self.tracking)
-            if self.pointing_status:
-                payload["pointing_status"] = dict(self.pointing_status)
+            # AntennaPointingStatus is intentionally not exposed to the operator
+            # status model.  It is a diagnostic/extrapolated topic and must not
+            # drive Command Az/El, Tracking, or Moving display.
             if self.az_unwrap_status:
                 payload["az_unwrap_status"] = dict(self.az_unwrap_status)
             if self.queue_status:

--- a/necst/web/live_telemetry.py
+++ b/necst/web/live_telemetry.py
@@ -1,0 +1,351 @@
+"""Best-effort live ROS telemetry cache for the Operator Console.
+
+This module is intentionally read-only.  It subscribes to NECST status topics
+and exposes a compact dictionary that can be merged by ``status_model``.  It is
+safe to import outside a ROS environment; ROS imports happen only when the cache
+is started.
+"""
+
+from __future__ import annotations
+
+import math
+import sys
+import threading
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+def _finite_float(value: Any) -> Optional[float]:
+    try:
+        out = float(value)
+    except Exception:
+        return None
+    return out if math.isfinite(out) else None
+
+
+def _msg_coord(msg: Any, *, prefix: str) -> Dict[str, Any]:
+    """Convert common NECST coordinate messages to status_model field names."""
+
+    lon = _finite_float(getattr(msg, "lon", None))
+    lat = _finite_float(getattr(msg, "lat", None))
+    if lon is None:
+        lon = _finite_float(getattr(msg, "az", None))
+    if lat is None:
+        lat = _finite_float(getattr(msg, "el", None))
+    if lon is None:
+        lon = _finite_float(getattr(msg, "az_deg", None))
+    if lat is None:
+        lat = _finite_float(getattr(msg, "el_deg", None))
+
+    payload: Dict[str, Any] = {}
+    if lon is not None:
+        payload[f"{prefix}_lon_deg"] = lon
+    if lat is not None:
+        payload[f"{prefix}_lat_deg"] = lat
+    frame = getattr(msg, "frame", None)
+    unit = getattr(msg, "unit", None)
+    name = getattr(msg, "name", None)
+    ts = _finite_float(getattr(msg, "time", None))
+    if frame not in (None, ""):
+        payload[f"{prefix}_frame"] = str(frame)
+    if unit not in (None, ""):
+        payload[f"{prefix}_unit"] = str(unit)
+    if name not in (None, ""):
+        payload[f"{prefix}_name"] = str(name)
+    if ts is not None:
+        payload[f"{prefix}_time_unix"] = ts
+    return payload
+
+
+class LiveTelemetryCache:
+    """Read-only ROS status cache for current antenna/chopper console display."""
+
+    def __init__(self, *, enabled: bool = True, node_name: str = "necst_operator_console_status") -> None:
+        self.requested = bool(enabled)
+        self.available = False
+        self.error: Optional[str] = None
+        self.node_name = str(node_name)
+        self._rclpy = None
+        self._node = None
+        self._executor = None
+        self._spin_thread: Optional[threading.Thread] = None
+        self._owns_context = False
+        self._lock = threading.RLock()
+        self._spin_mode = "disabled"
+
+        self.command: Dict[str, Any] = {}
+        self.encoder: Dict[str, Any] = {}
+        self.tracking: Dict[str, Any] = {}
+        self.pointing_status: Dict[str, Any] = {}
+        self.az_unwrap_status: Dict[str, Any] = {}
+        self.queue_status: Dict[str, Any] = {}
+        self.chopper_status: Dict[str, Any] = {}
+        self.spectrometer_status: Dict[str, Any] = {}
+        self.weather: Dict[str, Dict[str, Any]] = {}
+
+        if self.requested:
+            self._start()
+
+    def _start(self) -> None:
+        try:
+            repo_root = str(Path(__file__).resolve().parents[2])
+            if repo_root not in sys.path:
+                sys.path.insert(0, repo_root)
+            import rclpy  # type: ignore
+            from necst import config as necst_config  # type: ignore
+            from necst.definitions import topic  # type: ignore
+
+            self._rclpy = rclpy
+            self._owns_context = not rclpy.ok()
+            if self._owns_context:
+                rclpy.init(args=None)
+            self._node = rclpy.create_node(self.node_name)
+
+            def command_cb(msg: Any) -> None:
+                with self._lock:
+                    self.command = _msg_coord(msg, prefix="command")
+
+            def encoder_cb(msg: Any) -> None:
+                with self._lock:
+                    self.encoder = _msg_coord(msg, prefix="encoder")
+
+            def tracking_cb(msg: Any) -> None:
+                with self._lock:
+                    self.tracking = {
+                        "ok": bool(getattr(msg, "ok", False)),
+                        "error_deg": _finite_float(getattr(msg, "error", None)),
+                        "time_unix": _finite_float(getattr(msg, "time", None)),
+                    }
+
+            def pointing_status_cb(msg: Any) -> None:
+                with self._lock:
+                    self.pointing_status = {
+                        "valid": bool(getattr(msg, "valid", False)),
+                        "publish_time_unix": _finite_float(getattr(msg, "publish_time_unix", None)),
+                        "command_time_unix": _finite_float(getattr(msg, "command_time_unix", None)),
+                        "encoder_time_unix": _finite_float(getattr(msg, "encoder_time_unix", None)),
+                        "cmd_az_deg": _finite_float(getattr(msg, "cmd_az_deg", None)),
+                        "cmd_el_deg": _finite_float(getattr(msg, "cmd_el_deg", None)),
+                        "enc_az_deg": _finite_float(getattr(msg, "enc_az_deg", None)),
+                        "enc_el_deg": _finite_float(getattr(msg, "enc_el_deg", None)),
+                        "delta_az_deg": _finite_float(getattr(msg, "delta_az_deg", None)),
+                        "delta_el_deg": _finite_float(getattr(msg, "delta_el_deg", None)),
+                        "delta_az_cos_el_deg": _finite_float(getattr(msg, "delta_az_cos_el_deg", None)),
+                        "tracking_error_deg": _finite_float(getattr(msg, "tracking_error_deg", None)),
+                        "tracking_threshold_deg": _finite_float(getattr(msg, "tracking_threshold_deg", None)),
+                        "tracking_ok": bool(getattr(msg, "tracking_ok", False)),
+                        "cmd_age_sec": _finite_float(getattr(msg, "cmd_age_sec", None)),
+                        "enc_age_sec": _finite_float(getattr(msg, "enc_age_sec", None)),
+                        "command_stale": bool(getattr(msg, "command_stale", False)),
+                        "encoder_stale": bool(getattr(msg, "encoder_stale", False)),
+                        "basis": str(getattr(msg, "basis", "")),
+                    }
+
+            def az_unwrap_status_cb(msg: Any) -> None:
+                with self._lock:
+                    self.az_unwrap_status = {
+                        "enabled": bool(getattr(msg, "enabled", False)),
+                        "valid": bool(getattr(msg, "valid", False)),
+                        "mode": str(getattr(msg, "mode", "")),
+                        "state": str(getattr(msg, "state", "")),
+                        "reason": str(getattr(msg, "reason", "")),
+                        "publish_time_unix": _finite_float(getattr(msg, "publish_time_unix", None)),
+                        "encoder_time_unix": _finite_float(getattr(msg, "encoder_time_unix", None)),
+                        "raw_az_deg": _finite_float(getattr(msg, "raw_az_deg", None)),
+                        "modulo_az_deg": _finite_float(getattr(msg, "modulo_az_deg", None)),
+                        "continuous_az_deg": _finite_float(getattr(msg, "continuous_az_deg", None)),
+                        "branch": int(getattr(msg, "branch", 0)),
+                        "state_age_sec": _finite_float(getattr(msg, "state_age_sec", None)),
+                    }
+
+            def queue_status_cb(msg: Any) -> None:
+                with self._lock:
+                    self.queue_status = {
+                        "active": bool(getattr(msg, "active", False)),
+                        "guard_latched": bool(getattr(msg, "guard_latched", False)),
+                        "queue_depth": int(getattr(msg, "queue_depth", 0)),
+                        "time_unix": _finite_float(getattr(msg, "time", None)),
+                    }
+
+            def spectrometer_status_cb(msg: Any) -> None:
+                with self._lock:
+                    self.spectrometer_status = {
+                        "status": str(getattr(msg, "status", "")),
+                        "time_src": str(getattr(msg, "time_src", "")),
+                        "time_unix": _finite_float(getattr(msg, "time", None)),
+                    }
+
+            def chopper_status_cb(msg: Any) -> None:
+                position = _finite_float(getattr(msg, "position", None))
+                try:
+                    insert = bool(getattr(msg, "insert"))
+                except Exception:
+                    insert = None
+                try:
+                    insert_position = int(necst_config.chopper_motor_position["insert"])
+                    remove_position = int(necst_config.chopper_motor_position["remove"])
+                except Exception:
+                    insert_position = None
+                    remove_position = None
+                try:
+                    simulator_boolean_only = bool(getattr(necst_config, "simulator", False))
+                except Exception:
+                    simulator_boolean_only = False
+
+                if position is not None and insert_position is not None and int(position) == insert_position and insert is not False:
+                    state = "in"
+                elif position is not None and remove_position is not None and int(position) == remove_position and insert is not True:
+                    state = "out"
+                elif simulator_boolean_only and position == 0 and insert is True:
+                    state = "in"
+                elif simulator_boolean_only and position == 0 and insert is False:
+                    state = "out"
+                elif insert is True:
+                    state = "in?"
+                elif insert is False:
+                    state = "out?"
+                else:
+                    state = "unknown"
+                with self._lock:
+                    self.chopper_status = {
+                        "insert": insert,
+                        "state": state,
+                        "position": position,
+                        "time_unix": _finite_float(getattr(msg, "time", None)),
+                    }
+
+            def weather_cb(key: str):
+                def _callback(msg: Any) -> None:
+                    payload = {
+                        "temperature_k": _finite_float(getattr(msg, "temperature", None)),
+                        "pressure_hpa": _finite_float(getattr(msg, "pressure", None)),
+                        "humidity_percent": _finite_float(getattr(msg, "humidity", None)),
+                        "wind_speed_mps": _finite_float(getattr(msg, "wind_speed", None)),
+                        "wind_direction_deg": _finite_float(getattr(msg, "wind_direction", None)),
+                        "time_unix": _finite_float(getattr(msg, "time", None)),
+                    }
+                    with self._lock:
+                        self.weather[key] = payload
+
+                return _callback
+
+            topic.altaz_cmd.subscription(self._node, command_cb)
+            topic.antenna_encoder.subscription(self._node, encoder_cb)
+            try:
+                topic.antenna_tracking.subscription(self._node, tracking_cb)
+            except Exception:
+                pass
+            for topic_obj, callback in (
+                (getattr(topic, "antenna_pointing_status", None), pointing_status_cb),
+                (getattr(topic, "antenna_az_unwrap_status", None), az_unwrap_status_cb),
+                (getattr(topic, "antenna_command_queue_status", None), queue_status_cb),
+                (getattr(topic, "spectrometer_status", None), spectrometer_status_cb),
+                (getattr(topic, "chopper_status", None), chopper_status_cb),
+            ):
+                try:
+                    if topic_obj is not None:
+                        topic_obj.subscription(self._node, callback)
+                except Exception:
+                    pass
+            try:
+                topic.weather["out"].subscription(self._node, weather_cb("out"))
+                topic.weather["in"].subscription(self._node, weather_cb("in"))
+            except Exception:
+                pass
+            self.available = True
+            self._start_background_spin()
+        except Exception as exc:
+            self.available = False
+            self.error = str(exc)
+            try:
+                if self._node is not None:
+                    self._node.destroy_node()
+            except Exception:
+                pass
+            self._node = None
+
+    def _start_background_spin(self) -> None:
+        if not (self.available and self._rclpy is not None and self._node is not None):
+            return
+        try:
+            from rclpy.executors import MultiThreadedExecutor  # type: ignore
+
+            executor = MultiThreadedExecutor(num_threads=2)
+            executor.add_node(self._node)
+            self._executor = executor
+            self._spin_mode = "background-executor"
+            self._spin_thread = threading.Thread(
+                target=executor.spin,
+                name="necst-console-ros-spin",
+                daemon=True,
+            )
+            self._spin_thread.start()
+        except Exception as exc:
+            self._executor = None
+            self._spin_thread = None
+            self._spin_mode = "request-spin-fallback"
+            self.error = f"background ROS spin disabled: {exc}"
+
+    def spin_once(self, timeout_sec: float = 0.0) -> None:
+        if not (self.available and self._rclpy is not None and self._node is not None):
+            return
+        if self._executor is not None:
+            return
+        try:
+            self._rclpy.spin_once(self._node, timeout_sec=timeout_sec)
+        except Exception as exc:
+            self.error = str(exc)
+            self.available = False
+
+    def snapshot(self) -> Dict[str, Any]:
+        if self.available:
+            self.spin_once(timeout_sec=0.0)
+        with self._lock:
+            payload: Dict[str, Any] = {
+                "requested": self.requested,
+                "available": self.available,
+                "spin_mode": self._spin_mode,
+            }
+            if self.error:
+                payload["error"] = self.error
+            if self.command:
+                payload["command"] = dict(self.command)
+            if self.encoder:
+                payload["encoder"] = dict(self.encoder)
+            if self.tracking:
+                payload["tracking"] = dict(self.tracking)
+            if self.pointing_status:
+                payload["pointing_status"] = dict(self.pointing_status)
+            if self.az_unwrap_status:
+                payload["az_unwrap_status"] = dict(self.az_unwrap_status)
+            if self.queue_status:
+                payload["queue_status"] = dict(self.queue_status)
+            if self.chopper_status:
+                payload["chopper_status"] = dict(self.chopper_status)
+            if self.spectrometer_status:
+                payload["spectrometer_status"] = dict(self.spectrometer_status)
+            if self.weather:
+                payload["weather"] = {key: dict(value) for key, value in self.weather.items()}
+            return payload
+
+    def close(self) -> None:
+        try:
+            if self._executor is not None:
+                self._executor.shutdown()
+        except Exception:
+            pass
+        try:
+            if self._spin_thread is not None and self._spin_thread.is_alive():
+                self._spin_thread.join(timeout=1.0)
+        except Exception:
+            pass
+        try:
+            if self._node is not None:
+                self._node.destroy_node()
+        except Exception:
+            pass
+        try:
+            if self._owns_context and self._rclpy is not None and self._rclpy.ok():
+                self._rclpy.shutdown()
+        except Exception:
+            pass

--- a/necst/web/live_telemetry.py
+++ b/necst/web/live_telemetry.py
@@ -16,6 +16,10 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 
+ENCODER_MOTION_DEADBAND_DEG = 1.0e-4
+ENCODER_MOTION_HOLD_SEC = 1.0
+
+
 def _finite_float(value: Any) -> Optional[float]:
     try:
         out = float(value)
@@ -79,9 +83,13 @@ class LiveTelemetryCache:
 
         self.command: Dict[str, Any] = {}
         self.encoder: Dict[str, Any] = {}
+        self.encoder_motion: Dict[str, Any] = {}
+        self._previous_encoder_sample: Optional[Dict[str, float]] = None
+        self._last_significant_encoder_motion_unix: Optional[float] = None
         self.tracking: Dict[str, Any] = {}
         self.pointing_status: Dict[str, Any] = {}
         self.az_unwrap_status: Dict[str, Any] = {}
+        self.section_status: Dict[str, Any] = {}
         self.queue_status: Dict[str, Any] = {}
         self.chopper_status: Dict[str, Any] = {}
         self.spectrometer_status: Dict[str, Any] = {}
@@ -94,6 +102,57 @@ class LiveTelemetryCache:
         now = time.time()
         self._sample_counts[key] = int(self._sample_counts.get(key, 0)) + 1
         self._last_message_time_unix[key] = now
+
+    def _update_encoder_motion_locked(self, payload: Dict[str, Any]) -> None:
+        """Estimate actual antenna motion from encoder samples with deadband.
+
+        Encoder readout often jitters in the low-order digits even when the
+        antenna is physically stopped.  This fallback therefore ignores changes
+        at or below 1e-4 deg and is used only as a secondary source when no
+        fresher explicit motion/section status is available.
+        """
+
+        now = time.time()
+        lon = _finite_float(payload.get("encoder_lon_deg"))
+        lat = _finite_float(payload.get("encoder_lat_deg"))
+        if lon is None or lat is None:
+            self.encoder_motion = {
+                "moving": False,
+                "source": "encoder_unavailable",
+                "deadband_deg": ENCODER_MOTION_DEADBAND_DEG,
+                "time_unix": now,
+            }
+            return
+
+        previous = self._previous_encoder_sample
+        delta_az = None
+        delta_el = None
+        significant = False
+        if previous is not None:
+            delta_az = abs(lon - previous.get("lon", lon))
+            delta_el = abs(lat - previous.get("lat", lat))
+            significant = bool(
+                delta_az > ENCODER_MOTION_DEADBAND_DEG
+                or delta_el > ENCODER_MOTION_DEADBAND_DEG
+            )
+
+        if significant:
+            self._last_significant_encoder_motion_unix = now
+        held = bool(
+            self._last_significant_encoder_motion_unix is not None
+            and now - self._last_significant_encoder_motion_unix <= ENCODER_MOTION_HOLD_SEC
+        )
+        moving = bool(significant or held)
+        self.encoder_motion = {
+            "moving": moving,
+            "source": "encoder_delta" if moving else "encoder_delta_deadband",
+            "delta_az_deg": delta_az,
+            "delta_el_deg": delta_el,
+            "deadband_deg": ENCODER_MOTION_DEADBAND_DEG,
+            "hold_sec": ENCODER_MOTION_HOLD_SEC,
+            "time_unix": now,
+        }
+        self._previous_encoder_sample = {"lon": lon, "lat": lat, "time_unix": now}
 
     def _has_position_locked(self) -> bool:
         enc_lon = _finite_float(self.encoder.get("encoder_lon_deg"))
@@ -146,6 +205,7 @@ class LiveTelemetryCache:
             def encoder_cb(msg: Any) -> None:
                 with self._lock:
                     self.encoder = _msg_coord(msg, prefix="encoder")
+                    self._update_encoder_motion_locked(self.encoder)
                     self._record_sample_locked("encoder")
 
             def tracking_cb(msg: Any) -> None:
@@ -181,6 +241,26 @@ class LiveTelemetryCache:
                         "basis": str(getattr(msg, "basis", "")),
                     }
                     self._record_sample_locked("pointing_status")
+
+            def section_status_cb(msg: Any) -> None:
+                try:
+                    line_index = int(getattr(msg, "line_index", -1))
+                except Exception:
+                    line_index = -1
+                with self._lock:
+                    self.section_status = {
+                        "active": bool(getattr(msg, "active", False)),
+                        "control_id": str(getattr(msg, "control_id", "")),
+                        "section_uid": str(getattr(msg, "section_uid", "")),
+                        "section_kind": str(getattr(msg, "section_kind", "")),
+                        "section_label": str(getattr(msg, "section_label", "")),
+                        "line_index": line_index,
+                        "publish_time_unix": _finite_float(getattr(msg, "publish_time_unix", None)),
+                        "query_time_unix": _finite_float(getattr(msg, "query_time_unix", None)),
+                        "command_time_unix": _finite_float(getattr(msg, "command_time_unix", None)),
+                        "status_basis": str(getattr(msg, "status_basis", "")),
+                    }
+                    self._record_sample_locked("section_status")
 
             def az_unwrap_status_cb(msg: Any) -> None:
                 with self._lock:
@@ -282,6 +362,7 @@ class LiveTelemetryCache:
             except Exception:
                 pass
             for topic_obj, callback in (
+                (getattr(topic, "antenna_section_status", None), section_status_cb),
                 (getattr(topic, "antenna_az_unwrap_status", None), az_unwrap_status_cb),
                 (getattr(topic, "antenna_command_queue_status", None), queue_status_cb),
                 (getattr(topic, "spectrometer_status", None), spectrometer_status_cb),
@@ -379,6 +460,8 @@ class LiveTelemetryCache:
                 payload["command"] = dict(self.command)
             if self.encoder:
                 payload["encoder"] = dict(self.encoder)
+            if self.encoder_motion:
+                payload["encoder_motion"] = dict(self.encoder_motion)
             if self.tracking:
                 payload["tracking"] = dict(self.tracking)
             # AntennaPointingStatus is intentionally not exposed to the operator
@@ -386,6 +469,8 @@ class LiveTelemetryCache:
             # drive Command Az/El, Tracking, or Moving display.
             if self.az_unwrap_status:
                 payload["az_unwrap_status"] = dict(self.az_unwrap_status)
+            if self.section_status:
+                payload["section_status"] = dict(self.section_status)
             if self.queue_status:
                 payload["queue_status"] = dict(self.queue_status)
             if self.chopper_status:

--- a/necst/web/live_telemetry.py
+++ b/necst/web/live_telemetry.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import math
 import sys
 import threading
+import time
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -72,6 +73,9 @@ class LiveTelemetryCache:
         self._owns_context = False
         self._lock = threading.RLock()
         self._spin_mode = "disabled"
+        self._started_at_unix = time.time()
+        self._sample_counts: Dict[str, int] = {}
+        self._last_message_time_unix: Dict[str, float] = {}
 
         self.command: Dict[str, Any] = {}
         self.encoder: Dict[str, Any] = {}
@@ -85,6 +89,43 @@ class LiveTelemetryCache:
 
         if self.requested:
             self._start()
+
+    def _record_sample_locked(self, key: str) -> None:
+        now = time.time()
+        self._sample_counts[key] = int(self._sample_counts.get(key, 0)) + 1
+        self._last_message_time_unix[key] = now
+
+    def _has_position_locked(self) -> bool:
+        enc_lon = _finite_float(self.encoder.get("encoder_lon_deg"))
+        enc_lat = _finite_float(self.encoder.get("encoder_lat_deg"))
+        if enc_lon is not None and enc_lat is not None:
+            return True
+        pointing_az = _finite_float(self.pointing_status.get("enc_az_deg"))
+        pointing_el = _finite_float(self.pointing_status.get("enc_el_deg"))
+        return pointing_az is not None and pointing_el is not None
+
+    def has_position(self) -> bool:
+        with self._lock:
+            return self._has_position_locked()
+
+    def wait_for_initial_position(self, timeout_sec: float = 2.0) -> bool:
+        """Wait briefly for the first encoder/pointing sample after startup.
+
+        This prevents the console from starting with empty/demo Current Az/El
+        simply because subscriptions have not yet received their first samples.
+        It is read-only and does not send any telescope command.
+        """
+
+        if not self.available:
+            return False
+        deadline = time.monotonic() + max(0.0, float(timeout_sec))
+        while time.monotonic() <= deadline:
+            if self.has_position():
+                return True
+            self.spin_once(timeout_sec=0.05)
+            if self._executor is not None and self._spin_thread is not None and self._spin_thread.is_alive():
+                time.sleep(0.05)
+        return self.has_position()
 
     def _start(self) -> None:
         try:
@@ -104,10 +145,12 @@ class LiveTelemetryCache:
             def command_cb(msg: Any) -> None:
                 with self._lock:
                     self.command = _msg_coord(msg, prefix="command")
+                    self._record_sample_locked("command")
 
             def encoder_cb(msg: Any) -> None:
                 with self._lock:
                     self.encoder = _msg_coord(msg, prefix="encoder")
+                    self._record_sample_locked("encoder")
 
             def tracking_cb(msg: Any) -> None:
                 with self._lock:
@@ -116,6 +159,7 @@ class LiveTelemetryCache:
                         "error_deg": _finite_float(getattr(msg, "error", None)),
                         "time_unix": _finite_float(getattr(msg, "time", None)),
                     }
+                    self._record_sample_locked("tracking")
 
             def pointing_status_cb(msg: Any) -> None:
                 with self._lock:
@@ -140,6 +184,7 @@ class LiveTelemetryCache:
                         "encoder_stale": bool(getattr(msg, "encoder_stale", False)),
                         "basis": str(getattr(msg, "basis", "")),
                     }
+                    self._record_sample_locked("pointing_status")
 
             def az_unwrap_status_cb(msg: Any) -> None:
                 with self._lock:
@@ -157,6 +202,7 @@ class LiveTelemetryCache:
                         "branch": int(getattr(msg, "branch", 0)),
                         "state_age_sec": _finite_float(getattr(msg, "state_age_sec", None)),
                     }
+                    self._record_sample_locked("az_unwrap_status")
 
             def queue_status_cb(msg: Any) -> None:
                 with self._lock:
@@ -166,6 +212,7 @@ class LiveTelemetryCache:
                         "queue_depth": int(getattr(msg, "queue_depth", 0)),
                         "time_unix": _finite_float(getattr(msg, "time", None)),
                     }
+                    self._record_sample_locked("queue_status")
 
             def spectrometer_status_cb(msg: Any) -> None:
                 with self._lock:
@@ -174,6 +221,7 @@ class LiveTelemetryCache:
                         "time_src": str(getattr(msg, "time_src", "")),
                         "time_unix": _finite_float(getattr(msg, "time", None)),
                     }
+                    self._record_sample_locked("spectrometer_status")
 
             def chopper_status_cb(msg: Any) -> None:
                 position = _finite_float(getattr(msg, "position", None))
@@ -213,6 +261,7 @@ class LiveTelemetryCache:
                         "position": position,
                         "time_unix": _finite_float(getattr(msg, "time", None)),
                     }
+                    self._record_sample_locked("chopper_status")
 
             def weather_cb(key: str):
                 def _callback(msg: Any) -> None:
@@ -226,6 +275,7 @@ class LiveTelemetryCache:
                     }
                     with self._lock:
                         self.weather[key] = payload
+                        self._record_sample_locked(f"weather/{key}")
 
                 return _callback
 
@@ -290,7 +340,18 @@ class LiveTelemetryCache:
         if not (self.available and self._rclpy is not None and self._node is not None):
             return
         if self._executor is not None:
-            return
+            if self._spin_thread is not None and self._spin_thread.is_alive():
+                return
+            # The background executor was created but is no longer spinning.
+            # Fall back to request-thread spin_once so /api/status keeps
+            # telemetry alive instead of freezing until a GUI action happens.
+            try:
+                self._executor.shutdown()
+            except Exception:
+                pass
+            self._executor = None
+            self._spin_thread = None
+            self._spin_mode = "request-spin-fallback-after-thread-exit"
         try:
             self._rclpy.spin_once(self._node, timeout_sec=timeout_sec)
         except Exception as exc:
@@ -301,10 +362,21 @@ class LiveTelemetryCache:
         if self.available:
             self.spin_once(timeout_sec=0.0)
         with self._lock:
+            now = time.time()
+            last_age_sec = {
+                key: max(0.0, now - float(ts))
+                for key, ts in self._last_message_time_unix.items()
+            }
             payload: Dict[str, Any] = {
                 "requested": self.requested,
                 "available": self.available,
                 "spin_mode": self._spin_mode,
+                "uptime_sec": max(0.0, now - self._started_at_unix),
+                "has_position": self._has_position_locked(),
+                "sample_counts": dict(self._sample_counts),
+                "last_message_time_unix": dict(self._last_message_time_unix),
+                "last_message_age_sec": last_age_sec,
+                "received_topics": sorted(self._sample_counts),
             }
             if self.error:
                 payload["error"] = self.error

--- a/necst/web/live_telemetry.py
+++ b/necst/web/live_telemetry.py
@@ -17,7 +17,6 @@ from typing import Any, Dict, List, Optional
 
 from . import node_health
 
-
 ENCODER_MOTION_DEADBAND_DEG = 5.0e-4
 ENCODER_MOTION_START_CUMULATIVE_DEG = 8.0e-4
 ENCODER_MOTION_HOLD_SEC = 0.8
@@ -68,7 +67,9 @@ def _msg_coord(msg: Any, *, prefix: str) -> Dict[str, Any]:
 class LiveTelemetryCache:
     """Read-only ROS status cache for current antenna/chopper console display."""
 
-    def __init__(self, *, enabled: bool = True, node_name: str = "necst_operator_console_status") -> None:
+    def __init__(
+        self, *, enabled: bool = True, node_name: str = "necst_operator_console_status"
+    ) -> None:
         self.requested = bool(enabled)
         self.available = False
         self.error: Optional[str] = None
@@ -138,7 +139,8 @@ class LiveTelemetryCache:
         cumulative_start_significant = False
         was_recently_moving = bool(
             self._last_significant_encoder_motion_unix is not None
-            and now - self._last_significant_encoder_motion_unix <= ENCODER_MOTION_HOLD_SEC
+            and now - self._last_significant_encoder_motion_unix
+            <= ENCODER_MOTION_HOLD_SEC
         )
         if previous is not None:
             delta_az = abs(lon - previous.get("lon", lon))
@@ -178,7 +180,8 @@ class LiveTelemetryCache:
             self._last_significant_encoder_motion_unix = now
         held = bool(
             self._last_significant_encoder_motion_unix is not None
-            and now - self._last_significant_encoder_motion_unix <= ENCODER_MOTION_HOLD_SEC
+            and now - self._last_significant_encoder_motion_unix
+            <= ENCODER_MOTION_HOLD_SEC
         )
         moving = bool(significant or held)
         if self._encoder_motion_anchor is None or (was_recently_moving and not moving):
@@ -222,7 +225,11 @@ class LiveTelemetryCache:
             if self.has_position():
                 return True
             self.spin_once(timeout_sec=0.05)
-            if self._executor is not None and self._spin_thread is not None and self._spin_thread.is_alive():
+            if (
+                self._executor is not None
+                and self._spin_thread is not None
+                and self._spin_thread.is_alive()
+            ):
                 time.sleep(0.05)
         return self.has_position()
 
@@ -265,18 +272,34 @@ class LiveTelemetryCache:
                 with self._lock:
                     self.pointing_status = {
                         "valid": bool(getattr(msg, "valid", False)),
-                        "publish_time_unix": _finite_float(getattr(msg, "publish_time_unix", None)),
-                        "command_time_unix": _finite_float(getattr(msg, "command_time_unix", None)),
-                        "encoder_time_unix": _finite_float(getattr(msg, "encoder_time_unix", None)),
+                        "publish_time_unix": _finite_float(
+                            getattr(msg, "publish_time_unix", None)
+                        ),
+                        "command_time_unix": _finite_float(
+                            getattr(msg, "command_time_unix", None)
+                        ),
+                        "encoder_time_unix": _finite_float(
+                            getattr(msg, "encoder_time_unix", None)
+                        ),
                         "cmd_az_deg": _finite_float(getattr(msg, "cmd_az_deg", None)),
                         "cmd_el_deg": _finite_float(getattr(msg, "cmd_el_deg", None)),
                         "enc_az_deg": _finite_float(getattr(msg, "enc_az_deg", None)),
                         "enc_el_deg": _finite_float(getattr(msg, "enc_el_deg", None)),
-                        "delta_az_deg": _finite_float(getattr(msg, "delta_az_deg", None)),
-                        "delta_el_deg": _finite_float(getattr(msg, "delta_el_deg", None)),
-                        "delta_az_cos_el_deg": _finite_float(getattr(msg, "delta_az_cos_el_deg", None)),
-                        "tracking_error_deg": _finite_float(getattr(msg, "tracking_error_deg", None)),
-                        "tracking_threshold_deg": _finite_float(getattr(msg, "tracking_threshold_deg", None)),
+                        "delta_az_deg": _finite_float(
+                            getattr(msg, "delta_az_deg", None)
+                        ),
+                        "delta_el_deg": _finite_float(
+                            getattr(msg, "delta_el_deg", None)
+                        ),
+                        "delta_az_cos_el_deg": _finite_float(
+                            getattr(msg, "delta_az_cos_el_deg", None)
+                        ),
+                        "tracking_error_deg": _finite_float(
+                            getattr(msg, "tracking_error_deg", None)
+                        ),
+                        "tracking_threshold_deg": _finite_float(
+                            getattr(msg, "tracking_threshold_deg", None)
+                        ),
                         "tracking_ok": bool(getattr(msg, "tracking_ok", False)),
                         "cmd_age_sec": _finite_float(getattr(msg, "cmd_age_sec", None)),
                         "enc_age_sec": _finite_float(getattr(msg, "enc_age_sec", None)),
@@ -299,9 +322,15 @@ class LiveTelemetryCache:
                         "section_kind": str(getattr(msg, "section_kind", "")),
                         "section_label": str(getattr(msg, "section_label", "")),
                         "line_index": line_index,
-                        "publish_time_unix": _finite_float(getattr(msg, "publish_time_unix", None)),
-                        "query_time_unix": _finite_float(getattr(msg, "query_time_unix", None)),
-                        "command_time_unix": _finite_float(getattr(msg, "command_time_unix", None)),
+                        "publish_time_unix": _finite_float(
+                            getattr(msg, "publish_time_unix", None)
+                        ),
+                        "query_time_unix": _finite_float(
+                            getattr(msg, "query_time_unix", None)
+                        ),
+                        "command_time_unix": _finite_float(
+                            getattr(msg, "command_time_unix", None)
+                        ),
                         "status_basis": str(getattr(msg, "status_basis", "")),
                     }
                     self._record_sample_locked("section_status")
@@ -314,13 +343,23 @@ class LiveTelemetryCache:
                         "mode": str(getattr(msg, "mode", "")),
                         "state": str(getattr(msg, "state", "")),
                         "reason": str(getattr(msg, "reason", "")),
-                        "publish_time_unix": _finite_float(getattr(msg, "publish_time_unix", None)),
-                        "encoder_time_unix": _finite_float(getattr(msg, "encoder_time_unix", None)),
+                        "publish_time_unix": _finite_float(
+                            getattr(msg, "publish_time_unix", None)
+                        ),
+                        "encoder_time_unix": _finite_float(
+                            getattr(msg, "encoder_time_unix", None)
+                        ),
                         "raw_az_deg": _finite_float(getattr(msg, "raw_az_deg", None)),
-                        "modulo_az_deg": _finite_float(getattr(msg, "modulo_az_deg", None)),
-                        "continuous_az_deg": _finite_float(getattr(msg, "continuous_az_deg", None)),
+                        "modulo_az_deg": _finite_float(
+                            getattr(msg, "modulo_az_deg", None)
+                        ),
+                        "continuous_az_deg": _finite_float(
+                            getattr(msg, "continuous_az_deg", None)
+                        ),
                         "branch": int(getattr(msg, "branch", 0)),
-                        "state_age_sec": _finite_float(getattr(msg, "state_age_sec", None)),
+                        "state_age_sec": _finite_float(
+                            getattr(msg, "state_age_sec", None)
+                        ),
                     }
                     self._record_sample_locked("az_unwrap_status")
 
@@ -356,13 +395,25 @@ class LiveTelemetryCache:
                     insert_position = None
                     remove_position = None
                 try:
-                    simulator_boolean_only = bool(getattr(necst_config, "simulator", False))
+                    simulator_boolean_only = bool(
+                        getattr(necst_config, "simulator", False)
+                    )
                 except Exception:
                     simulator_boolean_only = False
 
-                if position is not None and insert_position is not None and int(position) == insert_position and insert is not False:
+                if (
+                    position is not None
+                    and insert_position is not None
+                    and int(position) == insert_position
+                    and insert is not False
+                ):
                     state = "in"
-                elif position is not None and remove_position is not None and int(position) == remove_position and insert is not True:
+                elif (
+                    position is not None
+                    and remove_position is not None
+                    and int(position) == remove_position
+                    and insert is not True
+                ):
                     state = "out"
                 elif simulator_boolean_only and position == 0 and insert is True:
                     state = "in"
@@ -386,11 +437,19 @@ class LiveTelemetryCache:
             def weather_cb(key: str):
                 def _callback(msg: Any) -> None:
                     payload = {
-                        "temperature_k": _finite_float(getattr(msg, "temperature", None)),
+                        "temperature_k": _finite_float(
+                            getattr(msg, "temperature", None)
+                        ),
                         "pressure_hpa": _finite_float(getattr(msg, "pressure", None)),
-                        "humidity_percent": _finite_float(getattr(msg, "humidity", None)),
-                        "wind_speed_mps": _finite_float(getattr(msg, "wind_speed", None)),
-                        "wind_direction_deg": _finite_float(getattr(msg, "wind_direction", None)),
+                        "humidity_percent": _finite_float(
+                            getattr(msg, "humidity", None)
+                        ),
+                        "wind_speed_mps": _finite_float(
+                            getattr(msg, "wind_speed", None)
+                        ),
+                        "wind_direction_deg": _finite_float(
+                            getattr(msg, "wind_direction", None)
+                        ),
                         "time_unix": _finite_float(getattr(msg, "time", None)),
                     }
                     with self._lock:
@@ -495,8 +554,7 @@ class LiveTelemetryCache:
             self.error = f"failed to read ROS graph node list: {exc}"
             raise
         names = [
-            node_health.full_node_name(name, namespace)
-            for name, namespace in pairs
+            node_health.full_node_name(name, namespace) for name, namespace in pairs
         ]
         return sorted(name for name in names if name)
 
@@ -544,7 +602,9 @@ class LiveTelemetryCache:
             if self.spectrometer_status:
                 payload["spectrometer_status"] = dict(self.spectrometer_status)
             if self.weather:
-                payload["weather"] = {key: dict(value) for key, value in self.weather.items()}
+                payload["weather"] = {
+                    key: dict(value) for key, value in self.weather.items()
+                }
             return payload
 
     def close(self) -> None:

--- a/necst/web/log_reader.py
+++ b/necst/web/log_reader.py
@@ -1,220 +1,160 @@
-"""Read-only log access helpers for the NECST Operator Console.
-
-The operator console writes two kinds of local logs:
-
-* operator_console.jsonl: one JSON object per accepted/rejected operator action;
-* launcher stdout/stderr logs: local child-process output captured by the console.
-
-This module only reads files that are explicitly configured by the running
-console process.  It never follows arbitrary browser-supplied paths outside the
-configured log roots.
-"""
+"""Small, safe log readers for the NECST operator console."""
 
 from __future__ import annotations
 
 import json
 import os
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Mapping, Optional
 
 
-JsonDict = Dict[str, Any]
-
-
-def _coerce_limit(value: Any, *, default: int, minimum: int = 1, maximum: int = 1000) -> int:
+def _tail_lines(path: Path, *, limit: int = 100) -> List[str]:
+    limit = max(1, min(int(limit), 5000))
     try:
-        number = int(value)
+        with path.open("r", encoding="utf-8", errors="replace") as fh:
+            lines = fh.readlines()
+        return [line.rstrip("\n") for line in lines[-limit:]]
     except Exception:
-        number = int(default)
-    return max(int(minimum), min(int(maximum), number))
-
-
-def _coerce_max_bytes(value: Any, *, default: int = 32768, maximum: int = 262144) -> int:
-    try:
-        number = int(value)
-    except Exception:
-        number = int(default)
-    return max(1, min(int(maximum), number))
-
-
-def _tail_lines(path: Path, *, limit: int) -> List[str]:
-    """Return the last ``limit`` lines without assuming the file is small."""
-
-    if limit <= 0:
         return []
-    # The operator log is normally small, but avoid unbounded memory use.
-    block_size = 8192
-    chunks: List[bytes] = []
-    newline_count = 0
-    with path.open("rb") as fh:
-        fh.seek(0, os.SEEK_END)
-        pos = fh.tell()
-        while pos > 0 and newline_count <= limit:
-            read_size = min(block_size, pos)
-            pos -= read_size
-            fh.seek(pos)
-            chunk = fh.read(read_size)
-            chunks.append(chunk)
-            newline_count += chunk.count(b"\n")
-    data = b"".join(reversed(chunks))
-    text = data.decode("utf-8", errors="replace")
-    return text.splitlines()[-limit:]
 
 
-def read_operator_log(path: Optional[Path], *, limit: Any = 100) -> JsonDict:
-    """Read the tail of ``operator_console.jsonl`` as parsed JSON entries."""
-
-    n = _coerce_limit(limit, default=100, maximum=1000)
-    if path is None:
-        return {
-            "ok": False,
-            "reason": "operator log path is not configured",
-            "path": None,
-            "entries": [],
-        }
-    log_path = Path(path)
-    if not log_path.exists():
-        return {
-            "ok": True,
-            "reason": "operator log file does not exist yet",
-            "path": str(log_path),
-            "entries": [],
-            "line_count": 0,
-        }
-    if not log_path.is_file():
-        return {
-            "ok": False,
-            "reason": "operator log path is not a regular file",
-            "path": str(log_path),
-            "entries": [],
-        }
-    entries: List[JsonDict] = []
-    parse_errors: List[JsonDict] = []
-    lines = _tail_lines(log_path, limit=n)
-    start_line = None
-    try:
-        # Only used for display context; bounded file-tail parsing remains above.
-        with log_path.open("rb") as fh:
-            total_lines = sum(1 for _ in fh)
-        start_line = max(1, total_lines - len(lines) + 1)
-    except Exception:
-        total_lines = None
-    for idx, line in enumerate(lines, start=start_line or 1):
+def read_operator_log(path_value: Any, *, limit: Any = 100) -> Dict[str, Any]:
+    if path_value in (None, ""):
+        return {"ok": False, "reason": "operator log path is not configured", "entries": []}
+    path = Path(str(path_value)).expanduser()
+    if not path.exists():
+        return {"ok": True, "reason": "operator log does not exist yet", "path": str(path), "entries": []}
+    entries: List[Dict[str, Any]] = []
+    parse_errors = 0
+    for line in _tail_lines(path, limit=int(limit or 100)):
         if not line.strip():
             continue
         try:
             payload = json.loads(line)
             if isinstance(payload, dict):
-                payload.setdefault("_line", idx)
                 entries.append(payload)
             else:
-                parse_errors.append({"line": idx, "reason": "JSON value is not an object"})
-        except Exception as exc:
-            parse_errors.append({"line": idx, "reason": str(exc), "text": line[:200]})
+                entries.append({"message": str(payload)})
+        except Exception:
+            parse_errors += 1
+            entries.append({"message": line, "parse_error": True})
     return {
-        "ok": not bool(parse_errors),
-        "reason": "operator log read" if not parse_errors else "operator log read with parse warnings",
-        "path": str(log_path),
+        "ok": True,
+        "reason": f"read {len(entries)} operator log entrie(s)",
+        "path": str(path),
         "entries": entries,
         "parse_errors": parse_errors,
-        "requested_limit": n,
-        "returned_count": len(entries),
-        "line_count": total_lines,
     }
 
 
-def _safe_relative_to(path: Path, root: Path) -> bool:
-    try:
-        path.resolve().relative_to(root.resolve())
-        return True
-    except Exception:
-        return False
-
-
-def _allowed_log_path(
-    requested: Any,
+def _allowed_paths(
     *,
     launcher_log_dir: Optional[Path],
     operator_log_path: Optional[Path],
     extra_roots: Optional[Iterable[Path]] = None,
-) -> Tuple[Optional[Path], Optional[str]]:
-    if requested in (None, ""):
-        return None, "log path is empty"
-    candidate = Path(str(requested)).expanduser()
-    if not candidate.is_absolute():
-        return None, "log path must be absolute"
+) -> List[Path]:
     roots: List[Path] = []
-    if launcher_log_dir is not None:
-        roots.append(Path(launcher_log_dir))
+    for item in (launcher_log_dir,):
+        if item is not None:
+            roots.append(Path(item).expanduser())
     if operator_log_path is not None:
-        roots.append(Path(operator_log_path).parent)
-    if extra_roots is not None:
-        roots.extend(Path(root) for root in extra_roots)
-    candidate_resolved = candidate.resolve()
+        roots.append(Path(operator_log_path).expanduser().parent)
+    for item in extra_roots or []:
+        if item is not None:
+            roots.append(Path(item).expanduser())
+    out: List[Path] = []
+    seen = set()
     for root in roots:
-        if _safe_relative_to(candidate_resolved, Path(root)):
-            return candidate_resolved, None
-    return None, "requested log path is outside configured console log directories"
+        try:
+            key = str(root.resolve())
+        except Exception:
+            key = str(root)
+        if key not in seen:
+            seen.add(key)
+            out.append(root)
+    return out
+
+
+def _resolve_safe_log_path(
+    path_value: Any,
+    *,
+    launcher_log_dir: Optional[Path],
+    operator_log_path: Optional[Path],
+    extra_roots: Optional[Iterable[Path]] = None,
+) -> Path:
+    raw = str(path_value or "").strip()
+    if not raw:
+        raise ValueError("log file path is empty")
+    path = Path(raw).expanduser()
+    roots = _allowed_paths(launcher_log_dir=launcher_log_dir, operator_log_path=operator_log_path, extra_roots=extra_roots)
+    if not path.is_absolute():
+        if any(part == ".." for part in path.parts):
+            raise ValueError("relative log path must not contain '..'")
+        if launcher_log_dir is None:
+            raise ValueError("relative log path requires launcher_log_dir")
+        path = Path(launcher_log_dir).expanduser() / path
+    resolved = path.resolve()
+    for root in roots:
+        try:
+            resolved.relative_to(root.resolve())
+            return resolved
+        except Exception:
+            continue
+    raise ValueError(f"log path is outside allowed log directories: {path}")
 
 
 def read_text_log(
-    requested_path: Any,
+    path_value: Any,
     *,
     launcher_log_dir: Optional[Path],
     operator_log_path: Optional[Path],
     max_bytes: Any = 32768,
     extra_roots: Optional[Iterable[Path]] = None,
-) -> JsonDict:
-    """Read the tail of an allowed local text log file."""
-
-    path, error = _allowed_log_path(
-        requested_path,
-        launcher_log_dir=launcher_log_dir,
-        operator_log_path=operator_log_path,
-        extra_roots=extra_roots,
-    )
-    if error is not None or path is None:
-        return {"ok": False, "reason": error or "invalid log path", "path": str(requested_path or "")}
-    if not path.exists():
-        return {"ok": False, "reason": "log file does not exist", "path": str(path)}
-    if not path.is_file():
-        return {"ok": False, "reason": "log path is not a regular file", "path": str(path)}
-    size = path.stat().st_size
-    nbytes = _coerce_max_bytes(max_bytes)
-    with path.open("rb") as fh:
-        if size > nbytes:
-            fh.seek(size - nbytes)
-            raw = fh.read(nbytes)
-            truncated = True
-        else:
-            raw = fh.read()
-            truncated = False
-    return {
-        "ok": True,
-        "reason": "log file read",
-        "path": str(path),
-        "size_bytes": size,
-        "returned_bytes": len(raw),
-        "truncated_head": truncated,
-        "text": raw.decode("utf-8", errors="replace"),
-    }
+) -> Dict[str, Any]:
+    try:
+        path = _resolve_safe_log_path(
+            path_value,
+            launcher_log_dir=launcher_log_dir,
+            operator_log_path=operator_log_path,
+            extra_roots=extra_roots,
+        )
+        max_b = max(1024, min(int(max_bytes or 32768), 1024 * 1024))
+        if not path.exists() or not path.is_file():
+            return {"ok": False, "reason": f"log file does not exist: {path}", "path": str(path)}
+        size = path.stat().st_size
+        with path.open("rb") as fh:
+            if size > max_b:
+                fh.seek(size - max_b)
+            data = fh.read(max_b)
+        return {
+            "ok": True,
+            "reason": "log file read",
+            "path": str(path),
+            "text": data.decode("utf-8", errors="replace"),
+            "size_bytes": size,
+            "returned_bytes": len(data),
+            "truncated_head": size > max_b,
+        }
+    except Exception as exc:
+        return {"ok": False, "reason": str(exc), "path": str(path_value or "")}
 
 
-def launcher_log_choices(processes: Iterable[Mapping[str, Any]]) -> List[JsonDict]:
-    """Return stdout/stderr paths from process records for UI display."""
-
-    out: List[JsonDict] = []
-    for record in processes:
+def launcher_log_choices(process_records: Iterable[Mapping[str, Any]]) -> List[Dict[str, Any]]:
+    choices: List[Dict[str, Any]] = []
+    for record in process_records or []:
+        if not isinstance(record, Mapping):
+            continue
+        label = str(record.get("label") or record.get("category") or "launcher")
         pid = record.get("pid")
-        label = record.get("label") or record.get("action") or "launcher"
         for stream, key in (("stdout", "stdout_path"), ("stderr", "stderr_path")):
             path = record.get(key)
-            if path:
-                out.append({
-                    "pid": pid,
-                    "label": label,
-                    "stream": stream,
-                    "path": path,
-                    "status": record.get("status"),
-                })
-    return out
+            if not path:
+                continue
+            choices.append({
+                "label": f"{label} pid={pid} {stream}",
+                "path": str(path),
+                "stream": stream,
+                "pid": pid,
+                "category": record.get("category"),
+            })
+    return choices

--- a/necst/web/log_reader.py
+++ b/necst/web/log_reader.py
@@ -1,0 +1,220 @@
+"""Read-only log access helpers for the NECST Operator Console.
+
+The operator console writes two kinds of local logs:
+
+* operator_console.jsonl: one JSON object per accepted/rejected operator action;
+* launcher stdout/stderr logs: local child-process output captured by the console.
+
+This module only reads files that are explicitly configured by the running
+console process.  It never follows arbitrary browser-supplied paths outside the
+configured log roots.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
+
+
+JsonDict = Dict[str, Any]
+
+
+def _coerce_limit(value: Any, *, default: int, minimum: int = 1, maximum: int = 1000) -> int:
+    try:
+        number = int(value)
+    except Exception:
+        number = int(default)
+    return max(int(minimum), min(int(maximum), number))
+
+
+def _coerce_max_bytes(value: Any, *, default: int = 32768, maximum: int = 262144) -> int:
+    try:
+        number = int(value)
+    except Exception:
+        number = int(default)
+    return max(1, min(int(maximum), number))
+
+
+def _tail_lines(path: Path, *, limit: int) -> List[str]:
+    """Return the last ``limit`` lines without assuming the file is small."""
+
+    if limit <= 0:
+        return []
+    # The operator log is normally small, but avoid unbounded memory use.
+    block_size = 8192
+    chunks: List[bytes] = []
+    newline_count = 0
+    with path.open("rb") as fh:
+        fh.seek(0, os.SEEK_END)
+        pos = fh.tell()
+        while pos > 0 and newline_count <= limit:
+            read_size = min(block_size, pos)
+            pos -= read_size
+            fh.seek(pos)
+            chunk = fh.read(read_size)
+            chunks.append(chunk)
+            newline_count += chunk.count(b"\n")
+    data = b"".join(reversed(chunks))
+    text = data.decode("utf-8", errors="replace")
+    return text.splitlines()[-limit:]
+
+
+def read_operator_log(path: Optional[Path], *, limit: Any = 100) -> JsonDict:
+    """Read the tail of ``operator_console.jsonl`` as parsed JSON entries."""
+
+    n = _coerce_limit(limit, default=100, maximum=1000)
+    if path is None:
+        return {
+            "ok": False,
+            "reason": "operator log path is not configured",
+            "path": None,
+            "entries": [],
+        }
+    log_path = Path(path)
+    if not log_path.exists():
+        return {
+            "ok": True,
+            "reason": "operator log file does not exist yet",
+            "path": str(log_path),
+            "entries": [],
+            "line_count": 0,
+        }
+    if not log_path.is_file():
+        return {
+            "ok": False,
+            "reason": "operator log path is not a regular file",
+            "path": str(log_path),
+            "entries": [],
+        }
+    entries: List[JsonDict] = []
+    parse_errors: List[JsonDict] = []
+    lines = _tail_lines(log_path, limit=n)
+    start_line = None
+    try:
+        # Only used for display context; bounded file-tail parsing remains above.
+        with log_path.open("rb") as fh:
+            total_lines = sum(1 for _ in fh)
+        start_line = max(1, total_lines - len(lines) + 1)
+    except Exception:
+        total_lines = None
+    for idx, line in enumerate(lines, start=start_line or 1):
+        if not line.strip():
+            continue
+        try:
+            payload = json.loads(line)
+            if isinstance(payload, dict):
+                payload.setdefault("_line", idx)
+                entries.append(payload)
+            else:
+                parse_errors.append({"line": idx, "reason": "JSON value is not an object"})
+        except Exception as exc:
+            parse_errors.append({"line": idx, "reason": str(exc), "text": line[:200]})
+    return {
+        "ok": not bool(parse_errors),
+        "reason": "operator log read" if not parse_errors else "operator log read with parse warnings",
+        "path": str(log_path),
+        "entries": entries,
+        "parse_errors": parse_errors,
+        "requested_limit": n,
+        "returned_count": len(entries),
+        "line_count": total_lines,
+    }
+
+
+def _safe_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.resolve().relative_to(root.resolve())
+        return True
+    except Exception:
+        return False
+
+
+def _allowed_log_path(
+    requested: Any,
+    *,
+    launcher_log_dir: Optional[Path],
+    operator_log_path: Optional[Path],
+    extra_roots: Optional[Iterable[Path]] = None,
+) -> Tuple[Optional[Path], Optional[str]]:
+    if requested in (None, ""):
+        return None, "log path is empty"
+    candidate = Path(str(requested)).expanduser()
+    if not candidate.is_absolute():
+        return None, "log path must be absolute"
+    roots: List[Path] = []
+    if launcher_log_dir is not None:
+        roots.append(Path(launcher_log_dir))
+    if operator_log_path is not None:
+        roots.append(Path(operator_log_path).parent)
+    if extra_roots is not None:
+        roots.extend(Path(root) for root in extra_roots)
+    candidate_resolved = candidate.resolve()
+    for root in roots:
+        if _safe_relative_to(candidate_resolved, Path(root)):
+            return candidate_resolved, None
+    return None, "requested log path is outside configured console log directories"
+
+
+def read_text_log(
+    requested_path: Any,
+    *,
+    launcher_log_dir: Optional[Path],
+    operator_log_path: Optional[Path],
+    max_bytes: Any = 32768,
+    extra_roots: Optional[Iterable[Path]] = None,
+) -> JsonDict:
+    """Read the tail of an allowed local text log file."""
+
+    path, error = _allowed_log_path(
+        requested_path,
+        launcher_log_dir=launcher_log_dir,
+        operator_log_path=operator_log_path,
+        extra_roots=extra_roots,
+    )
+    if error is not None or path is None:
+        return {"ok": False, "reason": error or "invalid log path", "path": str(requested_path or "")}
+    if not path.exists():
+        return {"ok": False, "reason": "log file does not exist", "path": str(path)}
+    if not path.is_file():
+        return {"ok": False, "reason": "log path is not a regular file", "path": str(path)}
+    size = path.stat().st_size
+    nbytes = _coerce_max_bytes(max_bytes)
+    with path.open("rb") as fh:
+        if size > nbytes:
+            fh.seek(size - nbytes)
+            raw = fh.read(nbytes)
+            truncated = True
+        else:
+            raw = fh.read()
+            truncated = False
+    return {
+        "ok": True,
+        "reason": "log file read",
+        "path": str(path),
+        "size_bytes": size,
+        "returned_bytes": len(raw),
+        "truncated_head": truncated,
+        "text": raw.decode("utf-8", errors="replace"),
+    }
+
+
+def launcher_log_choices(processes: Iterable[Mapping[str, Any]]) -> List[JsonDict]:
+    """Return stdout/stderr paths from process records for UI display."""
+
+    out: List[JsonDict] = []
+    for record in processes:
+        pid = record.get("pid")
+        label = record.get("label") or record.get("action") or "launcher"
+        for stream, key in (("stdout", "stdout_path"), ("stderr", "stderr_path")):
+            path = record.get(key)
+            if path:
+                out.append({
+                    "pid": pid,
+                    "label": label,
+                    "stream": stream,
+                    "path": path,
+                    "status": record.get("status"),
+                })
+    return out

--- a/necst/web/log_reader.py
+++ b/necst/web/log_reader.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Mapping, Optional
 
@@ -20,10 +19,19 @@ def _tail_lines(path: Path, *, limit: int = 100) -> List[str]:
 
 def read_operator_log(path_value: Any, *, limit: Any = 100) -> Dict[str, Any]:
     if path_value in (None, ""):
-        return {"ok": False, "reason": "operator log path is not configured", "entries": []}
+        return {
+            "ok": False,
+            "reason": "operator log path is not configured",
+            "entries": [],
+        }
     path = Path(str(path_value)).expanduser()
     if not path.exists():
-        return {"ok": True, "reason": "operator log does not exist yet", "path": str(path), "entries": []}
+        return {
+            "ok": True,
+            "reason": "operator log does not exist yet",
+            "path": str(path),
+            "entries": [],
+        }
     entries: List[Dict[str, Any]] = []
     parse_errors = 0
     for line in _tail_lines(path, limit=int(limit or 100)):
@@ -86,7 +94,11 @@ def _resolve_safe_log_path(
     if not raw:
         raise ValueError("log file path is empty")
     path = Path(raw).expanduser()
-    roots = _allowed_paths(launcher_log_dir=launcher_log_dir, operator_log_path=operator_log_path, extra_roots=extra_roots)
+    roots = _allowed_paths(
+        launcher_log_dir=launcher_log_dir,
+        operator_log_path=operator_log_path,
+        extra_roots=extra_roots,
+    )
     if not path.is_absolute():
         if any(part == ".." for part in path.parts):
             raise ValueError("relative log path must not contain '..'")
@@ -120,7 +132,11 @@ def read_text_log(
         )
         max_b = max(1024, min(int(max_bytes or 32768), 1024 * 1024))
         if not path.exists() or not path.is_file():
-            return {"ok": False, "reason": f"log file does not exist: {path}", "path": str(path)}
+            return {
+                "ok": False,
+                "reason": f"log file does not exist: {path}",
+                "path": str(path),
+            }
         size = path.stat().st_size
         with path.open("rb") as fh:
             if size > max_b:
@@ -139,7 +155,9 @@ def read_text_log(
         return {"ok": False, "reason": str(exc), "path": str(path_value or "")}
 
 
-def launcher_log_choices(process_records: Iterable[Mapping[str, Any]]) -> List[Dict[str, Any]]:
+def launcher_log_choices(
+    process_records: Iterable[Mapping[str, Any]],
+) -> List[Dict[str, Any]]:
     choices: List[Dict[str, Any]] = []
     for record in process_records or []:
         if not isinstance(record, Mapping):
@@ -150,11 +168,13 @@ def launcher_log_choices(process_records: Iterable[Mapping[str, Any]]) -> List[D
             path = record.get(key)
             if not path:
                 continue
-            choices.append({
-                "label": f"{label} pid={pid} {stream}",
-                "path": str(path),
-                "stream": stream,
-                "pid": pid,
-                "category": record.get("category"),
-            })
+            choices.append(
+                {
+                    "label": f"{label} pid={pid} {stream}",
+                    "path": str(path),
+                    "stream": stream,
+                    "pid": pid,
+                    "category": record.get("category"),
+                }
+            )
     return choices

--- a/necst/web/node_health.py
+++ b/necst/web/node_health.py
@@ -1,0 +1,260 @@
+"""Read-only ROS node health evaluation for the operator console.
+
+Phase 1 intentionally checks only whether configured ROS node names are present
+in the ROS graph.  It never starts, stops, restarts, or kills any process.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+import math
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Set
+
+
+VALID_CLASSES = {
+    "manual_mount_required",
+    "observation_required",
+    "optional",
+    "debug",
+}
+
+
+@dataclass(frozen=True)
+class ExpectedNode:
+    name: str
+    label: str
+    node_class: str = "optional"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "label": self.label,
+            "class": self.node_class,
+        }
+
+
+@dataclass(frozen=True)
+class NodeHealthConfig:
+    enabled: bool = False
+    poll_interval_sec: float = 2.0
+    nodes: Sequence[ExpectedNode] = field(default_factory=tuple)
+    warnings: Sequence[str] = field(default_factory=tuple)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "enabled": bool(self.enabled),
+            "poll_interval_sec": float(self.poll_interval_sec),
+            "nodes": [node.to_dict() for node in self.nodes],
+            "warnings": list(self.warnings),
+        }
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace(
+        "+00:00", "Z"
+    )
+
+
+def normalize_node_name(name: Any) -> str:
+    text = str(name or "").strip()
+    if not text:
+        return ""
+    while "//" in text:
+        text = text.replace("//", "/")
+    if len(text) > 1:
+        text = text.rstrip("/")
+    return text
+
+
+def full_node_name(name: Any, namespace: Any = "/") -> str:
+    node = str(name or "").strip().strip("/")
+    ns = str(namespace or "/").strip()
+    if not node:
+        return ""
+    if not ns or ns == "/":
+        return "/" + node
+    return normalize_node_name(ns.rstrip("/") + "/" + node)
+
+
+def config_from_mapping(config: Mapping[str, Any]) -> NodeHealthConfig:
+    """Parse ``[console.health]`` from a site TOML mapping.
+
+    Missing ``[console.health]`` means fully disabled.  Invalid entries are kept
+    out of the expected-node list and reported as warnings so the console can
+    start normally.
+    """
+
+    console = config.get("console") if isinstance(config.get("console"), Mapping) else None
+    health = console.get("health") if isinstance(console, Mapping) else None
+    if not isinstance(health, Mapping):
+        return NodeHealthConfig(enabled=False)
+
+    warnings: List[str] = []
+    enabled = bool(health.get("enabled", True))
+    poll_raw = health.get("poll_interval_sec", 2.0)
+    try:
+        poll_interval = float(poll_raw)
+        if not math.isfinite(poll_interval) or poll_interval <= 0:
+            raise ValueError
+        poll_interval = max(0.5, poll_interval)
+    except Exception:
+        poll_interval = 2.0
+        warnings.append(
+            f"invalid console.health.poll_interval_sec={poll_raw!r}; using 2.0 sec"
+        )
+
+    raw_nodes = health.get("nodes", [])
+    if raw_nodes is None:
+        raw_nodes = []
+    if not isinstance(raw_nodes, list):
+        warnings.append("console.health.nodes must be an array of tables")
+        raw_nodes = []
+
+    nodes: List[ExpectedNode] = []
+    seen: Set[str] = set()
+    for index, item in enumerate(raw_nodes):
+        if not isinstance(item, Mapping):
+            warnings.append(f"console.health.nodes[{index}] is not a table; ignored")
+            continue
+        name = normalize_node_name(item.get("name"))
+        if not name:
+            warnings.append(f"console.health.nodes[{index}] has no name; ignored")
+            continue
+        if not name.startswith("/"):
+            warnings.append(
+                f"console.health.nodes[{index}] name={name!r} is not fully qualified; ignored"
+            )
+            continue
+        if name in seen:
+            warnings.append(f"duplicate console.health node {name!r}; ignored")
+            continue
+        seen.add(name)
+        label_raw = str(item.get("label") or "").strip()
+        label = label_raw or name.rsplit("/", 1)[-1] or name
+        node_class = str(item.get("class") or "optional").strip()
+        if node_class not in VALID_CLASSES:
+            warnings.append(
+                f"unknown console.health class {node_class!r} for {name}; treating as optional"
+            )
+            node_class = "optional"
+        nodes.append(ExpectedNode(name=name, label=label, node_class=node_class))
+
+    return NodeHealthConfig(
+        enabled=enabled,
+        poll_interval_sec=poll_interval,
+        nodes=tuple(nodes),
+        warnings=tuple(warnings),
+    )
+
+
+def _status_class(value: str) -> str:
+    if value == "OK":
+        return "ok"
+    if value == "DEGRADED":
+        return "warn"
+    if value == "NG":
+        return "bad"
+    return "warn"
+
+
+def evaluate(
+    config: NodeHealthConfig,
+    actual_nodes: Optional[Iterable[str]],
+    *,
+    error: Optional[str] = None,
+    checked_utc: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Return the node_health status payload for ``/api/status``."""
+
+    if not config.enabled:
+        return {"enabled": False}
+
+    checked = checked_utc or _utc_now_iso()
+    base: Dict[str, Any] = {
+        "enabled": True,
+        "poll_interval_sec": float(config.poll_interval_sec),
+        "last_checked_utc": checked,
+        "config_warnings": list(config.warnings),
+    }
+    if error:
+        base.update(
+            {
+                "system": "UNKNOWN",
+                "manual_mount": "UNKNOWN",
+                "observation": "UNKNOWN",
+                "summary_class": "warn",
+                "error": str(error),
+                "missing_required": [],
+                "missing_optional": [],
+                "nodes": [
+                    {**node.to_dict(), "present": None} for node in config.nodes
+                ],
+            }
+        )
+        return base
+
+    if not config.nodes:
+        base.update(
+            {
+                "system": "UNKNOWN",
+                "manual_mount": "UNKNOWN",
+                "observation": "UNKNOWN",
+                "summary_class": "warn",
+                "error": "no expected ROS nodes configured in [console.health]",
+                "missing_required": [],
+                "missing_optional": [],
+                "nodes": [],
+            }
+        )
+        return base
+
+    actual: Set[str] = {normalize_node_name(name) for name in (actual_nodes or [])}
+    actual.discard("")
+    node_payload: List[Dict[str, Any]] = []
+    missing_manual: List[str] = []
+    missing_observation: List[str] = []
+    missing_optional: List[str] = []
+    missing_debug: List[str] = []
+
+    for node in config.nodes:
+        present = node.name in actual
+        row = {**node.to_dict(), "present": bool(present)}
+        node_payload.append(row)
+        if present:
+            continue
+        if node.node_class == "manual_mount_required":
+            missing_manual.append(node.label)
+        elif node.node_class == "observation_required":
+            missing_observation.append(node.label)
+        elif node.node_class == "debug":
+            missing_debug.append(node.label)
+        else:
+            missing_optional.append(node.label)
+
+    missing_required = missing_manual + missing_observation
+    manual_mount = "NG" if missing_manual else "OK"
+    observation = "NG" if missing_required else "OK"
+    if missing_required:
+        system = "NG"
+    elif missing_optional:
+        system = "DEGRADED"
+    else:
+        system = "OK"
+
+    base.update(
+        {
+            "system": system,
+            "manual_mount": manual_mount,
+            "observation": observation,
+            "summary_class": _status_class(system),
+            "missing_required": missing_required,
+            "missing_manual_mount": missing_manual,
+            "missing_observation": missing_observation,
+            "missing_optional": missing_optional,
+            "missing_debug": missing_debug,
+            "nodes": node_payload,
+            "actual_node_count": len(actual),
+        }
+    )
+    return base

--- a/necst/web/node_health.py
+++ b/necst/web/node_health.py
@@ -11,7 +11,6 @@ from datetime import datetime, timezone
 import math
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Set
 
-
 VALID_CLASSES = {
     "manual_mount_required",
     "observation_required",
@@ -51,8 +50,10 @@ class NodeHealthConfig:
 
 
 def _utc_now_iso() -> str:
-    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace(
-        "+00:00", "Z"
+    return (
+        datetime.now(timezone.utc)
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z")
     )
 
 
@@ -85,7 +86,9 @@ def config_from_mapping(config: Mapping[str, Any]) -> NodeHealthConfig:
     start normally.
     """
 
-    console = config.get("console") if isinstance(config.get("console"), Mapping) else None
+    console = (
+        config.get("console") if isinstance(config.get("console"), Mapping) else None
+    )
     health = console.get("health") if isinstance(console, Mapping) else None
     if not isinstance(health, Mapping):
         return NodeHealthConfig(enabled=False)
@@ -187,9 +190,7 @@ def evaluate(
                 "error": str(error),
                 "missing_required": [],
                 "missing_optional": [],
-                "nodes": [
-                    {**node.to_dict(), "present": None} for node in config.nodes
-                ],
+                "nodes": [{**node.to_dict(), "present": None} for node in config.nodes],
             }
         )
         return base

--- a/necst/web/observation_log.py
+++ b/necst/web/observation_log.py
@@ -130,14 +130,17 @@ def _ensure_writable_dir(path: Path) -> Tuple[bool, str]:
 def resolve_log_dir(
     configured_dir: Optional[os.PathLike[str] | str] = None,
     *,
+    site_configured_dir: Optional[os.PathLike[str] | str] = None,
     record_roots: Optional[List[os.PathLike[str] | str]] = None,
 ) -> Tuple[Path, str, Optional[str], List[str]]:
     """Return ``(directory, source, record_root, warnings)``.
 
     Directory selection order:
-    1. explicit argument or NECST_OBSLOG_DIR;
-    2. ``<record root>/obslogs`` from known record-root environment variables;
-    3. ``~/.necst/observation_logs``.
+    1. explicit argument, usually CLI ``--obslog-dir``;
+    2. ``NECST_OBSLOG_DIR``;
+    3. site TOML ``[console.observation_log].directory``;
+    4. ``<record root>/obslogs`` from explicit/site/env record-root candidates;
+    5. ``~/.necst/observation_logs``.
     """
 
     warnings: List[str] = []
@@ -156,6 +159,14 @@ def resolve_log_dir(
         if ok:
             return path, "NECST_OBSLOG_DIR", None, warnings
         warnings.append(f"NECST_OBSLOG_DIR is not writable: {path}: {reason}")
+
+    site_dir = str(site_configured_dir or "").strip()
+    if site_dir:
+        path = Path(site_dir).expanduser()
+        ok, reason = _ensure_writable_dir(path)
+        if ok:
+            return path, "site_config_observation_log_dir", None, warnings
+        warnings.append(f"site TOML observation log directory is not writable: {path}: {reason}")
 
     for root in _candidate_record_roots(record_roots):
         path = root / "obslogs"
@@ -373,12 +384,17 @@ class ObservationLogManager:
         cls,
         *,
         configured_dir: Optional[os.PathLike[str] | str] = None,
+        site_configured_dir: Optional[os.PathLike[str] | str] = None,
         record_roots: Optional[List[os.PathLike[str] | str]] = None,
         prefix: Any = DEFAULT_PREFIX,
         observer: Any = DEFAULT_OBSERVER,
         telescope: str = "NECST",
     ) -> "ObservationLogManager":
-        log_dir, source, record_root, warnings = resolve_log_dir(configured_dir, record_roots=record_roots)
+        log_dir, source, record_root, warnings = resolve_log_dir(
+            configured_dir,
+            site_configured_dir=site_configured_dir,
+            record_roots=record_roots,
+        )
         return cls(
             log_dir=log_dir,
             log_dir_source=source,
@@ -810,8 +826,10 @@ class ObservationLogManager:
             "tooltips": {
                 "directory": (
                     "Log directory selection:\n"
-                    "1. NECST_OBSLOG_DIR, if set.\n"
-                    "2. <record root>/obslogs, if available.\n"
+                    "1. --obslog-dir, if set.\n"
+                    "2. NECST_OBSLOG_DIR, if set.\n"
+                    "3. [console.observation_log].directory in site TOML, if set.\n"
+                    "4. <record root>/obslogs, if available.\n"
                     "3. ~/.necst/observation_logs as fallback.\n"
                     "This path is inside the console container. Use a bind-mounted path if you need the log on the host."
                 ),

--- a/necst/web/observation_log.py
+++ b/necst/web/observation_log.py
@@ -1,0 +1,821 @@
+"""Operator-facing observation CSV log for the NECST console.
+
+This log is intentionally separate from the internal operator JSONL log.  The
+CSV is compact and append-only for observers and later analysis; the JSON sidecar
+keeps session/environment metadata out of each CSV row.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import os
+import re
+import socket
+import threading
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path, PureWindowsPath
+from typing import Any, Dict, List, Mapping, Optional, Tuple
+
+
+CSV_HEADER = [
+    "utc_iso",
+    "enc_az_deg",
+    "enc_el_deg",
+    "comment",
+    "mode",
+    "event",
+    "action_or_obsfile",
+    "result",
+    "user",
+    "record_dir",
+    "session_id",
+    "row_id",
+    "temp_C",
+    "humidity_pct",
+    "pressure_hPa",
+    "weather_source",
+]
+
+SCHEMA_VERSION = "1.0"
+DEFAULT_PREFIX = "obslog"
+DEFAULT_OBSERVER = "User"
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def utc_iso(dt: Optional[datetime] = None) -> str:
+    dt = dt or utc_now()
+    return dt.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def utc_stamp(dt: Optional[datetime] = None) -> str:
+    dt = dt or utc_now()
+    return dt.strftime("%Y%m%dT%H%M%SZ")
+
+
+def sanitize_prefix(prefix: Any) -> str:
+    text = str(prefix or "").strip() or DEFAULT_PREFIX
+    text = re.sub(r"[^A-Za-z0-9_.-]+", "_", text)
+    text = text.strip("._-") or DEFAULT_PREFIX
+    return text[:64]
+
+
+def sanitize_observer(observer: Any) -> str:
+    text = str(observer or "").strip() or DEFAULT_OBSERVER
+    return text[:128]
+
+
+def _split_env_paths(value: str) -> List[str]:
+    out: List[str] = []
+    for chunk in str(value or "").replace(";", os.pathsep).split(os.pathsep):
+        chunk = chunk.strip()
+        if chunk:
+            out.append(chunk)
+    return out
+
+
+def _candidate_record_roots(extra_roots: Optional[List[os.PathLike[str] | str]] = None) -> List[Path]:
+    raw: List[str] = []
+    for value in extra_roots or []:
+        if str(value or "").strip():
+            raw.append(str(value))
+    for env_name in (
+        "NECST_CONSOLE_PC_RECORD_ROOT",
+        "NECST_CONSOLE_RECORD_ROOT",
+        "NECST_RECORD_ROOT",
+        "NECST_DATA_ROOT",
+        "NECST_CONSOLE_DATA_ROOT",
+    ):
+        raw.extend(_split_env_paths(os.environ.get(env_name, "")))
+    roots: List[Path] = []
+    seen: set[str] = set()
+    for item in raw:
+        try:
+            path = Path(item).expanduser()
+        except Exception:
+            continue
+        key = str(path)
+        if key in seen:
+            continue
+        seen.add(key)
+        roots.append(path)
+    return roots
+
+
+def _ensure_writable_dir(path: Path) -> Tuple[bool, str]:
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+        probe = path / ".necst_obslog_write_probe"
+        with probe.open("a", encoding="utf-8") as fh:
+            fh.write("")
+            fh.flush()
+            try:
+                os.fsync(fh.fileno())
+            except Exception:
+                pass
+        try:
+            probe.unlink()
+        except Exception:
+            pass
+        return True, ""
+    except Exception as exc:
+        return False, str(exc)
+
+
+def resolve_log_dir(
+    configured_dir: Optional[os.PathLike[str] | str] = None,
+    *,
+    record_roots: Optional[List[os.PathLike[str] | str]] = None,
+) -> Tuple[Path, str, Optional[str], List[str]]:
+    """Return ``(directory, source, record_root, warnings)``.
+
+    Directory selection order:
+    1. explicit argument or NECST_OBSLOG_DIR;
+    2. ``<record root>/obslogs`` from known record-root environment variables;
+    3. ``~/.necst/observation_logs``.
+    """
+
+    warnings: List[str] = []
+    explicit_arg = str(configured_dir or "").strip()
+    if explicit_arg:
+        path = Path(explicit_arg).expanduser()
+        ok, reason = _ensure_writable_dir(path)
+        if ok:
+            return path, "configured_dir", None, warnings
+        warnings.append(f"configured observation log directory is not writable: {path}: {reason}")
+
+    explicit_env = str(os.environ.get("NECST_OBSLOG_DIR", "")).strip()
+    if explicit_env:
+        path = Path(explicit_env).expanduser()
+        ok, reason = _ensure_writable_dir(path)
+        if ok:
+            return path, "NECST_OBSLOG_DIR", None, warnings
+        warnings.append(f"NECST_OBSLOG_DIR is not writable: {path}: {reason}")
+
+    for root in _candidate_record_roots(record_roots):
+        path = root / "obslogs"
+        ok, reason = _ensure_writable_dir(path)
+        if ok:
+            return path, "record_root_obslogs", str(root), warnings
+        warnings.append(f"record-root obslogs is not writable: {path}: {reason}")
+
+    fallback = Path.home() / ".necst" / "observation_logs"
+    ok, reason = _ensure_writable_dir(fallback)
+    if ok:
+        return fallback, "home_fallback", None, warnings
+    warnings.append(f"fallback observation log directory is not writable: {fallback}: {reason}")
+    # Let the caller fail explicitly when it tries to open the path.
+    return fallback, "home_fallback_unwritable", None, warnings
+
+
+def _metadata_path(csv_path: Path) -> Path:
+    return csv_path.with_suffix(csv_path.suffix + ".meta.json")
+
+
+def _finite_number(value: Any) -> Optional[float]:
+    try:
+        number = float(value)
+    except Exception:
+        return None
+    if not (number == number) or number in (float("inf"), float("-inf")):
+        return None
+    return number
+
+
+def _format_float(value: Any, ndigits: int) -> str:
+    number = _finite_number(value)
+    if number is None:
+        return ""
+    return f"{number:.{ndigits}f}"
+
+
+
+
+def _last_path_component(value: Any) -> str:
+    """Return only the final path component for compact observer-facing CSV fields.
+
+    Paths in the operator console are container paths, but this also tolerates
+    Windows-style separators so copied paths still become a compact basename.
+    Non-path values are returned unchanged.
+    """
+
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    trimmed = text.rstrip("/\\")
+    if not trimmed:
+        return text
+    if "\\" in trimmed and "/" not in trimmed:
+        name = PureWindowsPath(trimmed).name
+    else:
+        name = Path(trimmed).name
+    return name or trimmed
+
+
+def obsfile_name_for_csv(value: Any) -> str:
+    """Return the observation-instruction filename to store in action_or_obsfile."""
+
+    return _last_path_component(value)
+
+
+def record_dir_name_for_csv(value: Any) -> str:
+    """Return the final record-directory component to store in record_dir."""
+
+    return _last_path_component(value)
+
+
+def _first_present(payload: Mapping[str, Any], keys: Tuple[str, ...]) -> Any:
+    for key in keys:
+        if key in payload and payload.get(key) is not None:
+            return payload.get(key)
+    return None
+
+
+def _temperature_c_from_weather(payload: Mapping[str, Any], *, inside: bool = False) -> str:
+    if inside:
+        c_value = _first_present(payload, ("in_temperature_c", "in_temperature_degC"))
+        k_value = _first_present(payload, ("in_temperature_k", "in_temperature"))
+    else:
+        c_value = _first_present(payload, ("temperature_c", "temperature_degC"))
+        k_value = _first_present(payload, ("temperature_k", "temperature"))
+    if c_value is not None:
+        return _format_float(c_value, 2)
+    number = _finite_number(k_value)
+    if number is None:
+        return ""
+    # NECST WeatherMsg.temperature is Kelvin.  Values in a physical Celsius
+    # range may still arrive under temperature_c/temperature_degC and are
+    # handled above; bare temperature/temperature_k are treated as Kelvin.
+    return _format_float(number - 273.15, 2)
+
+
+def _humidity_pct_from_weather(payload: Mapping[str, Any], *, inside: bool = False) -> str:
+    if inside:
+        value = _first_present(payload, ("in_humidity_percent", "in_humidity_pct", "in_humidity"))
+    else:
+        value = _first_present(payload, ("humidity_percent", "humidity_pct", "humidity"))
+    number = _finite_number(value)
+    if number is None:
+        return ""
+    # NECST WeatherMsg.humidity is a fraction in the range 0--1, while some
+    # logs or simulators may already use percent.  Normalize fractions to %.
+    if -1.0 <= number <= 1.0:
+        number *= 100.0
+    return _format_float(number, 2)
+
+
+def _pressure_hpa_from_weather(payload: Mapping[str, Any], *, inside: bool = False) -> str:
+    if inside:
+        value = _first_present(payload, ("in_pressure_hpa", "in_pressure_hPa", "in_pressure"))
+        if value is not None:
+            return _format_float(value, 2)
+    return _format_float(_first_present(payload, ("pressure_hpa", "pressure_hPa", "pressure")), 2)
+
+
+def _weather_from_payload(payload: Mapping[str, Any], *, source: str, inside: bool = False) -> Tuple[str, str, str, str]:
+    temp = _temperature_c_from_weather(payload, inside=inside)
+    humidity = _humidity_pct_from_weather(payload, inside=inside)
+    pressure = _pressure_hpa_from_weather(payload, inside=inside)
+    if temp or humidity or pressure:
+        return temp, humidity, pressure, source
+    return "", "", "", ""
+
+
+def select_weather(weather: Mapping[str, Any]) -> Tuple[str, str, str, str]:
+    """Return temp_C, humidity_pct, pressure_hPa, source.
+
+    Prefer outside weather.  If outside data are unavailable, fall back to inside
+    weather.  NECST WeatherMsg humidity is normally a 0--1 fraction, but the CSV
+    column is explicitly percent, so fractions are normalized here.
+    """
+
+    if not isinstance(weather, Mapping):
+        return "", "", "", ""
+
+    for source in ("out", "outside", "outdoor"):
+        payload = weather.get(source)
+        if isinstance(payload, Mapping):
+            result = _weather_from_payload(payload, source="out", inside=False)
+            if result[3]:
+                return result
+
+    # Some NECST live payloads carry inside values as in_* fields in the same
+    # outside weather message.  Try those before falling back to explicit
+    # inside/indoor payloads.
+    for source in ("out", "outside", "outdoor"):
+        payload = weather.get(source)
+        if isinstance(payload, Mapping):
+            result = _weather_from_payload(payload, source="in", inside=True)
+            if result[3]:
+                return result
+
+    for source in ("in", "inside", "indoor"):
+        payload = weather.get(source)
+        if isinstance(payload, Mapping):
+            # Inside payloads may use either generic keys (temperature,
+            # humidity, pressure) or explicit in_* keys depending on the source.
+            result = _weather_from_payload(payload, source="in", inside=False)
+            if result[3]:
+                return result
+            result = _weather_from_payload(payload, source="in", inside=True)
+            if result[3]:
+                return result
+
+    # Last resort: tolerate a flat weather mapping.
+    result = _weather_from_payload(weather, source="out", inside=False)
+    if result[3]:
+        return result
+    result = _weather_from_payload(weather, source="in", inside=True)
+    if result[3]:
+        return result
+    return "", "", "", ""
+
+
+@dataclass
+class ObservationLogManager:
+    """Append-only observer CSV log with a JSON metadata sidecar."""
+
+    log_dir: Path
+    log_dir_source: str
+    record_root: Optional[str] = None
+    prefix: str = DEFAULT_PREFIX
+    observer: str = DEFAULT_OBSERVER
+    telescope: str = "NECST"
+    directory_warnings: List[str] = field(default_factory=list)
+    session_id: str = field(init=False)
+    created_utc: str = field(init=False)
+    csv_path: Path = field(init=False)
+    meta_path: Path = field(init=False)
+    row_id: int = field(default=0, init=False)
+    closed_utc: Optional[str] = field(default=None, init=False)
+    last_rows: List[Dict[str, Any]] = field(default_factory=list, init=False)
+    last_error: str = field(default="", init=False)
+    _lock: threading.RLock = field(default_factory=threading.RLock, init=False, repr=False)
+    _pending_open_warning: str = field(default="", init=False, repr=False)
+    _fh: Any = field(default=None, init=False, repr=False)
+    _writer: Optional[csv.writer] = field(default=None, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self.prefix = sanitize_prefix(self.prefix)
+        self.observer = sanitize_observer(self.observer)
+        created = utc_now()
+        self.created_utc = utc_iso(created)
+        self.session_id = f"{utc_stamp(created)}-{uuid.uuid4().hex[:4]}"
+        self.open_new(prefix=self.prefix, observer=self.observer, initial=True, created=created)
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        configured_dir: Optional[os.PathLike[str] | str] = None,
+        record_roots: Optional[List[os.PathLike[str] | str]] = None,
+        prefix: Any = DEFAULT_PREFIX,
+        observer: Any = DEFAULT_OBSERVER,
+        telescope: str = "NECST",
+    ) -> "ObservationLogManager":
+        log_dir, source, record_root, warnings = resolve_log_dir(configured_dir, record_roots=record_roots)
+        return cls(
+            log_dir=log_dir,
+            log_dir_source=source,
+            record_root=record_root,
+            prefix=sanitize_prefix(prefix),
+            observer=sanitize_observer(observer),
+            telescope=telescope,
+            directory_warnings=warnings,
+        )
+
+    def _default_path(self, *, prefix: str, created: Optional[datetime] = None) -> Path:
+        stamp = utc_stamp(created)
+        base = self.log_dir / f"{sanitize_prefix(prefix)}_{stamp}.csv"
+        if not base.exists():
+            return base
+        for idx in range(2, 1000):
+            candidate = self.log_dir / f"{sanitize_prefix(prefix)}_{stamp}_{idx}.csv"
+            if not candidate.exists():
+                return candidate
+        return self.log_dir / f"{sanitize_prefix(prefix)}_{stamp}_{uuid.uuid4().hex[:6]}.csv"
+
+    def _write_meta(self) -> None:
+        payload = {
+            "schema_version": SCHEMA_VERSION,
+            "session_id": self.session_id,
+            "created_utc": self.created_utc,
+            "closed_utc": self.closed_utc,
+            "observer": self.observer,
+            "prefix": self.prefix,
+            "csv_path": str(self.csv_path),
+            "meta_path": str(self.meta_path),
+            "log_dir": str(self.log_dir),
+            "log_dir_source": self.log_dir_source,
+            "record_root": self.record_root,
+            "telescope": self.telescope,
+            "hostname": socket.gethostname(),
+            "pid": os.getpid(),
+            "schema_columns": list(CSV_HEADER),
+            "notes": "CSV is append-only; web reload does not change the file. Paths are inside the console container.",
+        }
+        tmp = self.meta_path.with_suffix(self.meta_path.suffix + ".tmp")
+        tmp.parent.mkdir(parents=True, exist_ok=True)
+        with tmp.open("w", encoding="utf-8") as fh:
+            json.dump(payload, fh, ensure_ascii=False, indent=2, sort_keys=True)
+            fh.write("\n")
+            fh.flush()
+            try:
+                os.fsync(fh.fileno())
+            except Exception:
+                pass
+        tmp.replace(self.meta_path)
+
+    def _open_path(self, path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        existed = path.exists()
+        size = path.stat().st_size if existed else 0
+        self.csv_path = path
+        self.meta_path = _metadata_path(path)
+        self.last_rows = []
+        self._pending_open_warning = ""
+        self._fh = path.open("a", encoding="utf-8", newline="")
+        self._writer = csv.writer(self._fh)
+        if size == 0:
+            self.row_id = 0
+            self._writer.writerow(CSV_HEADER)
+            self._sync()
+        elif existed:
+            try:
+                with path.open("r", encoding="utf-8", newline="") as check_fh:
+                    reader = csv.reader(check_fh)
+                    header = next(reader, [])
+                    row_count = 0
+                    max_existing_row_id = 0
+                    recent: List[Dict[str, Any]] = []
+                    for row in reader:
+                        if not row or not any(str(cell).strip() for cell in row):
+                            continue
+                        row_count += 1
+                        if header == CSV_HEADER:
+                            values = list(row)[: len(CSV_HEADER)]
+                            if len(values) < len(CSV_HEADER):
+                                values.extend([""] * (len(CSV_HEADER) - len(values)))
+                            row_dict = dict(zip(CSV_HEADER, values))
+                            try:
+                                max_existing_row_id = max(max_existing_row_id, int(str(row_dict.get("row_id") or "0")))
+                            except Exception:
+                                pass
+                            recent.append(row_dict)
+                            if len(recent) > 20:
+                                del recent[0]
+                self.row_id = max_existing_row_id if header == CSV_HEADER and max_existing_row_id > 0 else row_count
+                if header != CSV_HEADER:
+                    self._pending_open_warning = "CSV header differs from the current observation-log schema; appending anyway"
+                    self.last_error = self._pending_open_warning
+                else:
+                    self.last_rows = list(reversed(recent))
+            except Exception as exc:
+                self.row_id = 0
+                self._pending_open_warning = f"failed to inspect existing CSV header; appending anyway: {exc}"
+                self.last_error = self._pending_open_warning
+        self._write_meta()
+
+    def _resolve_user_csv_path(self, path_text: Any) -> Path:
+        raw = str(path_text or "").strip()
+        if not raw:
+            raise ValueError("log file path is empty")
+        path = Path(raw).expanduser()
+        if not path.is_absolute():
+            # Relative paths are intended to stay under the active log
+            # directory.  Reject traversal explicitly so that a friendly UI
+            # string such as "../other.csv" cannot escape the log directory.
+            if any(part == ".." for part in path.parts):
+                raise ValueError("relative observation log path must not contain '..'")
+            path = self.log_dir / path
+        if raw.endswith(("/", "\\")):
+            raise ValueError("observation log path must include a CSV filename")
+        if path.suffix == "":
+            path = path.with_suffix(".csv")
+        elif path.suffix.lower() != ".csv":
+            raise ValueError("observation log path must end with .csv")
+        return path
+
+    def _preflight_csv_path(self, path: Path) -> None:
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with path.open("a", encoding="utf-8", newline="") as fh:
+                fh.flush()
+                try:
+                    os.fsync(fh.fileno())
+                except Exception:
+                    pass
+        except Exception as exc:
+            raise OSError(f"observation log path is not writable: {path}: {exc}") from exc
+
+    def _record_switch_failure(self, path: Path, exc: BaseException) -> None:
+        try:
+            self.write_event(
+                {},
+                comment=str(exc),
+                mode="Console",
+                event="log_open_failed",
+                action_or_obsfile=str(path),
+                result="failed",
+            )
+        except Exception:
+            self.last_error = str(exc)
+
+    def _restore_previous_after_switch_failure(self, previous: Optional[Path], target: Path, exc: BaseException) -> None:
+        try:
+            if self._fh is not None:
+                self._fh.close()
+        except Exception:
+            pass
+        self._fh = None
+        self._writer = None
+        if previous is None:
+            self.last_error = str(exc)
+            return
+        try:
+            self.closed_utc = None
+            self._open_path(previous)
+            self.write_event(
+                {},
+                comment=str(exc),
+                mode="Console",
+                event="log_open_failed",
+                action_or_obsfile=str(target),
+                result="failed",
+            )
+        except Exception as restore_exc:
+            self.last_error = f"failed to open {target}: {exc}; failed to restore {previous}: {restore_exc}"
+
+    def _sync(self) -> None:
+        if self._fh is None:
+            return
+        self._fh.flush()
+        os.fsync(self._fh.fileno())
+
+    def update_observer(self, observer: Any) -> bool:
+        with self._lock:
+            return self._update_observer_unlocked(observer)
+
+    def _update_observer_unlocked(self, observer: Any) -> bool:
+        new_observer = sanitize_observer(observer)
+        if new_observer == self.observer:
+            return False
+        old = self.observer
+        self.observer = new_observer
+        self.write_event(
+            {},
+            comment="",
+            mode="Console",
+            event="observer_changed",
+            action_or_obsfile=f"{old} -> {new_observer}",
+            result="success",
+        )
+        self._write_meta()
+        return True
+
+    def open_new(
+        self,
+        *,
+        prefix: Any = None,
+        observer: Any = None,
+        initial: bool = False,
+        created: Optional[datetime] = None,
+    ) -> None:
+        with self._lock:
+            self._open_new_unlocked(prefix=prefix, observer=observer, initial=initial, created=created)
+
+    def _open_new_unlocked(
+        self,
+        *,
+        prefix: Any = None,
+        observer: Any = None,
+        initial: bool = False,
+        created: Optional[datetime] = None,
+    ) -> None:
+        old_observer = self.observer
+        old_prefix = self.prefix
+        if observer is not None:
+            self.observer = sanitize_observer(observer)
+        if prefix is not None:
+            self.prefix = sanitize_prefix(prefix)
+        created = created or utc_now()
+        path = self._default_path(prefix=self.prefix, created=created)
+        previous = getattr(self, "csv_path", None)
+        try:
+            self._preflight_csv_path(path)
+        except Exception as exc:
+            self.observer = old_observer
+            self.prefix = old_prefix
+            self._record_switch_failure(path, exc)
+            raise
+        if not initial and self._fh is not None:
+            self.write_event(
+                {},
+                mode="Console",
+                event="log_closed",
+                action_or_obsfile=str(path),
+                result="success",
+            )
+            self.close(write_log_closed=False)
+        self.closed_utc = None
+        self.created_utc = utc_iso(created)
+        try:
+            self._open_path(path)
+        except Exception as exc:
+            self._restore_previous_after_switch_failure(previous, path, exc)
+            raise
+        self.write_event(
+            {},
+            mode="Console",
+            event="log_opened" if not initial else "console_start",
+            action_or_obsfile=(f"from {previous}" if previous else str(path)),
+            result="success",
+        )
+
+    def open_existing(self, path_text: Any, *, observer: Any = None) -> None:
+        with self._lock:
+            self._open_existing_unlocked(path_text, observer=observer)
+
+    def _open_existing_unlocked(self, path_text: Any, *, observer: Any = None) -> None:
+        try:
+            path = self._resolve_user_csv_path(path_text)
+        except Exception as exc:
+            fallback = self.log_dir / str(path_text or "")
+            self._record_switch_failure(fallback, exc)
+            raise
+        old_observer = self.observer
+        if observer is not None:
+            self.observer = sanitize_observer(observer)
+        previous = getattr(self, "csv_path", None)
+        try:
+            self._preflight_csv_path(path)
+        except Exception as exc:
+            self.observer = old_observer
+            self._record_switch_failure(path, exc)
+            raise
+        if self._fh is not None:
+            self.write_event({}, mode="Console", event="log_closed", action_or_obsfile=str(path), result="success")
+            self.close(write_log_closed=False)
+        self.closed_utc = None
+        self.created_utc = utc_iso()
+        # Keep the original session id for this console process, even when the
+        # file changes.  This lets merged CSVs identify the console session.
+        try:
+            self._open_path(path)
+        except Exception as exc:
+            self._restore_previous_after_switch_failure(previous, path, exc)
+            raise
+        self.write_event(
+            {},
+            mode="Console",
+            event="log_opened",
+            action_or_obsfile=(f"from {previous}" if previous else str(path)),
+            result="success",
+        )
+
+    def write_event(
+        self,
+        context: Mapping[str, Any],
+        *,
+        comment: Any = "",
+        mode: Any = "Console",
+        event: Any = "event",
+        action_or_obsfile: Any = "",
+        result: Any = "unknown",
+        record_dir: Optional[Any] = None,
+    ) -> bool:
+        with self._lock:
+            return self._write_event_unlocked(
+                context,
+                comment=comment,
+                mode=mode,
+                event=event,
+                action_or_obsfile=action_or_obsfile,
+                result=result,
+                record_dir=record_dir,
+            )
+
+    def _write_event_unlocked(
+        self,
+        context: Mapping[str, Any],
+        *,
+        comment: Any = "",
+        mode: Any = "Console",
+        event: Any = "event",
+        action_or_obsfile: Any = "",
+        result: Any = "unknown",
+        record_dir: Optional[Any] = None,
+    ) -> bool:
+        if self._writer is None:
+            return False
+        try:
+            weather = context.get("weather") if isinstance(context, Mapping) else {}
+            temp, humidity, pressure, weather_source = select_weather(weather if isinstance(weather, Mapping) else {})
+            enc_az = _format_float(context.get("enc_az_deg"), 4) if isinstance(context, Mapping) else ""
+            enc_el = _format_float(context.get("enc_el_deg"), 4) if isinstance(context, Mapping) else ""
+            chosen_record_dir = record_dir
+            if chosen_record_dir in (None, "") and isinstance(context, Mapping):
+                chosen_record_dir = context.get("record_dir")
+            chosen_record_dir = record_dir_name_for_csv(chosen_record_dir)
+            next_row_id = self.row_id + 1
+            row = [
+                utc_iso(),
+                enc_az,
+                enc_el,
+                str(comment or ""),
+                str(mode or ""),
+                str(event or ""),
+                str(action_or_obsfile or ""),
+                str(result or ""),
+                self.observer,
+                str(chosen_record_dir or ""),
+                self.session_id,
+                next_row_id,
+                temp,
+                humidity,
+                pressure,
+                weather_source,
+            ]
+            self._writer.writerow(row)
+            self._fh.flush()
+            fsync_error = ""
+            try:
+                os.fsync(self._fh.fileno())
+            except Exception as exc:
+                fsync_error = str(exc)
+            self.row_id = next_row_id
+            row_dict = dict(zip(CSV_HEADER, row))
+            self.last_rows.insert(0, row_dict)
+            del self.last_rows[20:]
+            self.last_error = fsync_error or self._pending_open_warning
+            return not bool(fsync_error)
+        except Exception as exc:
+            self.last_error = str(exc)
+            return False
+
+    def close(self, *, write_log_closed: bool = True) -> None:
+        with self._lock:
+            self._close_unlocked(write_log_closed=write_log_closed)
+
+    def _close_unlocked(self, *, write_log_closed: bool = True) -> None:
+        if self._fh is None:
+            return
+        if write_log_closed:
+            self.write_event({}, mode="Console", event="log_closed", action_or_obsfile="console server stopping", result="success")
+        self.closed_utc = utc_iso()
+        try:
+            self._write_meta()
+        except Exception as exc:
+            self.last_error = str(exc)
+        try:
+            self._sync()
+        finally:
+            try:
+                self._fh.close()
+            finally:
+                self._fh = None
+                self._writer = None
+
+    def status(self) -> Dict[str, Any]:
+        with self._lock:
+            return self._status_unlocked()
+
+    def _status_unlocked(self) -> Dict[str, Any]:
+        return {
+            "ok": self._writer is not None,
+            "writing": self._writer is not None,
+            "csv_path": str(self.csv_path),
+            "csv_name": self.csv_path.name,
+            "meta_path": str(self.meta_path),
+            "meta_name": self.meta_path.name,
+            "created_utc": self.created_utc,
+            "closed_utc": self.closed_utc,
+            "log_dir": str(self.log_dir),
+            "log_dir_source": self.log_dir_source,
+            "record_root": self.record_root,
+            "prefix": self.prefix,
+            "observer": self.observer,
+            "session_id": self.session_id,
+            "row_id": self.row_id,
+            "schema_version": SCHEMA_VERSION,
+            "columns": list(CSV_HEADER),
+            "last_rows": list(self.last_rows),
+            "last_error": self.last_error,
+            "directory_warnings": list(self.directory_warnings),
+            "tooltips": {
+                "directory": (
+                    "Log directory selection:\n"
+                    "1. NECST_OBSLOG_DIR, if set.\n"
+                    "2. <record root>/obslogs, if available.\n"
+                    "3. ~/.necst/observation_logs as fallback.\n"
+                    "This path is inside the console container. Use a bind-mounted path if you need the log on the host."
+                ),
+                "file": "A new log file is created when the console server starts. Reloading the web page does not change the log file.",
+                "switch": "Close the current log file and continue writing to a new or selected CSV file. This does not rename the existing file.",
+            },
+        }

--- a/necst/web/observation_log.py
+++ b/necst/web/observation_log.py
@@ -19,7 +19,6 @@ from datetime import datetime, timezone
 from pathlib import Path, PureWindowsPath
 from typing import Any, Dict, List, Mapping, Optional, Tuple
 
-
 CSV_HEADER = [
     "utc_iso",
     "enc_az_deg",
@@ -79,7 +78,9 @@ def _split_env_paths(value: str) -> List[str]:
     return out
 
 
-def _candidate_record_roots(extra_roots: Optional[List[os.PathLike[str] | str]] = None) -> List[Path]:
+def _candidate_record_roots(
+    extra_roots: Optional[List[os.PathLike[str] | str]] = None,
+) -> List[Path]:
     raw: List[str] = []
     for value in extra_roots or []:
         if str(value or "").strip():
@@ -150,7 +151,9 @@ def resolve_log_dir(
         ok, reason = _ensure_writable_dir(path)
         if ok:
             return path, "configured_dir", None, warnings
-        warnings.append(f"configured observation log directory is not writable: {path}: {reason}")
+        warnings.append(
+            f"configured observation log directory is not writable: {path}: {reason}"
+        )
 
     explicit_env = str(os.environ.get("NECST_OBSLOG_DIR", "")).strip()
     if explicit_env:
@@ -166,7 +169,9 @@ def resolve_log_dir(
         ok, reason = _ensure_writable_dir(path)
         if ok:
             return path, "site_config_observation_log_dir", None, warnings
-        warnings.append(f"site TOML observation log directory is not writable: {path}: {reason}")
+        warnings.append(
+            f"site TOML observation log directory is not writable: {path}: {reason}"
+        )
 
     for root in _candidate_record_roots(record_roots):
         path = root / "obslogs"
@@ -179,7 +184,9 @@ def resolve_log_dir(
     ok, reason = _ensure_writable_dir(fallback)
     if ok:
         return fallback, "home_fallback", None, warnings
-    warnings.append(f"fallback observation log directory is not writable: {fallback}: {reason}")
+    warnings.append(
+        f"fallback observation log directory is not writable: {fallback}: {reason}"
+    )
     # Let the caller fail explicitly when it tries to open the path.
     return fallback, "home_fallback_unwritable", None, warnings
 
@@ -203,8 +210,6 @@ def _format_float(value: Any, ndigits: int) -> str:
     if number is None:
         return ""
     return f"{number:.{ndigits}f}"
-
-
 
 
 def _last_path_component(value: Any) -> str:
@@ -247,7 +252,9 @@ def _first_present(payload: Mapping[str, Any], keys: Tuple[str, ...]) -> Any:
     return None
 
 
-def _temperature_c_from_weather(payload: Mapping[str, Any], *, inside: bool = False) -> str:
+def _temperature_c_from_weather(
+    payload: Mapping[str, Any], *, inside: bool = False
+) -> str:
     if inside:
         c_value = _first_present(payload, ("in_temperature_c", "in_temperature_degC"))
         k_value = _first_present(payload, ("in_temperature_k", "in_temperature"))
@@ -265,11 +272,17 @@ def _temperature_c_from_weather(payload: Mapping[str, Any], *, inside: bool = Fa
     return _format_float(number - 273.15, 2)
 
 
-def _humidity_pct_from_weather(payload: Mapping[str, Any], *, inside: bool = False) -> str:
+def _humidity_pct_from_weather(
+    payload: Mapping[str, Any], *, inside: bool = False
+) -> str:
     if inside:
-        value = _first_present(payload, ("in_humidity_percent", "in_humidity_pct", "in_humidity"))
+        value = _first_present(
+            payload, ("in_humidity_percent", "in_humidity_pct", "in_humidity")
+        )
     else:
-        value = _first_present(payload, ("humidity_percent", "humidity_pct", "humidity"))
+        value = _first_present(
+            payload, ("humidity_percent", "humidity_pct", "humidity")
+        )
     number = _finite_number(value)
     if number is None:
         return ""
@@ -280,15 +293,23 @@ def _humidity_pct_from_weather(payload: Mapping[str, Any], *, inside: bool = Fal
     return _format_float(number, 2)
 
 
-def _pressure_hpa_from_weather(payload: Mapping[str, Any], *, inside: bool = False) -> str:
+def _pressure_hpa_from_weather(
+    payload: Mapping[str, Any], *, inside: bool = False
+) -> str:
     if inside:
-        value = _first_present(payload, ("in_pressure_hpa", "in_pressure_hPa", "in_pressure"))
+        value = _first_present(
+            payload, ("in_pressure_hpa", "in_pressure_hPa", "in_pressure")
+        )
         if value is not None:
             return _format_float(value, 2)
-    return _format_float(_first_present(payload, ("pressure_hpa", "pressure_hPa", "pressure")), 2)
+    return _format_float(
+        _first_present(payload, ("pressure_hpa", "pressure_hPa", "pressure")), 2
+    )
 
 
-def _weather_from_payload(payload: Mapping[str, Any], *, source: str, inside: bool = False) -> Tuple[str, str, str, str]:
+def _weather_from_payload(
+    payload: Mapping[str, Any], *, source: str, inside: bool = False
+) -> Tuple[str, str, str, str]:
     temp = _temperature_c_from_weather(payload, inside=inside)
     humidity = _humidity_pct_from_weather(payload, inside=inside)
     pressure = _pressure_hpa_from_weather(payload, inside=inside)
@@ -366,7 +387,9 @@ class ObservationLogManager:
     closed_utc: Optional[str] = field(default=None, init=False)
     last_rows: List[Dict[str, Any]] = field(default_factory=list, init=False)
     last_error: str = field(default="", init=False)
-    _lock: threading.RLock = field(default_factory=threading.RLock, init=False, repr=False)
+    _lock: threading.RLock = field(
+        default_factory=threading.RLock, init=False, repr=False
+    )
     _pending_open_warning: str = field(default="", init=False, repr=False)
     _fh: Any = field(default=None, init=False, repr=False)
     _writer: Optional[csv.writer] = field(default=None, init=False, repr=False)
@@ -377,7 +400,9 @@ class ObservationLogManager:
         created = utc_now()
         self.created_utc = utc_iso(created)
         self.session_id = f"{utc_stamp(created)}-{uuid.uuid4().hex[:4]}"
-        self.open_new(prefix=self.prefix, observer=self.observer, initial=True, created=created)
+        self.open_new(
+            prefix=self.prefix, observer=self.observer, initial=True, created=created
+        )
 
     @classmethod
     def create(
@@ -414,7 +439,10 @@ class ObservationLogManager:
             candidate = self.log_dir / f"{sanitize_prefix(prefix)}_{stamp}_{idx}.csv"
             if not candidate.exists():
                 return candidate
-        return self.log_dir / f"{sanitize_prefix(prefix)}_{stamp}_{uuid.uuid4().hex[:6]}.csv"
+        return (
+            self.log_dir
+            / f"{sanitize_prefix(prefix)}_{stamp}_{uuid.uuid4().hex[:6]}.csv"
+        )
 
     def _write_meta(self) -> None:
         payload = {
@@ -479,13 +507,20 @@ class ObservationLogManager:
                                 values.extend([""] * (len(CSV_HEADER) - len(values)))
                             row_dict = dict(zip(CSV_HEADER, values))
                             try:
-                                max_existing_row_id = max(max_existing_row_id, int(str(row_dict.get("row_id") or "0")))
+                                max_existing_row_id = max(
+                                    max_existing_row_id,
+                                    int(str(row_dict.get("row_id") or "0")),
+                                )
                             except Exception:
                                 pass
                             recent.append(row_dict)
                             if len(recent) > 20:
                                 del recent[0]
-                self.row_id = max_existing_row_id if header == CSV_HEADER and max_existing_row_id > 0 else row_count
+                self.row_id = (
+                    max_existing_row_id
+                    if header == CSV_HEADER and max_existing_row_id > 0
+                    else row_count
+                )
                 if header != CSV_HEADER:
                     self._pending_open_warning = "CSV header differs from the current observation-log schema; appending anyway"
                     self.last_error = self._pending_open_warning
@@ -493,7 +528,9 @@ class ObservationLogManager:
                     self.last_rows = list(reversed(recent))
             except Exception as exc:
                 self.row_id = 0
-                self._pending_open_warning = f"failed to inspect existing CSV header; appending anyway: {exc}"
+                self._pending_open_warning = (
+                    f"failed to inspect existing CSV header; appending anyway: {exc}"
+                )
                 self.last_error = self._pending_open_warning
         self._write_meta()
 
@@ -527,7 +564,9 @@ class ObservationLogManager:
                 except Exception:
                     pass
         except Exception as exc:
-            raise OSError(f"observation log path is not writable: {path}: {exc}") from exc
+            raise OSError(
+                f"observation log path is not writable: {path}: {exc}"
+            ) from exc
 
     def _record_switch_failure(self, path: Path, exc: BaseException) -> None:
         try:
@@ -542,7 +581,9 @@ class ObservationLogManager:
         except Exception:
             self.last_error = str(exc)
 
-    def _restore_previous_after_switch_failure(self, previous: Optional[Path], target: Path, exc: BaseException) -> None:
+    def _restore_previous_after_switch_failure(
+        self, previous: Optional[Path], target: Path, exc: BaseException
+    ) -> None:
         try:
             if self._fh is not None:
                 self._fh.close()
@@ -603,7 +644,9 @@ class ObservationLogManager:
         created: Optional[datetime] = None,
     ) -> None:
         with self._lock:
-            self._open_new_unlocked(prefix=prefix, observer=observer, initial=initial, created=created)
+            self._open_new_unlocked(
+                prefix=prefix, observer=observer, initial=initial, created=created
+            )
 
     def _open_new_unlocked(
         self,
@@ -675,7 +718,13 @@ class ObservationLogManager:
             self._record_switch_failure(path, exc)
             raise
         if self._fh is not None:
-            self.write_event({}, mode="Console", event="log_closed", action_or_obsfile=str(path), result="success")
+            self.write_event(
+                {},
+                mode="Console",
+                event="log_closed",
+                action_or_obsfile=str(path),
+                result="success",
+            )
             self.close(write_log_closed=False)
         self.closed_utc = None
         self.created_utc = utc_iso()
@@ -731,9 +780,19 @@ class ObservationLogManager:
             return False
         try:
             weather = context.get("weather") if isinstance(context, Mapping) else {}
-            temp, humidity, pressure, weather_source = select_weather(weather if isinstance(weather, Mapping) else {})
-            enc_az = _format_float(context.get("enc_az_deg"), 4) if isinstance(context, Mapping) else ""
-            enc_el = _format_float(context.get("enc_el_deg"), 4) if isinstance(context, Mapping) else ""
+            temp, humidity, pressure, weather_source = select_weather(
+                weather if isinstance(weather, Mapping) else {}
+            )
+            enc_az = (
+                _format_float(context.get("enc_az_deg"), 4)
+                if isinstance(context, Mapping)
+                else ""
+            )
+            enc_el = (
+                _format_float(context.get("enc_el_deg"), 4)
+                if isinstance(context, Mapping)
+                else ""
+            )
             chosen_record_dir = record_dir
             if chosen_record_dir in (None, "") and isinstance(context, Mapping):
                 chosen_record_dir = context.get("record_dir")
@@ -782,7 +841,13 @@ class ObservationLogManager:
         if self._fh is None:
             return
         if write_log_closed:
-            self.write_event({}, mode="Console", event="log_closed", action_or_obsfile="console server stopping", result="success")
+            self.write_event(
+                {},
+                mode="Console",
+                event="log_closed",
+                action_or_obsfile="console server stopping",
+                result="success",
+            )
         self.closed_utc = utc_iso()
         try:
             self._write_meta()

--- a/necst/web/operator_console.py
+++ b/necst/web/operator_console.py
@@ -106,8 +106,8 @@ class ConsoleAuthorityState:
 
     ``held`` and ``session_id`` are the browser/session gate.  When running in
     live mode, ``necst_held`` means this console process also holds actual NECST
-    privilege through a persistent Commander.  Observation/RSky/SkyDip launchers
-    run as separate processes, so the console must release actual privilege
+    authority through a persistent Commander.  Observation/RSky/SkyDip launchers
+    run as separate processes, so the console must release actual authority
     before starting them to avoid blocking the child process.
     """
 
@@ -151,6 +151,14 @@ class OperatorConsoleState:
     authority_handle: Any = None
     last_command_az: Optional[float] = None
     last_command_el: Optional[float] = None
+    # Last fixed Az/El requested from the Manual telescope control card.  This is
+    # intentionally separate from Command Az/El display values: /ctrl/antenna/altaz
+    # can disappear after STOP, while the operator still needs the UI to recognize
+    # that the mount is already at the last requested fixed coordinate.
+    last_mount_target_az: Optional[float] = None
+    last_mount_target_el: Optional[float] = None
+    last_mount_target_started_at: Optional[float] = None
+    last_mount_target_reached_since: Optional[float] = None
     last_manual_state: str = "idle"
     last_active_task: str = "none"
     last_chopper_state: str = "unknown"
@@ -690,7 +698,7 @@ def _live_write_guard(state: OperatorConsoleState, action: str) -> Tuple[bool, s
 
 def _authority_allows(state: OperatorConsoleState, session_id: str) -> Tuple[bool, str]:
     if not state.authority.held:
-        return True, "temporary NECST privilege will be acquired by the action layer"
+        return True, "temporary NECST authority will be acquired by the action layer"
     if state.authority.session_id == session_id:
         return True, "using this console session's authority"
     return False, "authority is held by another browser session"
@@ -764,8 +772,8 @@ def _sync_authority_state(
     """Synchronize browser authority state with the held NECST handle.
 
     The browser-session gate is meaningful only while the underlying
-    OperatorAuthoritySession still reports that it holds privilege.  If the
-    authorizer restarted, the node lost privilege, or a reduced/stub
+    OperatorAuthoritySession still reports that it holds authority.  If the
+    authorizer restarted, the node lost authority, or a reduced/stub
     environment reports the handle as not held, clear the browser gate so other
     sessions are not blocked by stale state.
     """
@@ -792,7 +800,7 @@ def _sync_authority_state(
         return {"changed": True, "held": False, "reason": "status_check_failed"}
 
     if not handle_held:
-        note = "authority handle no longer reports NECST privilege; cleared browser gate"
+        note = "authority handle no longer reports NECST authority; cleared browser gate"
         _clear_authority_state(state)
         if log_if_cleared:
             state.add_log(False, note, action="authority_sync")
@@ -821,7 +829,7 @@ def _release_console_authority(
     session_id: Optional[str] = None,
     force: bool = False,
 ) -> Tuple[bool, str, JsonDict]:
-    """Release browser/session authority and any persistent NECST privilege."""
+    """Release browser/session authority and any persistent NECST authority."""
 
     if not state.authority.held and state.authority_handle is None:
         _clear_authority_state(state)
@@ -854,7 +862,7 @@ def _release_console_authority(
 def _release_before_subprocess_if_needed(
     state: OperatorConsoleState, session_id: str
 ) -> Optional[str]:
-    """Release persistent NECST privilege before starting a child launcher."""
+    """Release persistent NECST authority before starting a child launcher."""
 
     if state.action_mode == "dry-run":
         return None
@@ -865,7 +873,7 @@ def _release_before_subprocess_if_needed(
     ok, message, _data = _release_console_authority(state, session_id=session_id)
     if not ok:
         raise RuntimeError(message)
-    return "console NECST privilege was released before starting the launcher process"
+    return "console NECST authority was released before starting the launcher process"
 
 
 def _console_time_iso(ts: Optional[float]) -> Optional[str]:
@@ -956,6 +964,67 @@ def _active_launcher_summary(
     if category:
         return f"active {category} launcher already exists: " + ", ".join(labels)
     return "active launcher already exists: " + ", ".join(labels)
+
+
+def _last_mount_target_reached(
+    state: OperatorConsoleState,
+    *,
+    current_az: Any,
+    current_el: Any,
+    tol_deg: float = 7.5e-4,
+    require_settle_sec: float = 0.5,
+    update_state: bool = False,
+) -> bool:
+    """Return True when the encoder is at the last manual mount target.
+
+    This is not used to display Command Az/El.  It only prevents stale SKY or
+    tracking-like low-level status from trapping the operator UI after a fixed
+    Az/El mount-move has reached the requested coordinate, especially after STOP
+    clears the live command topic.
+    """
+
+    if state.last_mount_target_az is None or state.last_mount_target_el is None:
+        if update_state:
+            state.last_mount_target_reached_since = None
+        return False
+    try:
+        az = float(current_az)
+        el = float(current_el)
+        target_az = float(state.last_mount_target_az)
+        target_el = float(state.last_mount_target_el)
+    except Exception:
+        if update_state:
+            state.last_mount_target_reached_since = None
+        return False
+    if not (math.isfinite(az) and math.isfinite(el) and math.isfinite(target_az) and math.isfinite(target_el)):
+        if update_state:
+            state.last_mount_target_reached_since = None
+        return False
+
+    reached_now = abs(az - target_az) <= float(tol_deg) and abs(el - target_el) <= float(tol_deg)
+    now = time.time()
+    if not reached_now:
+        if update_state:
+            state.last_mount_target_reached_since = None
+        return False
+    if update_state and state.last_mount_target_reached_since is None:
+        state.last_mount_target_reached_since = now
+    since = state.last_mount_target_reached_since if state.last_mount_target_reached_since is not None else now
+    try:
+        settled = (now - float(since)) >= float(require_settle_sec)
+    except Exception:
+        settled = True
+    # For conflict checks we do not want a one-poll delay to trap the operator;
+    # for the visible status we use the small settle time to avoid flicker while
+    # the antenna is still passing through the target.
+    return bool(settled or require_settle_sec <= 0.0)
+
+
+def _clear_last_mount_target(state: OperatorConsoleState) -> None:
+    state.last_mount_target_az = None
+    state.last_mount_target_el = None
+    state.last_mount_target_started_at = None
+    state.last_mount_target_reached_since = None
 
 
 
@@ -1073,6 +1142,18 @@ def _operator_status_operation_conflict(
             motion.get("mount_target_reached")
             and motion.get("live_motion_active") is False
         )
+        antenna = op.get("antenna") if isinstance(op.get("antenna"), Mapping) else {}
+        operator_target_idle = False
+        if sys_state in {"", "idle", "unknown", "finished", "aborted", "error", "failed"}:
+            operator_target_idle = _last_mount_target_reached(
+                state,
+                current_az=antenna.get("current_az_deg"),
+                current_el=antenna.get("current_el_deg"),
+                require_settle_sec=0.0,
+                update_state=False,
+            )
+        if operator_target_idle:
+            at_target_idle = True
         active_task = str(motion.get("active_task") or "").strip()
         if active_task.lower() not in {"", "none", "idle", "unknown"} and not at_target_idle:
             return f"cannot start {requested_action}: active task is {active_task}; use STOP/ABORT or wait until READY"
@@ -1417,6 +1498,10 @@ def dispatch_action(
         if state.action_mode == "dry-run":
             state.last_command_az = az
             state.last_command_el = el
+            state.last_mount_target_az = az
+            state.last_mount_target_el = el
+            state.last_mount_target_started_at = time.time()
+            state.last_mount_target_reached_since = None
             return True, f"dry-run mount move: Az={az:.6f} deg, El={el:.6f} deg; no command was sent", {
                 "action": action,
                 "az_deg": az,
@@ -1443,6 +1528,10 @@ def dispatch_action(
             )
             state.last_command_az = az
             state.last_command_el = el
+            state.last_mount_target_az = az
+            state.last_mount_target_el = el
+            state.last_mount_target_started_at = time.time()
+            state.last_mount_target_reached_since = None
             state.last_manual_state = "moving"
             state.last_active_task = "manual mount move"
         return ok, message, data
@@ -1464,6 +1553,9 @@ def dispatch_action(
             state.last_active_task = "none"
             state.last_command_az = None
             state.last_command_el = None
+            # Keep last_mount_target_* so the status adapter can still recognize
+            # that the fixed mount-move target has been reached after STOP clears
+            # /ctrl/antenna/altaz.
         return ok, message, data
 
     if action == "start_tracking":
@@ -1493,6 +1585,7 @@ def dispatch_action(
             )
             state.last_command_az = None
             state.last_command_el = None
+            _clear_last_mount_target(state)
             state.last_manual_state = "tracking"
             state.last_active_task = "target tracking"
         return ok, message, data
@@ -1534,6 +1627,7 @@ def dispatch_action(
             state.last_active_task = "none"
             state.last_command_az = None
             state.last_command_el = None
+            _clear_last_mount_target(state)
         return ok, message, data
 
     if action == "start_observation":
@@ -1580,6 +1674,7 @@ def dispatch_action(
             )
             state.last_command_az = None
             state.last_command_el = None
+            _clear_last_mount_target(state)
             state.last_manual_state = "observing sequence"
             state.last_active_task = "observation"
             _register_launcher_if_needed(
@@ -1630,6 +1725,7 @@ def dispatch_action(
             )
             state.last_command_az = None
             state.last_command_el = None
+            _clear_last_mount_target(state)
             state.last_manual_state = "calibration"
             state.last_active_task = "RSky"
             _register_launcher_if_needed(
@@ -1680,6 +1776,7 @@ def dispatch_action(
             )
             state.last_command_az = None
             state.last_command_el = None
+            _clear_last_mount_target(state)
             state.last_manual_state = "calibration"
             state.last_active_task = "SkyDip"
             _register_launcher_if_needed(
@@ -1840,6 +1937,30 @@ def _operator_status_to_v7_status(
     if az is None or el is None:
         warnings = list(warnings) + ["antenna current Az/El is unavailable"]
 
+    motion_source_lower = str(motion.get("live_motion_source") or "").strip().lower()
+    operator_mount_target_reached = False
+    operator_mount_target_idle = False
+    if state.action_mode != "dry-run" and sys_state in {"", "idle", "unknown", "finished", "aborted", "error", "failed"}:
+        operator_mount_target_reached = _last_mount_target_reached(
+            state,
+            current_az=az,
+            current_el=el,
+            require_settle_sec=0.5,
+            update_state=True,
+        )
+        # If the encoder itself still reports motion, do not override.  But stale
+        # SKY/section/control activity after STOP or fixed-target hold should not
+        # keep the UI locked once the last manual mount target has settled.
+        operator_mount_target_idle = bool(
+            operator_mount_target_reached and motion_source_lower != "encoder_delta"
+        )
+    if operator_mount_target_idle:
+        manual_state = "idle"
+        active_task = "none"
+        motion_live_active = False
+        motion_mount_target_reached = True
+        motion_mount_hold_at_target = True
+
     cmd_az = antenna.get("command_az_deg")
     cmd_el = antenna.get("command_el_deg")
     if state.action_mode == "dry-run":
@@ -1886,6 +2007,11 @@ def _operator_status_to_v7_status(
         "motion_live_source": motion.get("live_motion_source"),
         "mount_target_reached": motion_mount_target_reached,
         "mount_hold_at_target": motion_mount_hold_at_target,
+        "operator_last_mount_target_reached": bool(operator_mount_target_reached),
+        "operator_last_mount_target_idle": bool(operator_mount_target_idle),
+        "operator_last_mount_target_az": state.last_mount_target_az,
+        "operator_last_mount_target_el": state.last_mount_target_el,
+        "operator_last_mount_target_reached_since": state.last_mount_target_reached_since,
         "mount_target_reached_tol_deg": motion.get("mount_target_reached_tol_deg"),
         "encoder_motion_deadband_deg": motion.get("encoder_motion_deadband_deg"),
         "encoder_motion_delta_az_deg": motion.get("encoder_motion_delta_az_deg"),

--- a/necst/web/operator_console.py
+++ b/necst/web/operator_console.py
@@ -90,6 +90,12 @@ EXCLUSIVE_START_STATUS_SEC = 15.0
 # is already stopped and ready for the next command.
 SAFETY_RELEASE_ASSUME_IDLE_AFTER_SEC = 1.0
 
+# Fixed Az/El mount move is complete only when the current encoder position
+# has reached the commanded mechanical mount coordinate.  Do not infer READY
+# merely because low-level motion/status temporarily reports idle while the
+# command topic still points away from the current encoder position.
+MOUNT_COMMAND_TARGET_REACHED_TOL_DEG = 7.5e-4
+
 # A progress sidecar can remain in a non-final lifecycle if an observation
 # launcher dies or blocks before writing its final snapshot.  Do not keep the
 # operator UI in OBSERVATION RUNNING forever when no local launcher is active
@@ -1537,6 +1543,33 @@ def _clear_stale_observation_state(state: OperatorConsoleState) -> Tuple[bool, s
         "note": "per-record progress/data directories were not deleted",
     }
 
+
+def _mount_target_reached_from_values(
+    *,
+    current_az: Any,
+    current_el: Any,
+    target_az: Any,
+    target_el: Any,
+    tol_deg: float = MOUNT_COMMAND_TARGET_REACHED_TOL_DEG,
+) -> Optional[bool]:
+    """Return whether current Az/El is at target, or None if unknown.
+
+    This intentionally uses direct mechanical Az difference rather than modulo
+    wrapping: the Manual Mount Az/El control treats Az=360 as a real mechanical
+    coordinate, not automatically as Az=0.
+    """
+
+    try:
+        az = float(current_az)
+        el = float(current_el)
+        taz = float(target_az)
+        tel = float(target_el)
+    except Exception:
+        return None
+    if not (math.isfinite(az) and math.isfinite(el) and math.isfinite(taz) and math.isfinite(tel)):
+        return None
+    return bool(abs(az - taz) <= float(tol_deg) and abs(el - tel) <= float(tol_deg))
+
 def _last_mount_target_reached(
     state: OperatorConsoleState,
     *,
@@ -1572,7 +1605,7 @@ def _last_mount_target_reached(
             state.last_mount_target_reached_since = None
         return False
 
-    reached_now = abs(az - target_az) <= float(tol_deg) and abs(el - target_el) <= float(tol_deg)
+    reached_now = bool(_mount_target_reached_from_values(current_az=az, current_el=el, target_az=target_az, target_el=target_el, tol_deg=tol_deg))
     now = time.time()
     if not reached_now:
         if update_state:
@@ -2695,6 +2728,32 @@ def _operator_status_to_v7_status(
         motion_mount_hold_at_target = False
         motion_source_lower = "operator_safety_release"
 
+    command_target_reached = _mount_target_reached_from_values(
+        current_az=az,
+        current_el=el,
+        target_az=cmd_az,
+        target_el=cmd_el,
+    )
+    operator_mount_command_pending = bool(
+        state.action_mode != "dry-run"
+        and not safety_release_idle
+        and cmd_az is not None
+        and cmd_el is not None
+        and command_target_reached is not True
+    )
+    if operator_mount_command_pending:
+        # The command topic still points to a fixed mechanical Az/El target
+        # that the encoder has not reached yet (or the current encoder value is
+        # unavailable).  Some low-level status streams can briefly report idle
+        # between encoder samples or while the mount is moving slowly.  Do not
+        # let that transient idle make the operator UI return READY.
+        manual_state = "moving"
+        active_task = "manual mount move"
+        motion_live_active = True
+        motion_mount_target_reached = False
+        motion_mount_hold_at_target = False
+        motion_source_lower = "operator_command_target_pending"
+
     if state.action_mode == "dry-run":
         chopper_state = str(chopper.get("state") or state.last_chopper_state or "unknown")
         chopper_position = chopper.get("position")
@@ -2740,6 +2799,8 @@ def _operator_status_to_v7_status(
         "operator_last_mount_target_reached_since": state.last_mount_target_reached_since,
         "operator_safety_release_idle": bool(safety_release_idle),
         "operator_safety_release_age_sec": safety_release_age,
+        "operator_mount_command_pending": bool(operator_mount_command_pending),
+        "operator_mount_command_reached": command_target_reached,
         "mount_target_reached_tol_deg": motion.get("mount_target_reached_tol_deg"),
         "encoder_motion_deadband_deg": motion.get("encoder_motion_deadband_deg"),
         "encoder_motion_delta_az_deg": motion.get("encoder_motion_delta_az_deg"),

--- a/necst/web/operator_console.py
+++ b/necst/web/operator_console.py
@@ -1127,7 +1127,7 @@ def _clear_stale_observation_state(state: OperatorConsoleState) -> Tuple[bool, s
     if active:
         return False, (
             "cannot clear stale observation state while a console-owned launcher "
-            f"is still active: {', '.join(sorted(active))}. Terminate the local "
+            f"is still active: {', '.join(sorted(active))}. Force-kill the local "
             "observation launcher first after confirming the hardware is safe."
         ), {"active_launcher_categories": sorted(active), "cleared": False}
 
@@ -1340,7 +1340,7 @@ def _operator_status_operation_conflict(
     if active_launcher is not None:
         return (
             f"cannot start {requested_action}: {active_launcher}. "
-            "Use STOP/ABORT or terminate the launcher before starting another operation."
+            "Use STOP/ABORT or force-kill the stuck local launcher before starting another operation."
         )
 
     recent_guard = _exclusive_start_guard_reason(state, requested_action=requested_action)
@@ -1373,7 +1373,7 @@ def _operator_status_operation_conflict(
             if stale.get("launcher_stuck"):
                 return (
                     f"cannot start {requested_action}: observation launcher appears stuck "
-                    f"for record {stale.get('record_name') or 'unknown'}; terminate the local observation launcher first"
+                    f"for record {stale.get('record_name') or 'unknown'}; force-kill the local observation launcher first"
                 )
             return (
                 f"cannot start {requested_action}: stale observation state remains "
@@ -1491,7 +1491,12 @@ def _request_launcher_stop(
     category: Optional[str] = None,
     kill: bool = False,
 ) -> Tuple[bool, str, JsonDict]:
-    """Terminate local launcher subprocesses started by this console only."""
+    """Force-kill local launcher subprocesses started by this console only.
+
+    This recovery action only signals local child processes owned by the
+    operator console.  It never sends telescope STOP, recorder STOP, or XFFTS
+    STOP commands.
+    """
 
     pid_value = params.get("pid")
     pid: Optional[int] = None
@@ -1510,7 +1515,7 @@ def _request_launcher_stop(
     )
     if not records:
         selector = f"pid={pid}" if pid is not None else f"category={category or 'any'}"
-        return False, f"no active launcher matched {selector}; no local process was terminated", {
+        return False, f"no active launcher matched {selector}; no local launcher process was force-killed", {
             "action": action,
             "pid": pid,
             "category": category,
@@ -1525,10 +1530,10 @@ def _request_launcher_stop(
         "kill": bool(kill),
         "signal": signal_name,
         "terminated": [record.to_dict() for record in records],
-        "note": "local launcher termination only; telescope STOP/ABORT is a separate action",
+        "note": "local launcher force-kill only; telescope STOP/ABORT/recorder/XFFTS stop are separate actions",
     }
     labels = ", ".join(f"{r.label}(pid={r.pid})" for r in records)
-    return True, f"requested {signal_name} for local launcher(s): {labels}", data
+    return True, f"requested {signal_name} for local launcher(s) only: {labels}", data
 
 
 def dispatch_action(
@@ -1933,6 +1938,11 @@ def dispatch_action(
             stderr_path=stderr_path,
         )
         ok, message, data = _result_to_response(result)
+        if isinstance(data, dict):
+            data.setdefault("obs_mode", mode)
+            data.setdefault("obs_path", path)
+            if channel not in (None, ""):
+                data.setdefault("channel", channel)
         if ok and not dry_run:
             _mark_exclusive_start_guard(
                 state,

--- a/necst/web/operator_console.py
+++ b/necst/web/operator_console.py
@@ -29,7 +29,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
 
-from . import log_reader, process_manager, progress_manager, self_check, site_config, status_model
+from . import log_reader, process_manager, progress_manager, self_check, site_config, status_model, live_telemetry
 
 
 JsonDict = Dict[str, Any]
@@ -105,6 +105,7 @@ class OperatorConsoleState:
     action_mode: str = "live"
     live_actions_enabled: bool = True
     status_refresh_ms: int = 1000
+    status_no_ros: bool = False
     quiet: bool = False
     events_limit: int = 12
     site_summary: site_config.SiteConfigSummary = field(
@@ -113,6 +114,7 @@ class OperatorConsoleState:
     mount_limits: Dict[str, float] = field(default_factory=dict)
     site_capabilities: Dict[str, bool] = field(default_factory=dict)
     chopper_config: Dict[str, Any] = field(default_factory=dict)
+    live_cache: Optional[live_telemetry.LiveTelemetryCache] = None
     operator_log_path: Optional[Path] = None
     launcher_log_dir: Optional[Path] = None
     process_registry: process_manager.ProcessRegistry = field(
@@ -632,6 +634,11 @@ def run_self_check(state: OperatorConsoleState, *, include_progress_health: bool
         progress_monitor=state.progress_monitor,
         events_limit=state.events_limit,
         include_progress_health=include_progress_health,
+        live_telemetry_snapshot=(
+            state.live_cache.snapshot()
+            if state.live_cache is not None
+            else {"requested": False, "available": False, "spin_mode": "disabled"}
+        ),
     )
 
 
@@ -1303,6 +1310,8 @@ def _operator_status_to_v7_status(
     antenna = op.get("antenna") if isinstance(op.get("antenna"), Mapping) else {}
     chopper = op.get("chopper") if isinstance(op.get("chopper"), Mapping) else {}
     progress = op.get("progress") if isinstance(op.get("progress"), Mapping) else {}
+    observation = op.get("observation") if isinstance(op.get("observation"), Mapping) else {}
+    paths = op.get("paths") if isinstance(op.get("paths"), Mapping) else {}
     warnings = op.get("warnings") if isinstance(op.get("warnings"), list) else []
 
     sys_state = str(system.get("state") or "unknown").lower()
@@ -1340,10 +1349,11 @@ def _operator_status_to_v7_status(
     current_az = antenna.get("current_az_deg")
     current_el = antenna.get("current_el_deg")
     try:
-        az = float(current_az) if current_az is not None else 0.0
-        el = float(current_el) if current_el is not None else 0.0
+        az = float(current_az) if current_az is not None else None
+        el = float(current_el) if current_el is not None else None
     except Exception:
-        az, el = 0.0, 0.0
+        az, el = None, None
+    if az is None or el is None:
         warnings = list(warnings) + ["antenna current Az/El is unavailable"]
 
     cmd_az = antenna.get("command_az_deg")
@@ -1402,6 +1412,12 @@ def _operator_status_to_v7_status(
             "owned_by_console": bool(monitor_status.get("owned_by_console")),
             "monitor_status": monitor_status.get("status"),
         },
+        "observation": {
+            "record_name": observation.get("record_name"),
+            "obs_file": observation.get("obs_file"),
+            "recording_dir": observation.get("recording_dir") or paths.get("recording_dir"),
+            "progress_record_dir": observation.get("progress_record_dir") or paths.get("progress_record_dir"),
+        },
         "authority": {
             "held": state.authority.held,
             "session_id": state.authority.session_id,
@@ -1449,6 +1465,11 @@ def _operator_status_to_v7_status(
             ),
         },
         "status_refresh_ms": int(state.status_refresh_ms),
+        "live_telemetry": (
+            state.live_cache.snapshot()
+            if state.live_cache is not None
+            else {"requested": False, "available": False, "spin_mode": "disabled"}
+        ),
         "operator_status": op,
     }
 
@@ -1457,9 +1478,11 @@ def build_console_status(state: OperatorConsoleState) -> JsonDict:
     with state.lock:
         _refresh_processes_and_log(state)
         _sync_authority_state(state)
+        live_payload = state.live_cache.snapshot() if state.live_cache is not None else None
         status_state = status_model.build_progress_status_state(
             state.progress_root,
             events_limit=state.events_limit,
+            live_payload=live_payload,
         )
         return _operator_status_to_v7_status(state, status_state)
 
@@ -1550,9 +1573,11 @@ class OperatorConsoleHandler(BaseHTTPRequestHandler):
             return
         if self.path == "/api/operator-status":
             state = self.server.state
+            live_payload = state.live_cache.snapshot() if state.live_cache is not None else None
             status_state = status_model.build_progress_status_state(
                 state.progress_root,
                 events_limit=state.events_limit,
+                live_payload=live_payload,
             )
             self._send_json(status_state.get("operator_status", {}))
             return
@@ -1730,6 +1755,7 @@ def run_server(
     progress_refresh_ms: int = 500,
     progress_no_ros: bool = False,
     progress_log_dir: Optional[os.PathLike[str] | str] = None,
+    status_no_ros: bool = False,
     action_mode: str = "live",
     live_actions_enabled: bool = True,
     status_refresh_ms: int = 1000,
@@ -1797,6 +1823,7 @@ def run_server(
         action_mode=action_mode,
         live_actions_enabled=bool(live_actions_enabled),
         status_refresh_ms=max(200, int(status_refresh_ms)),
+        status_no_ros=bool(status_no_ros),
         quiet=quiet,
         events_limit=int(events_limit),
         site_summary=site_summary,
@@ -1809,7 +1836,14 @@ def run_server(
         shutdown_launcher_timeout_sec=float(shutdown_launcher_timeout_sec),
         shutdown_launcher_kill_timeout_sec=float(shutdown_launcher_kill_timeout_sec),
     )
+    state.live_cache = live_telemetry.LiveTelemetryCache(enabled=not bool(status_no_ros))
     state.add_log(True, f"console started in action_mode={action_mode}")
+    if state.live_cache is not None:
+        live_snapshot = state.live_cache.snapshot()
+        if live_snapshot.get("available"):
+            state.add_log(True, f"live telemetry enabled ({live_snapshot.get('spin_mode')})", action="live_telemetry")
+        else:
+            state.add_log(False, f"live telemetry unavailable: {live_snapshot.get('error', 'disabled')}", action="live_telemetry")
     if action_mode == "live" and not live_actions_enabled:
         state.add_log(False, LIVE_ACTION_GUARD_MESSAGE, action="live_write_guard")
     if action_mode == "live" and live_actions_enabled:
@@ -1842,6 +1876,7 @@ def run_server(
     if action_mode == "live" and not live_actions_enabled:
         print("  live write guard: ON by --guard-live-actions (write actions blocked; STOP/ABORT remain available)")
     print(f"  status refresh: {max(200, int(status_refresh_ms))} ms")
+    print(f"  console live telemetry ROS: {'disabled' if status_no_ros else 'enabled'}")
     print(f"  operator log: {operator_log_path}")
     print(f"  launcher logs: {resolved_launcher_log_dir}")
     print(f"  progress logs: {resolved_progress_log_dir}")
@@ -1886,6 +1921,11 @@ def run_server(
     finally:
         with state.lock:
             _run_shutdown_cleanup(state)
+            if state.live_cache is not None:
+                try:
+                    state.live_cache.close()
+                except Exception as exc:
+                    state.add_log(False, f"failed to close live telemetry cache: {exc}", action="live_telemetry")
         server.shutdown()
         server.server_close()
         thread.join(timeout=2.0)

--- a/necst/web/operator_console.py
+++ b/necst/web/operator_console.py
@@ -1841,6 +1841,14 @@ def run_server(
         shutdown_launcher_kill_timeout_sec=float(shutdown_launcher_kill_timeout_sec),
     )
     state.live_cache = live_telemetry.LiveTelemetryCache(enabled=not bool(status_no_ros))
+    if state.live_cache is not None and state.live_cache.available:
+        # Wait briefly for the first encoder/pointing sample so the console
+        # starts with real Current Az/El whenever ROS status topics are alive.
+        # This is read-only; it does not send any telescope command.
+        try:
+            state.live_cache.wait_for_initial_position(timeout_sec=2.0)
+        except Exception as exc:
+            state.live_cache.error = f"initial live telemetry wait failed: {exc}"
     state.add_log(True, f"console started in action_mode={action_mode}")
     state.add_log(
         True,
@@ -1856,8 +1864,20 @@ def run_server(
     )
     if state.live_cache is not None:
         live_snapshot = state.live_cache.snapshot()
-        if live_snapshot.get("available"):
-            state.add_log(True, f"live telemetry enabled ({live_snapshot.get('spin_mode')})", action="live_telemetry")
+        if live_snapshot.get("available") and live_snapshot.get("has_position"):
+            state.add_log(
+                True,
+                f"live telemetry enabled ({live_snapshot.get('spin_mode')}); position sample received",
+                action="live_telemetry",
+                data={"sample_counts": live_snapshot.get("sample_counts", {})},
+            )
+        elif live_snapshot.get("available"):
+            state.add_log(
+                False,
+                f"live telemetry enabled ({live_snapshot.get('spin_mode')}) but no encoder/pointing position sample received yet",
+                action="live_telemetry",
+                data={"sample_counts": live_snapshot.get("sample_counts", {})},
+            )
         else:
             state.add_log(False, f"live telemetry unavailable: {live_snapshot.get('error', 'disabled')}", action="live_telemetry")
     if action_mode == "live" and not live_actions_enabled:

--- a/necst/web/operator_console.py
+++ b/necst/web/operator_console.py
@@ -30,6 +30,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
 
 from . import log_reader, process_manager, progress_manager, self_check, site_config, status_model, live_telemetry
+from ..ctrl.antenna.az_unwrap import assert_mount_az_allowed_when_unwrap_disabled
 
 
 JsonDict = Dict[str, Any]
@@ -253,6 +254,9 @@ def validate_mount_target(
         raise ValueError("site TOML El min/max are invalid")
     if not (az_min <= az <= az_max):
         raise ValueError(f"Az={az:g} deg is outside site TOML range {az_min:g}..{az_max:g} deg")
+    assert_mount_az_allowed_when_unwrap_disabled(
+        az, action_label="operator console mount move"
+    )
     if not (el_min <= el <= el_max):
         raise ValueError(f"El={el:g} deg is outside site TOML range {el_min:g}..{el_max:g} deg")
     return az, el
@@ -1785,9 +1789,9 @@ def run_server(
     )
     limits = dict(site_summary.mount_limits)
     resolved_operator_log_dir = (
-        Path(operator_log_dir)
+        Path(operator_log_dir).expanduser()
         if operator_log_dir not in (None, "")
-        else Path(progress_root) / "operator_console"
+        else Path(os.environ.get("NECST_OPERATOR_LOG_DIR", Path.home() / ".necst" / "operator_console")).expanduser()
     )
     resolved_launcher_log_dir = (
         Path(launcher_log_dir)
@@ -1838,6 +1842,18 @@ def run_server(
     )
     state.live_cache = live_telemetry.LiveTelemetryCache(enabled=not bool(status_no_ros))
     state.add_log(True, f"console started in action_mode={action_mode}")
+    state.add_log(
+        True,
+        "operator log append file configured",
+        action="operator_log",
+        data={
+            "operator_log_path": str(operator_log_path),
+            "operator_log_dir": str(resolved_operator_log_dir),
+            "launcher_log_dir": str(resolved_launcher_log_dir),
+            "progress_log_dir": str(resolved_progress_log_dir),
+            "append_only": True,
+        },
+    )
     if state.live_cache is not None:
         live_snapshot = state.live_cache.snapshot()
         if live_snapshot.get("available"):

--- a/necst/web/operator_console.py
+++ b/necst/web/operator_console.py
@@ -2117,6 +2117,8 @@ def _operator_status_to_v7_status(
             "record_name": observation.get("record_name"),
             "obs_file": observation.get("obs_file"),
             "recording_dir": observation.get("recording_dir") or paths.get("recording_dir"),
+            "local_recording_dir": observation.get("local_recording_dir") or paths.get("local_recording_dir"),
+            "record_path_display_mode": observation.get("record_path_display_mode") or paths.get("record_path_display_mode") or "local",
             "progress_record_dir": observation.get("progress_record_dir") or paths.get("progress_record_dir"),
         },
         "authority": {

--- a/necst/web/operator_console.py
+++ b/necst/web/operator_console.py
@@ -118,6 +118,7 @@ class OperatorConsoleState:
     live_cache: Optional[live_telemetry.LiveTelemetryCache] = None
     operator_log_path: Optional[Path] = None
     launcher_log_dir: Optional[Path] = None
+    obs_roots: List[Path] = field(default_factory=list)
     process_registry: process_manager.ProcessRegistry = field(
         default_factory=process_manager.ProcessRegistry
     )
@@ -276,6 +277,248 @@ def validate_observation_selection(params: Mapping[str, Any]) -> Tuple[str, str,
         raise ValueError("obs file extension must be .obs or .toml")
     channel = _optional_positive_int(params.get("channel"), name="channel override")
     return mode, path, channel
+
+
+def _split_env_paths(value: str) -> List[str]:
+    parts: List[str] = []
+    for chunk in str(value or "").replace(";", os.pathsep).split(os.pathsep):
+        chunk = chunk.strip()
+        if chunk:
+            parts.append(chunk)
+    return parts
+
+
+def _dir_has_obs_files(path: Path) -> bool:
+    """Return True when *path* directly contains likely obs files.
+
+    This deliberately checks only one directory level.  The browser can then
+    descend interactively; startup should not recursively scan large mounted
+    disks or network filesystems.
+    """
+
+    try:
+        for child in path.iterdir():
+            if child.is_file() and child.suffix.lower() in {".obs", ".toml"}:
+                return True
+    except Exception:
+        return False
+    return False
+
+
+def _auto_obs_root_candidates() -> List[Path]:
+    """Return NECST-side browse roots visible to this console process.
+
+    The browser cannot see Docker/container files directly.  The console
+    therefore exposes a read-only file chooser over the filesystem visible to
+    the process running this web server.  When no explicit ``--obs-root`` is
+    supplied we choose practical starting locations, including the filesystem
+    root, so the UI behaves like an ordinary file chooser rather than showing
+    an empty selector.
+    """
+
+    raw_candidates: List[str] = []
+    for raw in (
+        os.environ.get("NECST_CONSOLE_OBS_BASE", ""),
+        os.environ.get("NECST_OBS_BASE", ""),
+        os.environ.get("NECST_RECORD_ROOT", ""),
+        os.environ.get("ROS2_WS", ""),
+        os.environ.get("COLCON_PREFIX_PATH", "").split(os.pathsep)[0] if os.environ.get("COLCON_PREFIX_PATH") else "",
+        str(Path.cwd()),
+        str(Path.home()),
+        str(Path.home() / "obs"),
+        str(Path.home() / "observations"),
+        str(Path.home() / "data"),
+        str(Path.home() / "data" / "obs"),
+        str(Path.home() / "data" / "observations"),
+        "/root/obs",
+        "/root/observations",
+        "/root/data",
+        "/root/ros2_ws",
+        "/root",
+        "/home/necst/obs",
+        "/home/necst/observations",
+        "/data/obs",
+        "/data/observations",
+        "/data/observations/current",
+        "/data",
+        "/workspaces",
+        "/workspace",
+        "/mnt/data",
+        "/",
+    ):
+        raw = str(raw or "").strip()
+        if raw:
+            raw_candidates.append(raw)
+
+    # Put obs-like directories first when they exist, but do not hide the
+    # broader filesystem roots.  Users can still narrow the chooser by passing
+    # --obs-root or NECST_CONSOLE_OBS_ROOTS.
+    obs_names = ("obs", "obsfiles", "obs_files", "observation", "observations", "observation_files")
+    expanded: List[Path] = []
+    for raw in raw_candidates:
+        try:
+            base = Path(raw).expanduser()
+        except Exception:
+            continue
+        name = base.name.lower()
+        if name not in obs_names:
+            expanded.extend(base / name for name in obs_names)
+        expanded.append(base)
+    return expanded
+
+
+def resolve_obs_roots(configured_roots: Optional[List[os.PathLike[str] | str]] = None) -> List[Path]:
+    """Return NECST-side browse roots for preview and obs selection.
+
+    If ``--obs-root`` or ``NECST_CONSOLE_OBS_ROOTS`` is supplied, those paths
+    define the chooser locations.  Otherwise the console provides practical
+    defaults visible to the process running the console, including Home, common
+    obs/data directories, the current directory, and ``/``.  This makes the
+    chooser usable without command-line options while still allowing a site to
+    restrict it explicitly.
+    """
+
+    configured: List[os.PathLike[str] | str] = []
+    if configured_roots:
+        configured.extend(str(p) for p in configured_roots if str(p or "").strip())
+    for env_name in ("NECST_CONSOLE_OBS_ROOTS", "NECST_OBS_ROOTS"):
+        configured.extend(_split_env_paths(os.environ.get(env_name, "")))
+    for env_name in ("NECST_CONSOLE_OBS_ROOT", "NECST_OBS_ROOT", "NECST_OBS_DIR"):
+        val = os.environ.get(env_name, "").strip()
+        if val:
+            configured.append(val)
+
+    candidates = configured if configured else _auto_obs_root_candidates()
+
+    roots: List[Path] = []
+    seen: set[str] = set()
+    for raw in candidates:
+        try:
+            resolved = Path(raw).expanduser().resolve()
+        except Exception:
+            continue
+        key = str(resolved)
+        if key in seen:
+            continue
+        seen.add(key)
+        if resolved.exists() and resolved.is_dir():
+            roots.append(resolved)
+    return roots
+
+
+def _obs_root_label(path: Path) -> str:
+    try:
+        home = Path.home().resolve()
+        if path.resolve() == home:
+            return f"Home ({path})"
+    except Exception:
+        pass
+    if str(path) == "/":
+        return "Filesystem root (/)"
+    name = path.name or str(path)
+    if name.lower() in {"obs", "observations", "obsfiles", "obs_files"}:
+        return f"Obs folder ({path})"
+    if name.lower() == "data":
+        return f"Data folder ({path})"
+    if path == Path.cwd().resolve():
+        return f"Current directory ({path})"
+    return str(path)
+
+
+def _path_under_root(path: Path, roots: List[Path]) -> bool:
+    try:
+        resolved = path.expanduser().resolve()
+    except Exception:
+        return False
+    for root in roots:
+        try:
+            resolved.relative_to(root.resolve())
+            return True
+        except Exception:
+            continue
+    return False
+
+
+def _safe_obs_path(raw_path: str, roots: List[Path]) -> Path:
+    if not roots:
+        raise ValueError("no NECST-side locations are available; check filesystem permissions or set --obs-root")
+    if not str(raw_path or "").strip():
+        raise ValueError("obs path is empty")
+    path = Path(str(raw_path)).expanduser()
+    if not path.is_absolute():
+        path = roots[0] / path
+    try:
+        resolved = path.resolve()
+    except Exception as exc:
+        raise ValueError(f"cannot resolve NECST-side path: {exc}") from exc
+    if not _path_under_root(resolved, roots):
+        root_text = ", ".join(str(r) for r in roots)
+        raise ValueError(f"NECST-side path is outside configured locations: {resolved}; roots={root_text}")
+    return resolved
+
+
+def obs_roots_payload(roots: List[Path]) -> JsonDict:
+    return {
+        "ok": True,
+        "roots": [{"path": str(root), "label": _obs_root_label(root)} for root in roots],
+        "message": (
+            "NECST-side locations are paths visible to the process running this console"
+            if roots
+            else "no NECST-side locations found"
+        ),
+    }
+
+
+def list_server_obs_files(roots: List[Path], directory: str = "") -> JsonDict:
+    browse_dir = _safe_obs_path(directory or (str(roots[0]) if roots else ""), roots)
+    if not browse_dir.exists() or not browse_dir.is_dir():
+        raise ValueError(f"NECST-side directory does not exist or is not a directory: {browse_dir}")
+    entries: List[JsonDict] = []
+    parent = browse_dir.parent
+    if parent != browse_dir and _path_under_root(parent, roots):
+        entries.append({"type": "directory", "name": "..", "path": str(parent), "size": None})
+    try:
+        children = list(browse_dir.iterdir())
+    except Exception as exc:
+        raise ValueError(f"failed to list NECST-side directory {browse_dir}: {exc}") from exc
+    for child in sorted(children, key=lambda p: (not p.is_dir(), p.name.lower())):
+        try:
+            if child.is_dir():
+                entries.append({"type": "directory", "name": child.name, "path": str(child.resolve()), "size": None})
+            elif child.is_file() and child.suffix.lower() in {".obs", ".toml"}:
+                entries.append({
+                    "type": "file",
+                    "name": child.name,
+                    "path": str(child.resolve()),
+                    "size": int(child.stat().st_size),
+                })
+        except Exception:
+            continue
+    return {"ok": True, "directory": str(browse_dir), "entries": entries, "root_count": len(roots)}
+
+
+def preview_server_obs_file(roots: List[Path], path: str, *, max_bytes: int = 65536) -> JsonDict:
+    obs_path = _safe_obs_path(path, roots)
+    if obs_path.suffix.lower() not in {".obs", ".toml", ".txt"}:
+        raise ValueError("NECST-side preview only allows .obs, .toml, or .txt files")
+    if not obs_path.exists() or not obs_path.is_file():
+        raise ValueError(f"NECST-side obs file does not exist: {obs_path}")
+    max_b = max(1024, min(int(max_bytes), 1024 * 1024))
+    data = obs_path.read_bytes()
+    truncated = len(data) > max_b
+    chunk = data[:max_b]
+    preview_text = chunk.decode("utf-8", errors="replace")
+    return {
+        "ok": True,
+        "path": str(obs_path),
+        "directory": str(obs_path.parent),
+        "filename": obs_path.name,
+        "text": preview_text,
+        "size_bytes": len(data),
+        "returned_bytes": len(chunk),
+        "line_count": len(preview_text.splitlines()),
+        "truncated": bool(truncated),
+    }
 
 def validate_site_capability(
     state: OperatorConsoleState,
@@ -1575,6 +1818,26 @@ class OperatorConsoleHandler(BaseHTTPRequestHandler):
         if self.path == "/api/status":
             self._send_json(build_console_status(self.server.state))
             return
+        parsed = urllib.parse.urlparse(self.path)
+        query = urllib.parse.parse_qs(parsed.query)
+        if parsed.path == "/api/obs-roots":
+            self._send_json(obs_roots_payload(self.server.state.obs_roots))
+            return
+        if parsed.path == "/api/obs-list":
+            try:
+                directory = (query.get("dir") or [""])[0]
+                self._send_json(list_server_obs_files(self.server.state.obs_roots, directory))
+            except Exception as exc:
+                self._send_json({"ok": False, "reason": str(exc), "entries": []}, status=400)
+            return
+        if parsed.path == "/api/obs-preview":
+            try:
+                path = (query.get("path") or [""])[0]
+                max_bytes = int((query.get("max_bytes") or [65536])[0])
+                self._send_json(preview_server_obs_file(self.server.state.obs_roots, path, max_bytes=max_bytes))
+            except Exception as exc:
+                self._send_json({"ok": False, "reason": str(exc), "text": ""}, status=400)
+            return
         if self.path == "/api/operator-status":
             state = self.server.state
             live_payload = state.live_cache.snapshot() if state.live_cache is not None else None
@@ -1585,8 +1848,6 @@ class OperatorConsoleHandler(BaseHTTPRequestHandler):
             )
             self._send_json(status_state.get("operator_status", {}))
             return
-        parsed = urllib.parse.urlparse(self.path)
-        query = urllib.parse.parse_qs(parsed.query)
         if parsed.path == "/api/processes":
             state = self.server.state
             with state.lock:
@@ -1759,6 +2020,7 @@ def run_server(
     progress_refresh_ms: int = 500,
     progress_no_ros: bool = False,
     progress_log_dir: Optional[os.PathLike[str] | str] = None,
+    obs_roots: Optional[List[os.PathLike[str] | str]] = None,
     status_no_ros: bool = False,
     action_mode: str = "live",
     live_actions_enabled: bool = True,
@@ -1807,6 +2069,7 @@ def run_server(
     resolved_launcher_log_dir.mkdir(parents=True, exist_ok=True)
     resolved_progress_log_dir.mkdir(parents=True, exist_ok=True)
     operator_log_path = resolved_operator_log_dir / "operator_console.jsonl"
+    resolved_obs_roots = resolve_obs_roots(obs_roots)
     progress_script = Path(__file__).resolve().parents[2] / "bin" / "progress.py"
     progress_monitor = progress_manager.ProgressMonitorManager(
         progress_script=progress_script,
@@ -1836,6 +2099,7 @@ def run_server(
         chopper_config=dict(site_summary.chopper),
         operator_log_path=operator_log_path,
         launcher_log_dir=resolved_launcher_log_dir,
+        obs_roots=list(resolved_obs_roots),
         shutdown_terminate_launchers=bool(shutdown_terminate_launchers),
         shutdown_launcher_timeout_sec=float(shutdown_launcher_timeout_sec),
         shutdown_launcher_kill_timeout_sec=float(shutdown_launcher_kill_timeout_sec),
@@ -1861,6 +2125,16 @@ def run_server(
             "progress_log_dir": str(resolved_progress_log_dir),
             "append_only": True,
         },
+    )
+    state.add_log(
+        bool(resolved_obs_roots),
+        (
+            "NECST-side file chooser locations configured: " + ", ".join(str(p) for p in resolved_obs_roots)
+            if resolved_obs_roots
+            else "NECST-side file chooser found no existing locations; check filesystem permissions or use --obs-root"
+        ),
+        action="necst_side_obs_browser",
+        data={"obs_roots": [str(p) for p in resolved_obs_roots]},
     )
     if state.live_cache is not None:
         live_snapshot = state.live_cache.snapshot()

--- a/necst/web/operator_console.py
+++ b/necst/web/operator_console.py
@@ -30,7 +30,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
 
-from . import log_reader, process_manager, progress_manager, self_check, site_config, status_model, live_telemetry
+from . import log_reader, observation_log, process_manager, progress_manager, self_check, site_config, status_model, live_telemetry
 from ..az_unwrap_limits import assert_mount_az_allowed_when_unwrap_disabled
 
 
@@ -156,6 +156,7 @@ class OperatorConsoleState:
     site_capabilities: Dict[str, bool] = field(default_factory=dict)
     chopper_config: Dict[str, Any] = field(default_factory=dict)
     live_cache: Optional[live_telemetry.LiveTelemetryCache] = None
+    observation_log: Optional[observation_log.ObservationLogManager] = None
     operator_log_path: Optional[Path] = None
     launcher_log_dir: Optional[Path] = None
     obs_roots: List[Path] = field(default_factory=list)
@@ -181,6 +182,9 @@ class OperatorConsoleState:
     last_safety_release_requested_at: Optional[float] = None
     last_manual_state: str = "idle"
     last_active_task: str = "none"
+    last_observation_abort_requested_at: Optional[float] = None
+    last_observation_stop_requested_at: Optional[float] = None
+    last_observation_safety_labels: List[str] = field(default_factory=list)
     last_chopper_state: str = "unknown"
     last_chopper_position: Optional[float] = None
     shutdown_requested: bool = False
@@ -919,6 +923,226 @@ def _shutdown_snapshot(state: OperatorConsoleState) -> JsonDict:
         "summary": dict(state.cleanup_summary),
     }
 
+
+def _observation_log_context(state: OperatorConsoleState) -> JsonDict:
+    """Return current telemetry/context fields for the observer CSV log."""
+
+    context: JsonDict = {
+        "enc_az_deg": None,
+        "enc_el_deg": None,
+        "weather": {},
+        "record_dir": "",
+    }
+    live_payload = state.live_cache.snapshot() if state.live_cache is not None else {}
+    if isinstance(live_payload, Mapping):
+        encoder = live_payload.get("encoder") if isinstance(live_payload.get("encoder"), Mapping) else {}
+        context["enc_az_deg"] = encoder.get("encoder_lon_deg")
+        context["enc_el_deg"] = encoder.get("encoder_lat_deg")
+        weather = live_payload.get("weather") if isinstance(live_payload.get("weather"), Mapping) else {}
+        context["weather"] = dict(weather)
+    try:
+        status_state = status_model.build_progress_status_state(
+            state.progress_root,
+            events_limit=1,
+            live_payload=live_payload if isinstance(live_payload, Mapping) else None,
+        )
+        op = status_state.get("operator_status") if isinstance(status_state, Mapping) else {}
+        if isinstance(op, Mapping):
+            antenna = op.get("antenna") if isinstance(op.get("antenna"), Mapping) else {}
+            if context.get("enc_az_deg") is None:
+                context["enc_az_deg"] = antenna.get("current_az_deg")
+            if context.get("enc_el_deg") is None:
+                context["enc_el_deg"] = antenna.get("current_el_deg")
+            observation = op.get("observation") if isinstance(op.get("observation"), Mapping) else {}
+            paths = op.get("paths") if isinstance(op.get("paths"), Mapping) else {}
+            context["record_dir"] = (
+                observation.get("local_recording_dir")
+                or paths.get("local_recording_dir")
+                or observation.get("recording_dir")
+                or paths.get("recording_dir")
+                or observation.get("progress_record_dir")
+                or paths.get("progress_record_dir")
+                or ""
+            )
+        weather_state = status_state.get("weather") if isinstance(status_state.get("weather"), Mapping) else {}
+        if weather_state and not context.get("weather"):
+            context["weather"] = dict(weather_state)
+    except Exception:
+        pass
+    return context
+
+
+def _obslog_result(ok: bool, action: str, data: Mapping[str, Any]) -> str:
+    if not ok:
+        return "failed"
+    if action == "start_observation":
+        return "running"
+    if action == "run_rsky" or action == "run_skydip":
+        return "running"
+    if action == "abort_observation":
+        return "aborted"
+    if action in {"stop", "stop_tracking"}:
+        return "stopped"
+    return "success"
+
+
+def _active_process_labels(state: OperatorConsoleState, *, category: str) -> List[str]:
+    try:
+        return [str(record.label or record.category or "") for record in state.process_registry.active(category=category)]
+    except Exception:
+        return []
+
+
+def _mode_from_process_label(label: str, *, default: str = "Observation") -> str:
+    text = str(label or "")
+    if ":" in text:
+        candidate = text.split(":", 1)[1].strip()
+        if candidate:
+            return candidate.upper()
+    return default
+
+
+def _active_observation_mode(state: OperatorConsoleState) -> str:
+    labels = _active_process_labels(state, category="observation")
+    if labels:
+        return _mode_from_process_label(labels[0], default="Observation")
+    return "Observation"
+
+
+def _active_observation_text(state: OperatorConsoleState, *, fallback: str) -> str:
+    labels = [label for label in _active_process_labels(state, category="observation") if label]
+    if labels:
+        return ", ".join(labels)
+    return fallback
+
+
+def _obslog_event_for_action(action: str) -> Optional[str]:
+    return {
+        "check_observation": "observation_check_clicked",
+        "dry_run_observation": "observation_dry_run_clicked",
+        "start_observation": "observation_start_clicked",
+        "abort_observation": "abort_clicked",
+        "mount_move": "mount_move_clicked",
+        "mount_move_dry_run": "mount_move_dry_run_clicked",
+        "stop": "stop_clicked",
+        "start_tracking": "target_tracking_start_clicked",
+        "stop_tracking": "target_tracking_stop_clicked",
+        "run_rsky": "rsky_start_clicked",
+        "run_skydip": "skydip_start_clicked",
+        "chopper_in": "chopper_in_clicked",
+        "chopper_out": "chopper_out_clicked",
+        "chopper_status": "chopper_status_clicked",
+        "chopper_alarm_reset": "chopper_alarm_reset_clicked",
+        "chopper_home": "chopper_home_clicked",
+        "chopper_recover": "chopper_recover_clicked",
+        "clear_stale_observation_state": "stale_state_cleared",
+        "terminate_observation_launcher": "local_observation_launcher_force_kill_clicked",
+        "terminate_calibration_launcher": "local_calibration_launcher_force_kill_clicked",
+        "terminate_all_launchers": "local_launchers_force_kill_clicked",
+        "terminate_process": "local_launcher_force_kill_clicked",
+        "kill_process": "local_launcher_force_kill_clicked",
+    }.get(action)
+
+
+def _obslog_mode_for_action(
+    action: str,
+    params: Mapping[str, Any],
+    data: Mapping[str, Any],
+    state: Optional[OperatorConsoleState] = None,
+) -> str:
+    if action in {"check_observation", "dry_run_observation", "start_observation"}:
+        return str(data.get("obs_mode") or params.get("mode") or "Observation").upper()
+    if action in {"abort_observation", "stop"} and state is not None:
+        labels = _active_process_labels(state, category="observation")
+        if labels:
+            return _mode_from_process_label(labels[0], default="Observation")
+    if action in {"mount_move", "mount_move_dry_run"}:
+        return "Mount"
+    if action in {"start_tracking", "stop_tracking"}:
+        return "Tracking"
+    if action in {"run_rsky"}:
+        return "RSky"
+    if action in {"run_skydip"}:
+        return "SkyDip"
+    if action.startswith("chopper_"):
+        return "Chopper"
+    if action in {"stop", "abort_observation", "clear_stale_observation_state"}:
+        return "Console"
+    if action.startswith("terminate_") or action in {"kill_process"}:
+        return "Recovery"
+    return "Console"
+
+
+def _obslog_action_text(
+    action: str,
+    params: Mapping[str, Any],
+    data: Mapping[str, Any],
+    state: Optional[OperatorConsoleState] = None,
+) -> str:
+    if action in {"check_observation", "dry_run_observation", "start_observation"}:
+        return observation_log.obsfile_name_for_csv(data.get("obs_path") or params.get("file") or "")
+    if action in {"abort_observation", "stop"} and state is not None:
+        labels = _active_process_labels(state, category="observation")
+        if labels:
+            return f"{action}: " + ", ".join(labels)
+    if action in {"mount_move", "mount_move_dry_run"}:
+        return f"Az={params.get('az', '')}, El={params.get('el', '')}"
+    if action == "start_tracking":
+        target = params.get("target") or params.get("target_kind") or params.get("kind") or params.get("name") or "target"
+        return str(target)
+    if action in {"run_rsky", "run_skydip"}:
+        return ", ".join(f"{k}={v}" for k, v in params.items() if v not in (None, ""))
+    if action in {"chopper_in", "chopper_out"}:
+        return action.replace("chopper_", "chopper ").upper()
+    if action.startswith("terminate_") or action in {"kill_process"}:
+        note = data.get("note") or data.get("message") or ""
+        pid = params.get("pid")
+        pid_text = f"pid={pid}" if pid not in (None, "") else ""
+        return ", ".join(part for part in (str(note or action), pid_text) if part)
+    return str(data.get("action") or action)
+
+
+def _write_observation_log_for_action(
+    state: OperatorConsoleState,
+    *,
+    action: str,
+    params: Mapping[str, Any],
+    ok: bool,
+    data: Mapping[str, Any],
+) -> None:
+    manager = state.observation_log
+    if manager is None:
+        return
+    event = _obslog_event_for_action(action)
+    if event is None:
+        return
+    context = _observation_log_context(state)
+    record_dir = None
+    if action == "start_observation":
+        record_dir = data.get("recording_dir") or data.get("local_recording_dir") or data.get("progress_record_dir")
+    written = manager.write_event(
+        context,
+        mode=_obslog_mode_for_action(action, params, data, state),
+        event=event,
+        action_or_obsfile=_obslog_action_text(action, params, data, state),
+        result=_obslog_result(ok, action, data),
+        record_dir=record_dir,
+    )
+    if not written:
+        state.add_log(
+            False,
+            f"failed to append observation CSV log row: {manager.last_error or 'unknown error'}",
+            action="observation_csv_log",
+            data={"source_action": action},
+        )
+
+
+def _obslog_status_payload(state: OperatorConsoleState) -> JsonDict:
+    manager = state.observation_log
+    if manager is None:
+        return {"ok": False, "reason": "observation CSV log is not configured"}
+    return {"ok": True, "observation_log": manager.status()}
+
 def run_self_check(state: OperatorConsoleState, *, include_progress_health: bool = True) -> JsonDict:
     """Run read-only console self-checks without sending telescope commands."""
 
@@ -962,7 +1186,42 @@ def _refresh_processes_and_log(state: OperatorConsoleState) -> None:
         else:
             message = f"{record.label} pid={record.pid} is no longer tracked"
         state.add_log(ok, message, action="process_exit", data=record.to_dict())
+        if state.observation_log is not None and record.category in {"observation", "calibration"}:
+            label = str(getattr(record, "label", "") or "")
+            result_text = "success" if ok else "failed"
+            if record.category == "observation":
+                mode = label.split(":", 1)[1].upper() if ":" in label else "Observation"
+                safety_labels = list(getattr(state, "last_observation_safety_labels", []) or [])
+                safety_matches = (not safety_labels) or (label in safety_labels)
+                if state.last_observation_abort_requested_at is not None and safety_matches:
+                    event = "observation_aborted"
+                    result_text = "aborted"
+                elif state.last_observation_stop_requested_at is not None and safety_matches:
+                    event = "observation_stopped"
+                    result_text = "stopped"
+                else:
+                    event = "observation_finished" if ok else "observation_failed"
+            else:
+                mode = label.split(":", 1)[1] if ":" in label else "Calibration"
+                event = f"{mode.lower()}_finished" if ok else f"{mode.lower()}_failed"
+            written = state.observation_log.write_event(
+                _observation_log_context(state),
+                mode=mode,
+                event=event,
+                action_or_obsfile=label or getattr(record, "category", ""),
+                result=result_text,
+            )
+            if not written:
+                state.add_log(
+                    False,
+                    f"failed to append observation CSV final-state row: {state.observation_log.last_error or 'unknown error'}",
+                    action="observation_csv_log",
+                    data={"source_action": "process_exit", "label": label},
+                )
         if record.category == "observation" and not state.process_registry.active(category="observation"):
+            state.last_observation_abort_requested_at = None
+            state.last_observation_stop_requested_at = None
+            state.last_observation_safety_labels = []
             if state.last_active_task == "observation":
                 state.last_active_task = "none"
             if state.last_manual_state == "observing sequence":
@@ -1557,6 +1816,46 @@ def dispatch_action(
         state.log.clear()
         return True, "operation log cleared", {"action": action}
 
+    if action == "obslog_status":
+        data = _obslog_status_payload(state)
+        return bool(data.get("ok")), "observation CSV log status", data
+
+    if action == "obslog_comment":
+        manager = state.observation_log
+        if manager is None:
+            return False, "observation CSV log is not configured", {"action": action}
+        comment = str(params.get("comment") or "").strip()
+        if not comment:
+            return False, "comment is empty; no observation-log row was written", {"action": action}
+        written = manager.write_event(
+            _observation_log_context(state),
+            comment=comment,
+            mode="Comment",
+            event="comment",
+            action_or_obsfile="manual comment",
+            result="success",
+        )
+        if not written:
+            return False, f"failed to append observation CSV log comment: {manager.last_error or 'unknown error'}", {
+                "action": action,
+                "observation_log": manager.status(),
+            }
+        return True, "comment appended to observation CSV log", {"action": action, "observation_log": manager.status()}
+
+    if action == "obslog_new":
+        manager = state.observation_log
+        if manager is None:
+            return False, "observation CSV log is not configured", {"action": action}
+        manager.open_new(prefix=params.get("prefix") or manager.prefix, observer=params.get("user") or manager.observer)
+        return True, "new observation CSV log opened", {"action": action, "observation_log": manager.status()}
+
+    if action == "obslog_open_existing":
+        manager = state.observation_log
+        if manager is None:
+            return False, "observation CSV log is not configured", {"action": action}
+        manager.open_existing(params.get("path"), observer=params.get("user") or manager.observer)
+        return True, "existing observation CSV log opened for append", {"action": action, "observation_log": manager.status()}
+
     if action == "launch_progress":
         if state.progress_monitor is None:
             return True, f"progress monitor URL: {state.progress_url}", {
@@ -1817,6 +2116,10 @@ def dispatch_action(
         ok, message, data = _result_to_response(result)
         data.update(safety_data)
         if ok:
+            active_obs_labels = _active_process_labels(state, category="observation")
+            if active_obs_labels:
+                state.last_observation_stop_requested_at = time.time()
+                state.last_observation_safety_labels = active_obs_labels
             _clear_exclusive_start_guard(state)
             _mark_safety_release_request(state)
             state.last_manual_state = "stopped"
@@ -1894,6 +2197,10 @@ def dispatch_action(
         ok, message, data = _result_to_response(result)
         data.update(safety_data)
         if ok:
+            active_obs_labels = _active_process_labels(state, category="observation")
+            if active_obs_labels:
+                state.last_observation_abort_requested_at = time.time()
+                state.last_observation_safety_labels = active_obs_labels
             _clear_exclusive_start_guard(state)
             _mark_safety_release_request(state)
             state.last_manual_state = "stopped"
@@ -2399,6 +2706,7 @@ def _operator_status_to_v7_status(
         "self_check_endpoint": "/api/self-check",
         "operator_log_path": str(state.operator_log_path) if state.operator_log_path is not None else None,
         "launcher_log_dir": str(state.launcher_log_dir) if state.launcher_log_dir is not None else None,
+        "observation_log": (state.observation_log.status() if state.observation_log is not None else {"ok": False}),
         "action_mode": state.action_mode,
         "live_actions": {
             "enabled": bool(state.live_actions_enabled),
@@ -2618,6 +2926,10 @@ class OperatorConsoleHandler(BaseHTTPRequestHandler):
         session_id = str(payload.get("session_id") or uuid.uuid4())
         with self.server.state.lock:
             try:
+                manager = self.server.state.observation_log
+                obslog_user = payload.get("obslog_user")
+                if manager is not None and obslog_user not in (None, ""):
+                    manager.update_observer(obslog_user)
                 ok, reason, data = dispatch_action(
                     self.server.state,
                     action,
@@ -2627,6 +2939,14 @@ class OperatorConsoleHandler(BaseHTTPRequestHandler):
             except Exception as exc:
                 ok, reason, data = False, str(exc), {"exception_type": type(exc).__name__}
             self.server.state.add_log(ok, reason, action=action, session_id=session_id, data=data)
+            if isinstance(data, Mapping):
+                _write_observation_log_for_action(
+                    self.server.state,
+                    action=action,
+                    params=params,
+                    ok=ok,
+                    data=data,
+                )
         response: JsonDict = {"ok": ok, "reason": reason, "data": data}
         if isinstance(data, Mapping):
             if data.get("progress_url") is not None:
@@ -2736,6 +3056,9 @@ def run_server(
     site_config_path: Optional[os.PathLike[str] | str] = None,
     operator_log_dir: Optional[os.PathLike[str] | str] = None,
     launcher_log_dir: Optional[os.PathLike[str] | str] = None,
+    obslog_dir: Optional[os.PathLike[str] | str] = None,
+    obslog_prefix: Optional[str] = None,
+    obslog_user: Optional[str] = None,
     shutdown_terminate_launchers: bool = True,
     shutdown_launcher_timeout_sec: float = 3.0,
     shutdown_launcher_kill_timeout_sec: float = 1.0,
@@ -2775,6 +3098,17 @@ def run_server(
     resolved_progress_log_dir.mkdir(parents=True, exist_ok=True)
     operator_log_path = resolved_operator_log_dir / "operator_console.jsonl"
     resolved_obs_roots = resolve_obs_roots(obs_roots)
+    observer_csv_log = observation_log.ObservationLogManager.create(
+        configured_dir=obslog_dir,
+        # Do not use --obs-root here: it is an obs-file browser location, not
+        # necessarily the data/record root.  ObservationLogManager still uses
+        # NECST_CONSOLE_PC_RECORD_ROOT, NECST_RECORD_ROOT, etc. for
+        # <record root>/obslogs before falling back to ~/.necst.
+        record_roots=None,
+        prefix=obslog_prefix or os.environ.get("NECST_OBSLOG_PREFIX", observation_log.DEFAULT_PREFIX),
+        observer=obslog_user or os.environ.get("NECST_OBSLOG_USER", observation_log.DEFAULT_OBSERVER),
+        telescope=telescope,
+    )
     progress_script = Path(__file__).resolve().parents[2] / "bin" / "progress.py"
     progress_monitor = progress_manager.ProgressMonitorManager(
         progress_script=progress_script,
@@ -2802,6 +3136,7 @@ def run_server(
         mount_limits=limits,
         site_capabilities=dict(site_summary.capabilities),
         chopper_config=dict(site_summary.chopper),
+        observation_log=observer_csv_log,
         operator_log_path=operator_log_path,
         launcher_log_dir=resolved_launcher_log_dir,
         obs_roots=list(resolved_obs_roots),
@@ -2819,6 +3154,12 @@ def run_server(
         except Exception as exc:
             state.live_cache.error = f"initial live telemetry wait failed: {exc}"
     state.add_log(True, f"console started in action_mode={action_mode}")
+    state.add_log(
+        bool(observer_csv_log.status().get("ok")),
+        "observation CSV log configured",
+        action="observation_csv_log",
+        data=observer_csv_log.status(),
+    )
     state.add_log(
         True,
         "operator log append file configured",
@@ -2893,6 +3234,8 @@ def run_server(
     print(f"  status refresh: {max(200, int(status_refresh_ms))} ms")
     print(f"  console live telemetry ROS: {'disabled' if status_no_ros else 'enabled'}")
     print(f"  operator log: {operator_log_path}")
+    print(f"  observation CSV log: {observer_csv_log.status().get('csv_path')}")
+    print(f"  observation CSV meta: {observer_csv_log.status().get('meta_path')}")
     print(f"  launcher logs: {resolved_launcher_log_dir}")
     print(f"  progress logs: {resolved_progress_log_dir}")
     print(
@@ -2936,6 +3279,19 @@ def run_server(
     finally:
         with state.lock:
             _run_shutdown_cleanup(state)
+            # graceful_shutdown() updates ProcessRegistry records, but final
+            # observation/calibration rows are appended by _refresh_processes_and_log().
+            # Run it once more before closing the observer CSV log so launcher
+            # exits during console shutdown are not silently lost.
+            try:
+                _refresh_processes_and_log(state)
+            except Exception as exc:
+                state.add_log(False, f"failed to refresh launcher exits during shutdown: {exc}", action="process_exit")
+            if state.observation_log is not None:
+                try:
+                    state.observation_log.close(write_log_closed=True)
+                except Exception as exc:
+                    state.add_log(False, f"failed to close observation CSV log: {exc}", action="observation_csv_log")
             if state.live_cache is not None:
                 try:
                     state.live_cache.close()

--- a/necst/web/operator_console.py
+++ b/necst/web/operator_console.py
@@ -30,7 +30,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
 
-from . import log_reader, observation_log, process_manager, progress_manager, self_check, site_config, status_model, live_telemetry
+from . import log_reader, observation_log, process_manager, progress_manager, self_check, site_config, status_model, live_telemetry, node_health
 from ..az_unwrap_limits import assert_mount_az_allowed_when_unwrap_disabled
 
 
@@ -211,6 +211,9 @@ class OperatorConsoleState:
     local_state_reset_summary: Dict[str, Any] = field(default_factory=dict)
     last_status_exception_message: str = ""
     last_status_exception_at: Optional[float] = None
+    node_health_cache: JsonDict = field(default_factory=lambda: {"enabled": False})
+    node_health_checked_at_unix: float = 0.0
+    last_node_health_event_key: str = ""
     lock: threading.RLock = field(default_factory=threading.RLock)
 
     def add_log(
@@ -2922,9 +2925,96 @@ def _build_console_status_unchecked(state: OperatorConsoleState) -> JsonDict:
                 "Console started in safe/rescue mode; no hardware command was sent automatically."
             )
             payload["warning_count"] = len(payload.get("warnings") or [])
+        payload["node_health"] = _node_health_snapshot(state)
         if state.local_state_reset_archive:
             payload["local_state_reset"] = dict(state.local_state_reset_summary or {"archive_dir": state.local_state_reset_archive})
         return payload
+
+
+def _node_health_snapshot(state: OperatorConsoleState) -> JsonDict:
+    """Return cached read-only ROS node health without risking /api/status.
+
+    Phase 1 checks only ROS graph node presence against [console.health].  It is
+    display-only and must never send start/stop/restart/kill commands.
+    """
+
+    try:
+        config = state.site_summary.health
+    except Exception:
+        return {"enabled": False}
+    if not config.enabled:
+        state.node_health_cache = {"enabled": False}
+        state.node_health_checked_at_unix = 0.0
+        return dict(state.node_health_cache)
+
+    now = time.time()
+    try:
+        poll_interval = max(0.5, float(config.poll_interval_sec))
+    except Exception:
+        poll_interval = 2.0
+    if (
+        state.node_health_cache
+        and state.node_health_cache.get("enabled") is True
+        and state.node_health_checked_at_unix > 0
+        and now - float(state.node_health_checked_at_unix) < poll_interval
+    ):
+        return dict(state.node_health_cache)
+
+    actual_nodes: List[str] = []
+    error: Optional[str] = None
+    try:
+        if state.live_cache is None:
+            raise RuntimeError("live telemetry ROS is disabled")
+        actual_nodes = state.live_cache.ros_node_names()
+    except Exception as exc:
+        error = str(exc) or f"{type(exc).__name__}"
+
+    payload = node_health.evaluate(config, actual_nodes, error=error)
+    state.node_health_cache = dict(payload)
+    state.node_health_checked_at_unix = now
+
+    try:
+        missing_required = tuple(payload.get("missing_required") or [])
+        missing_optional = tuple(payload.get("missing_optional") or [])
+        event_key = "|".join([
+            str(payload.get("system") or ""),
+            ",".join(missing_required),
+            ",".join(missing_optional),
+            str(payload.get("error") or ""),
+        ])
+        if event_key != state.last_node_health_event_key:
+            state.last_node_health_event_key = event_key
+            if payload.get("system") in {"NG", "UNKNOWN"} or missing_optional:
+                state.add_log(
+                    payload.get("system") not in {"NG", "UNKNOWN"},
+                    "ROS node health: "
+                    f"system={payload.get('system')}, "
+                    f"manual_mount={payload.get('manual_mount')}, "
+                    f"observation={payload.get('observation')}",
+                    action="node_health",
+                    data={
+                        "missing_required": list(missing_required),
+                        "missing_optional": list(missing_optional),
+                        "error": payload.get("error"),
+                    },
+                )
+    except Exception:
+        pass
+    return dict(payload)
+
+
+def _node_health_rescue_payload(state: OperatorConsoleState, message: str) -> JsonDict:
+    try:
+        config = state.site_summary.health
+    except Exception:
+        return {"enabled": False}
+    if not config.enabled:
+        return {"enabled": False}
+    return node_health.evaluate(
+        config,
+        None,
+        error=f"normal status unavailable; node health not refreshed: {message}",
+    )
 
 
 def build_minimal_rescue_status(state: OperatorConsoleState, exc: BaseException) -> JsonDict:
@@ -3030,6 +3120,7 @@ def build_minimal_rescue_status(state: OperatorConsoleState, exc: BaseException)
         },
         "status_refresh_ms": int(state.status_refresh_ms),
         "live_telemetry": {"requested": not bool(state.status_no_ros), "available": False, "spin_mode": "rescue", "error": message},
+        "node_health": _node_health_rescue_payload(state, message),
         "operator_status": {},
         "status_error": {"message": message, "time": now},
         "safe_start": bool(state.safe_start),
@@ -3570,6 +3661,13 @@ def run_server(
         + (f", path={site_summary.source_path}" if site_summary.source_path else "")
         + (f", observatory={site_summary.observatory}" if site_summary.observatory else ""),
     )
+    if site_summary.health.enabled:
+        state.add_log(
+            True,
+            "ROS node health monitor enabled; read-only ROS graph check only",
+            action="node_health",
+            data=site_summary.health.to_dict(),
+        )
     for warning in site_summary.warnings:
         state.add_log(False, warning)
     if not limits:
@@ -3596,6 +3694,7 @@ def run_server(
         print("  live write guard: ON by --guard-live-actions (write actions blocked; STOP/ABORT remain available)")
     print(f"  status refresh: {max(200, int(status_refresh_ms))} ms")
     print(f"  console live telemetry ROS: {'disabled' if status_no_ros else 'enabled'}")
+    print(f"  ROS node health monitor: {'enabled' if site_summary.health.enabled else 'disabled'}")
     print(f"  operator log: {operator_log_path}")
     print(f"  observation CSV log: {observer_csv_log.status().get('csv_path')}")
     print(f"  observation CSV meta: {observer_csv_log.status().get('meta_path')}")

--- a/necst/web/operator_console.py
+++ b/necst/web/operator_console.py
@@ -1073,7 +1073,25 @@ def _operator_status_operation_conflict(
         if active_task.lower() not in {"", "none", "idle", "unknown"}:
             return f"cannot start {requested_action}: active task is {active_task}; use STOP/ABORT or wait until READY"
         stage = str(motion.get("stage") or "").strip()
-        if stage.lower() not in {"", "none", "idle", "unknown"}:
+        # Low-level antenna control can report a hold/tracking-like stage after
+        # a fixed Az/El mount-move has already reached the target.  The shared
+        # status model normally normalizes that to idle, but keep this guard
+        # tolerant so a stale or site-specific label does not trap the operator.
+        nonblocking_stages = {
+            "",
+            "none",
+            "idle",
+            "unknown",
+            "at_target",
+            "at target",
+            "holding",
+            "hold",
+            "command_hold",
+            "command hold",
+            "target_hold",
+            "target hold",
+        }
+        if stage.lower() not in nonblocking_stages:
             return f"cannot start {requested_action}: mount/activity stage is {stage}; use STOP/ABORT or wait until READY"
     except Exception:
         # If status probing fails, do not block the action solely because the
@@ -1782,6 +1800,19 @@ def _operator_status_to_v7_status(
         manual_state = raw_manual_state
     if manual_state.lower() in {"", "none", "unknown"}:
         manual_state = "idle"
+
+    if state.action_mode != "dry-run" and manual_state.lower() == "tracking":
+        # Some low-level antenna controllers use a generic "tracking" stage
+        # for fixed Az/El command hold after mount_move.  Do not present that as
+        # target tracking unless the console actually started target tracking.
+        last_manual = str(state.last_manual_state or "").strip().lower()
+        if last_manual == "moving":
+            manual_state = "moving"
+            if active_task.lower() in {"", "idle", "none", "unknown", "tracking"}:
+                active_task = "manual mount move"
+        elif last_manual == "tracking":
+            if active_task.lower() in {"", "idle", "none", "unknown", "tracking"}:
+                active_task = "target tracking"
 
     current_az = antenna.get("current_az_deg")
     current_el = antenna.get("current_el_deg")

--- a/necst/web/operator_console.py
+++ b/necst/web/operator_console.py
@@ -199,6 +199,12 @@ class OperatorConsoleState:
     exclusive_start_session_id: Optional[str] = None
     exclusive_start_started_at: Optional[float] = None
     exclusive_start_message: str = ""
+    safe_start: bool = False
+    rescue_mode: bool = False
+    local_state_reset_archive: Optional[str] = None
+    local_state_reset_summary: Dict[str, Any] = field(default_factory=dict)
+    last_status_exception_message: str = ""
+    last_status_exception_at: Optional[float] = None
     lock: threading.RLock = field(default_factory=threading.RLock)
 
     def add_log(
@@ -1036,6 +1042,7 @@ def _obslog_event_for_action(action: str) -> Optional[str]:
         "chopper_home": "chopper_home_clicked",
         "chopper_recover": "chopper_recover_clicked",
         "clear_stale_observation_state": "stale_state_cleared",
+        "reset_local_console_state": "local_state_reset",
         "terminate_observation_launcher": "local_observation_launcher_force_kill_clicked",
         "terminate_calibration_launcher": "local_calibration_launcher_force_kill_clicked",
         "terminate_all_launchers": "local_launchers_force_kill_clicked",
@@ -1066,7 +1073,7 @@ def _obslog_mode_for_action(
         return "SkyDip"
     if action.startswith("chopper_"):
         return "Chopper"
-    if action in {"stop", "abort_observation", "clear_stale_observation_state"}:
+    if action in {"stop", "abort_observation", "clear_stale_observation_state", "reset_local_console_state"}:
         return "Console"
     if action.startswith("terminate_") or action in {"kill_process"}:
         return "Recovery"
@@ -1290,6 +1297,99 @@ def _progress_snapshot_update_age_sec(status_state: Mapping[str, Any]) -> Option
         pass
     return None
 
+
+
+def _utc_reset_stamp() -> str:
+    return time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+
+
+def reset_local_console_state_files(
+    *,
+    progress_root: os.PathLike[str] | str,
+    operator_log_dir: os.PathLike[str] | str,
+    reason: str = "operator request",
+) -> JsonDict:
+    """Archive only local console/progress state files.
+
+    This never sends telescope, recorder, spectrometer, or ROS commands.  It is
+    intentionally limited to files that can make the web console believe a stale
+    observation is still current after an interrupted previous run.
+    """
+
+    stamp = _utc_reset_stamp()
+    archive_dir = Path(operator_log_dir).expanduser() / "reset_archive" / stamp
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    candidates = [
+        Path(progress_root).expanduser() / "current_observation_progress.json",
+        Path(progress_root).expanduser() / "current_observation_record.txt",
+    ]
+    moved: List[JsonDict] = []
+    missing: List[str] = []
+    errors: List[JsonDict] = []
+    for path in candidates:
+        try:
+            if not path.exists():
+                missing.append(str(path))
+                continue
+            target = archive_dir / path.name
+            if target.exists():
+                target = archive_dir / f"{path.stem}_{uuid.uuid4().hex[:6]}{path.suffix}"
+            shutil.move(str(path), str(target))
+            moved.append({"from": str(path), "to": str(target)})
+        except Exception as exc:
+            errors.append({"path": str(path), "error": str(exc)})
+    payload: JsonDict = {
+        "ok": not bool(errors),
+        "reason": str(reason or "operator request"),
+        "archive_dir": str(archive_dir),
+        "moved": moved,
+        "missing": missing,
+        "errors": errors,
+        "hardware_command_sent": False,
+    }
+    try:
+        manifest = archive_dir / "reset_manifest.json"
+        with manifest.open("w", encoding="utf-8") as fh:
+            json.dump(payload, fh, ensure_ascii=False, indent=2, sort_keys=True)
+            fh.write("\n")
+            fh.flush()
+            try:
+                os.fsync(fh.fileno())
+            except Exception:
+                pass
+        payload["manifest"] = str(manifest)
+    except Exception as exc:
+        payload.setdefault("errors", []).append({"path": str(archive_dir / "reset_manifest.json"), "error": str(exc)})
+        payload["ok"] = False
+    return payload
+
+
+def _reset_local_console_state(state: OperatorConsoleState, *, reason: str = "operator request") -> Tuple[bool, str, JsonDict]:
+    operator_dir = state.operator_log_path.parent if state.operator_log_path is not None else Path.home() / ".necst" / "operator_console"
+    data = reset_local_console_state_files(
+        progress_root=state.progress_root,
+        operator_log_dir=operator_dir,
+        reason=reason,
+    )
+    state.local_state_reset_archive = str(data.get("archive_dir") or "")
+    state.local_state_reset_summary = dict(data)
+    moved_count = len(data.get("moved") or [])
+    if state.observation_log is not None:
+        try:
+            state.observation_log.write_event(
+                {},
+                mode="Console",
+                event="local_state_reset",
+                action_or_obsfile=str(data.get("archive_dir") or ""),
+                result="success" if data.get("ok") else "failed",
+                comment=f"archived {moved_count} local state file(s); no hardware command sent",
+            )
+        except Exception:
+            pass
+    message = f"local console state reset; archived {moved_count} file(s); no hardware command sent"
+    if not data.get("ok"):
+        message = "local console state reset had errors; no hardware command sent"
+    return bool(data.get("ok")), message, data
 
 def _stale_observation_state(
     state: OperatorConsoleState,
@@ -1916,6 +2016,11 @@ def dispatch_action(
             "shutdown": _shutdown_snapshot(state),
         }
 
+    if action == "reset_local_console_state":
+        ok, message, data = _reset_local_console_state(state, reason="browser action")
+        data["action"] = action
+        return ok, message, data
+
     if action == "clear_stale_observation_state":
         ok, message, data = _clear_stale_observation_state(state)
         data["action"] = action
@@ -2462,7 +2567,11 @@ def _operator_status_to_v7_status(
     active_process_categories = {
         str(record.category or "")
         for record in process_records
-        if bool(record.is_active())
+        if bool(
+            record.is_active()
+            if hasattr(record, "is_active")
+            else getattr(record, "status", "") not in {"exited", "lost"}
+        )
     }
     stale_observation = _stale_observation_state(state, status_state, op)
     if stale_observation.get("running_stale") or stale_observation.get("launcher_stuck"):
@@ -2733,7 +2842,7 @@ def _operator_status_to_v7_status(
     }
 
 
-def build_console_status(state: OperatorConsoleState) -> JsonDict:
+def _build_console_status_unchecked(state: OperatorConsoleState) -> JsonDict:
     with state.lock:
         _refresh_processes_and_log(state)
         _sync_authority_state(state)
@@ -2744,7 +2853,148 @@ def build_console_status(state: OperatorConsoleState) -> JsonDict:
             events_limit=state.events_limit,
             live_payload=live_payload,
         )
-        return _operator_status_to_v7_status(state, status_state)
+        payload = _operator_status_to_v7_status(state, status_state)
+        if state.safe_start or state.rescue_mode:
+            payload["safe_start"] = bool(state.safe_start)
+            payload["rescue_mode"] = bool(state.rescue_mode)
+            payload.setdefault("warnings", []).append(
+                "Console started in safe/rescue mode; no hardware command was sent automatically."
+            )
+            payload["warning_count"] = len(payload.get("warnings") or [])
+        if state.local_state_reset_archive:
+            payload["local_state_reset"] = dict(state.local_state_reset_summary or {"archive_dir": state.local_state_reset_archive})
+        return payload
+
+
+def build_minimal_rescue_status(state: OperatorConsoleState, exc: BaseException) -> JsonDict:
+    """Return a status payload that is deliberately hard to break.
+
+    The browser must keep showing STOP/ABORT and local recovery controls even if
+    the normal status builder has a bug or a corrupted local pointer file.
+    """
+
+    message = f"{type(exc).__name__}: {exc}"
+    now = time.time()
+    try:
+        process_records = state.process_registry.all_records(refresh=False)
+        processes = [r.to_dict() for r in process_records]
+        process_counts = state.process_registry.counts()
+    except Exception as proc_exc:
+        processes = []
+        process_counts = {"total": 0, "active": 0, "finished": 0, "by_category": {}, "error": str(proc_exc)}
+    try:
+        obslog_status = state.observation_log.status() if state.observation_log is not None else {"ok": False}
+    except Exception as log_exc:
+        obslog_status = {"ok": False, "last_error": str(log_exc)}
+    try:
+        log_entries = [entry.__dict__ for entry in state.log]
+    except Exception:
+        log_entries = []
+    try:
+        site_dict = state.site_summary.to_dict()
+    except Exception:
+        site_dict = {"source": "unavailable"}
+    try:
+        mount_limits = dict(state.mount_limits)
+    except Exception:
+        mount_limits = {}
+    try:
+        progress_status = state.progress_monitor.status().to_dict() if state.progress_monitor is not None else {}
+    except Exception as progress_exc:
+        progress_status = {"status": "error", "message": str(progress_exc)}
+    warnings = [
+        "Normal console status generation failed; showing minimal rescue status.",
+        message,
+        "STOP/ABORT and local recovery actions remain available. No hardware command was sent automatically.",
+    ]
+    payload: JsonDict = {
+        "telescope": state.telescope,
+        "progress_url": state.progress_url,
+        "progress": {
+            "url": state.progress_url,
+            "running": False,
+            "owned_by_console": bool(progress_status.get("owned_by_console")),
+            "monitor": progress_status,
+        },
+        "state": "status_error",
+        "manual_state": "unknown",
+        "active_task": "status builder failed",
+        "az": None,
+        "el": None,
+        "command_az": None,
+        "command_el": None,
+        "mount_limits": mount_limits,
+        "site": site_dict,
+        "capabilities": dict(getattr(state, "site_capabilities", {}) or {}),
+        "warning_count": len(warnings),
+        "warnings": warnings,
+        "authority": {
+            "held": bool(getattr(state.authority, "held", False)),
+            "session_id": getattr(state.authority, "session_id", None),
+            "necst_held": bool(getattr(state.authority, "necst_held", False)),
+            "mode": getattr(state.authority, "mode", "unknown"),
+            "safety_actions_bypass_browser_gate": True,
+            "safety_actions": ["stop", "stop_tracking", "abort_observation", "terminate_*_launcher"],
+        },
+        "chopper": {
+            "state": getattr(state, "last_chopper_state", "unknown") or "unknown",
+            "position": getattr(state, "last_chopper_position", None),
+            "age": "status unavailable",
+        },
+        "observation": {},
+        "stale_observation": {
+            "running_stale": True,
+            "launcher_stuck": bool((process_counts or {}).get("active", 0)),
+            "can_clear": True,
+            "can_terminate_launcher": bool((process_counts or {}).get("active", 0)),
+            "record_name": "unknown",
+            "reason": "normal status builder failed; clear only local console/progress state after confirming hardware safety",
+        },
+        "log": log_entries,
+        "processes": processes,
+        "process_counts": process_counts,
+        "launcher_log_choices": [],
+        "shutdown": _shutdown_snapshot(state),
+        "self_check_endpoint": "/api/self-check",
+        "operator_log_path": str(state.operator_log_path) if state.operator_log_path is not None else None,
+        "launcher_log_dir": str(state.launcher_log_dir) if state.launcher_log_dir is not None else None,
+        "observation_log": obslog_status,
+        "action_mode": state.action_mode,
+        "live_actions": {
+            "enabled": bool(state.live_actions_enabled),
+            "guarded": state.action_mode == "live" and not bool(state.live_actions_enabled),
+            "write_actions": sorted(LIVE_WRITE_ACTIONS),
+            "safety_actions": sorted(SAFETY_ACTIONS),
+            "message": "minimal rescue status after status builder failure",
+        },
+        "status_refresh_ms": int(state.status_refresh_ms),
+        "live_telemetry": {"requested": not bool(state.status_no_ros), "available": False, "spin_mode": "rescue", "error": message},
+        "operator_status": {},
+        "status_error": {"message": message, "time": now},
+        "safe_start": bool(state.safe_start),
+        "rescue_mode": bool(state.rescue_mode),
+        "local_state_reset": dict(state.local_state_reset_summary or {}),
+    }
+    return payload
+
+
+def build_console_status(state: OperatorConsoleState) -> JsonDict:
+    try:
+        return _build_console_status_unchecked(state)
+    except Exception as exc:
+        message = f"{type(exc).__name__}: {exc}"
+        # Log sparingly so a refresh loop does not flood the internal JSONL log.
+        try:
+            with state.lock:
+                last = getattr(state, "last_status_exception_message", "")
+                last_at = float(getattr(state, "last_status_exception_at", 0.0) or 0.0)
+                if message != last or (time.time() - last_at) > 30.0:
+                    state.last_status_exception_message = message
+                    state.last_status_exception_at = time.time()
+                    state.add_log(False, f"normal status generation failed; using minimal rescue status: {message}", action="status_rescue")
+        except Exception:
+            pass
+        return build_minimal_rescue_status(state, exc)
 
 
 def load_demo_html(status_refresh_ms: int = 1000) -> str:
@@ -2831,6 +3081,9 @@ class OperatorConsoleHandler(BaseHTTPRequestHandler):
         if self.path == "/api/status":
             self._send_json(build_console_status(self.server.state))
             return
+        if self.path == "/api/rescue/status":
+            self._send_json(build_minimal_rescue_status(self.server.state, RuntimeError("rescue status requested")))
+            return
         parsed = urllib.parse.urlparse(self.path)
         query = urllib.parse.parse_qs(parsed.query)
         if parsed.path == "/api/obs-roots":
@@ -2853,13 +3106,16 @@ class OperatorConsoleHandler(BaseHTTPRequestHandler):
             return
         if self.path == "/api/operator-status":
             state = self.server.state
-            live_payload = state.live_cache.snapshot() if state.live_cache is not None else None
-            status_state = status_model.build_progress_status_state(
-                state.progress_root,
-                events_limit=state.events_limit,
-                live_payload=live_payload,
-            )
-            self._send_json(status_state.get("operator_status", {}))
+            try:
+                live_payload = state.live_cache.snapshot() if state.live_cache is not None else None
+                status_state = status_model.build_progress_status_state(
+                    state.progress_root,
+                    events_limit=state.events_limit,
+                    live_payload=live_payload,
+                )
+                self._send_json(status_state.get("operator_status", {}))
+            except Exception as exc:
+                self._send_json({"ok": False, "reason": str(exc), "operator_status": {}}, status=200)
             return
         if parsed.path == "/api/processes":
             state = self.server.state
@@ -3062,6 +3318,9 @@ def run_server(
     shutdown_terminate_launchers: bool = True,
     shutdown_launcher_timeout_sec: float = 3.0,
     shutdown_launcher_kill_timeout_sec: float = 1.0,
+    safe_start: bool = False,
+    reset_local_state: bool = False,
+    rescue: bool = False,
     az_min: Optional[float] = None,
     az_max: Optional[float] = None,
     el_min: Optional[float] = None,
@@ -3097,6 +3356,16 @@ def run_server(
     resolved_launcher_log_dir.mkdir(parents=True, exist_ok=True)
     resolved_progress_log_dir.mkdir(parents=True, exist_ok=True)
     operator_log_path = resolved_operator_log_dir / "operator_console.jsonl"
+    rescue = bool(rescue)
+    safe_start = bool(safe_start or rescue)
+    reset_local_state = bool(reset_local_state or rescue)
+    local_state_reset_summary: JsonDict = {}
+    if reset_local_state:
+        local_state_reset_summary = reset_local_console_state_files(
+            progress_root=progress_root,
+            operator_log_dir=resolved_operator_log_dir,
+            reason="console startup --reset-local-state" + ("/--rescue" if rescue else ""),
+        )
     resolved_obs_roots = resolve_obs_roots(obs_roots)
     observer_csv_log = observation_log.ObservationLogManager.create(
         configured_dir=obslog_dir,
@@ -3143,9 +3412,13 @@ def run_server(
         shutdown_terminate_launchers=bool(shutdown_terminate_launchers),
         shutdown_launcher_timeout_sec=float(shutdown_launcher_timeout_sec),
         shutdown_launcher_kill_timeout_sec=float(shutdown_launcher_kill_timeout_sec),
+        safe_start=bool(safe_start),
+        rescue_mode=bool(rescue),
+        local_state_reset_archive=str(local_state_reset_summary.get("archive_dir") or ""),
+        local_state_reset_summary=dict(local_state_reset_summary),
     )
     state.live_cache = live_telemetry.LiveTelemetryCache(enabled=not bool(status_no_ros))
-    if state.live_cache is not None and state.live_cache.available:
+    if state.live_cache is not None and state.live_cache.available and not bool(safe_start):
         # Wait briefly for the first encoder/pointing sample so the console
         # starts with real Current Az/El whenever ROS status topics are alive.
         # This is read-only; it does not send any telescope command.
@@ -3153,7 +3426,32 @@ def run_server(
             state.live_cache.wait_for_initial_position(timeout_sec=2.0)
         except Exception as exc:
             state.live_cache.error = f"initial live telemetry wait failed: {exc}"
-    state.add_log(True, f"console started in action_mode={action_mode}")
+    state.add_log(True, f"console started in action_mode={action_mode}" + (" (safe/rescue mode)" if (safe_start or rescue) else ""))
+    if safe_start or rescue:
+        state.add_log(
+            True,
+            "console safe/rescue start active; no hardware command was sent automatically",
+            action="console_safe_start",
+            data={"safe_start": bool(safe_start), "rescue": bool(rescue)},
+        )
+    if local_state_reset_summary:
+        state.add_log(
+            bool(local_state_reset_summary.get("ok")),
+            "local console state reset at startup; no hardware command sent",
+            action="local_state_reset",
+            data=local_state_reset_summary,
+        )
+        try:
+            observer_csv_log.write_event(
+                {},
+                mode="Console",
+                event="local_state_reset",
+                action_or_obsfile=str(local_state_reset_summary.get("archive_dir") or ""),
+                result="success" if local_state_reset_summary.get("ok") else "failed",
+                comment="startup reset; no hardware command sent",
+            )
+        except Exception:
+            pass
     state.add_log(
         bool(observer_csv_log.status().get("ok")),
         "observation CSV log configured",
@@ -3229,6 +3527,10 @@ def run_server(
     print(f"  managed progress bind: {progress_host}:{int(progress_port)}")
     print(f"  action mode: {action_mode}")
     print(f"  live write actions enabled: {bool(live_actions_enabled)}")
+    print(f"  safe start: {bool(safe_start)}")
+    print(f"  rescue mode: {bool(rescue)}")
+    if local_state_reset_summary:
+        print(f"  local state reset archive: {local_state_reset_summary.get('archive_dir')}")
     if action_mode == "live" and not live_actions_enabled:
         print("  live write guard: ON by --guard-live-actions (write actions blocked; STOP/ABORT remain available)")
     print(f"  status refresh: {max(200, int(status_refresh_ms))} ms")

--- a/necst/web/operator_console.py
+++ b/necst/web/operator_console.py
@@ -18,6 +18,7 @@ import sys
 import json
 import math
 import os
+import shutil
 import threading
 import time
 import uuid
@@ -88,6 +89,13 @@ EXCLUSIVE_START_STATUS_SEC = 15.0
 # This prevents STOP REQUESTED from degrading into ATTENTION while the telescope
 # is already stopped and ready for the next command.
 SAFETY_RELEASE_ASSUME_IDLE_AFTER_SEC = 1.0
+
+# A progress sidecar can remain in a non-final lifecycle if an observation
+# launcher dies or blocks before writing its final snapshot.  Do not keep the
+# operator UI in OBSERVATION RUNNING forever when no local launcher is active
+# and the sidecar has not been updated for this long.  This only changes the
+# console status; it does not send telescope commands or delete data.
+STALE_OBSERVATION_PROGRESS_SEC = float(os.environ.get("NECST_CONSOLE_STALE_OBSERVATION_SEC", "60.0"))
 
 LIVE_ACTION_GUARD_MESSAGE = (
     "live write actions are guarded by --guard-live-actions; "
@@ -977,6 +985,169 @@ def _active_launcher_summary(
     return "active launcher already exists: " + ", ".join(labels)
 
 
+
+def _active_launcher_categories(state: OperatorConsoleState) -> set[str]:
+    """Return active launcher categories currently owned by this console."""
+
+    return {
+        str(record.category or "").strip().lower()
+        for record in state.process_registry.active()
+        if str(record.category or "").strip()
+    }
+
+
+def _progress_snapshot_update_age_sec(status_state: Mapping[str, Any]) -> Optional[float]:
+    """Return age of the current progress snapshot update, if known."""
+
+    now = time.time()
+    snapshot = status_state.get("snapshot") if isinstance(status_state, Mapping) else {}
+    snapshot = snapshot if isinstance(snapshot, Mapping) else {}
+    timing = snapshot.get("time") if isinstance(snapshot.get("time"), Mapping) else {}
+    candidates = [
+        timing.get("updated_at_unix"),
+        timing.get("last_update_unix"),
+        timing.get("server_time_unix"),
+    ]
+    raw = status_state.get("raw_snapshot") if isinstance(status_state, Mapping) else {}
+    raw = raw if isinstance(raw, Mapping) else {}
+    raw_timing = raw.get("time") if isinstance(raw.get("time"), Mapping) else {}
+    candidates.extend([
+        raw_timing.get("updated_at_unix"),
+        raw_timing.get("last_update_unix"),
+    ])
+    for value in candidates:
+        try:
+            ts = float(value)
+        except Exception:
+            continue
+        if math.isfinite(ts) and ts > 0:
+            return max(0.0, now - ts)
+    try:
+        path = Path(str((status_state.get("paths") or {}).get("snapshot") or ""))
+        if path.exists():
+            return max(0.0, now - path.stat().st_mtime)
+    except Exception:
+        pass
+    return None
+
+
+def _stale_observation_state(
+    state: OperatorConsoleState,
+    status_state: Mapping[str, Any],
+    operator_status: Optional[Mapping[str, Any]] = None,
+) -> JsonDict:
+    """Classify stale observation-running sidecars.
+
+    This is intentionally conservative.  It does not declare a live observation
+    stale while a console-owned observation/calibration launcher is still active.
+    It only marks the status as stale when a progress sidecar still says the
+    lifecycle is non-final but the sidecar has not been refreshed for the
+    configured timeout.
+    """
+
+    op = operator_status if isinstance(operator_status, Mapping) else {}
+    if not op:
+        op = status_state.get("operator_status") if isinstance(status_state, Mapping) else {}
+        op = op if isinstance(op, Mapping) else {}
+    system = op.get("system") if isinstance(op.get("system"), Mapping) else {}
+    progress = op.get("progress") if isinstance(op.get("progress"), Mapping) else {}
+    observation = op.get("observation") if isinstance(op.get("observation"), Mapping) else {}
+    lifecycle = str(system.get("state") or "unknown").strip().lower()
+    percent = progress.get("percent")
+    nonfinal_lifecycle = lifecycle not in {"", "idle", "unknown", "finished", "aborted", "error", "failed"}
+    progress_running = bool(nonfinal_lifecycle or percent is not None)
+    active_categories = _active_launcher_categories(state)
+    active_launcher = bool(active_categories.intersection({"observation", "calibration"}))
+    age = _progress_snapshot_update_age_sec(status_state)
+    threshold = max(5.0, float(STALE_OBSERVATION_PROGRESS_SEC))
+    running_stale = bool(
+        progress_running
+        and not active_launcher
+        and age is not None
+        and age >= threshold
+    )
+    return {
+        "running_stale": running_stale,
+        "progress_running": bool(progress_running),
+        "active_launcher": active_launcher,
+        "active_launcher_categories": sorted(active_categories),
+        "age_sec": age,
+        "threshold_sec": threshold,
+        "lifecycle_state": lifecycle,
+        "record_name": observation.get("record_name"),
+        "progress_record_dir": observation.get("progress_record_dir"),
+        "reason": (
+            "progress sidecar is non-final/still-running, but no console-owned "
+            "observation launcher is active and the sidecar update is stale"
+            if running_stale
+            else ""
+        ),
+        "can_clear": bool(running_stale and not active_launcher),
+    }
+
+
+def _clear_stale_observation_state(state: OperatorConsoleState) -> Tuple[bool, str, JsonDict]:
+    """Archive stale current-observation pointers so the console can return READY.
+
+    This is an explicit operator recovery action.  It never sends hardware
+    commands and it does not delete the per-record progress directory or data.
+    It only moves the global current-observation pointer files out of the way.
+    """
+
+    active = _active_launcher_categories(state).intersection({"observation", "calibration"})
+    if active:
+        return False, (
+            "cannot clear stale observation state while a console-owned launcher "
+            f"is still active: {', '.join(sorted(active))}"
+        ), {"active_launcher_categories": sorted(active), "cleared": False}
+
+    root = state.progress_root
+    stamp = time.strftime("%Y%m%d_%H%M%S", time.localtime())
+    archive_dir = root / "stale_console_clear" / stamp
+    moved: List[Dict[str, str]] = []
+    missing: List[str] = []
+    errors: List[str] = []
+    for name in ("current_observation_progress.json", "current_observation_record.txt"):
+        src = root / name
+        if not src.exists():
+            missing.append(str(src))
+            continue
+        try:
+            archive_dir.mkdir(parents=True, exist_ok=True)
+            dst = archive_dir / name
+            shutil.move(str(src), str(dst))
+            moved.append({"from": str(src), "to": str(dst)})
+        except Exception as exc:
+            errors.append(f"{src}: {exc}")
+    if errors:
+        return False, "failed to clear one or more stale progress pointer files", {
+            "cleared": False,
+            "moved": moved,
+            "missing": missing,
+            "errors": errors,
+            "archive_dir": str(archive_dir),
+        }
+
+    _clear_exclusive_start_guard(state)
+    _clear_safety_release_request(state)
+    _clear_last_mount_target(state)
+    state.last_manual_state = "idle"
+    state.last_active_task = "none"
+    state.last_command_az = None
+    state.last_command_el = None
+    message = "stale observation state cleared"
+    if moved:
+        message += f"; archived {len(moved)} current progress pointer file(s)"
+    else:
+        message += "; no current progress pointer files were present"
+    return True, message, {
+        "cleared": True,
+        "moved": moved,
+        "missing": missing,
+        "archive_dir": str(archive_dir) if moved else None,
+        "note": "per-record progress/data directories were not deleted",
+    }
+
 def _last_mount_target_reached(
     state: OperatorConsoleState,
     *,
@@ -1167,6 +1338,12 @@ def _operator_status_operation_conflict(
         )
         op = status_state.get("operator_status") if isinstance(status_state, Mapping) else {}
         op = op if isinstance(op, Mapping) else {}
+        stale = _stale_observation_state(state, status_state, op)
+        if stale.get("running_stale"):
+            return (
+                f"cannot start {requested_action}: stale observation state remains "
+                f"for record {stale.get('record_name') or 'unknown'}; use Clear stale observation state"
+            )
         system = op.get("system") if isinstance(op.get("system"), Mapping) else {}
         motion = op.get("motion") if isinstance(op.get("motion"), Mapping) else {}
         sys_state = str(system.get("state") or "").strip().lower()
@@ -1399,6 +1576,11 @@ def dispatch_action(
             ),
             "shutdown": _shutdown_snapshot(state),
         }
+
+    if action == "clear_stale_observation_state":
+        ok, message, data = _clear_stale_observation_state(state)
+        data["action"] = action
+        return ok, message, data
 
     live_allowed, live_reason, live_data = _live_write_guard(state, action)
     if not live_allowed:
@@ -1930,7 +2112,13 @@ def _operator_status_to_v7_status(
         for record in process_records
         if bool(record.is_active())
     }
-    if sys_state == "idle":
+    stale_observation = _stale_observation_state(state, status_state, op)
+    if stale_observation.get("running_stale"):
+        sys_state = "stale_observation"
+        warnings = list(warnings) + [
+            "stale observation progress state remains; use Clear stale observation state after confirming hardware is safe"
+        ]
+    elif sys_state == "idle":
         if "observation" in active_process_categories:
             sys_state = "observing"
         elif "calibration" in active_process_categories:
@@ -2103,6 +2291,7 @@ def _operator_status_to_v7_status(
             "position": chopper_position if chopper_position is not None else "unknown",
             "age": age_text,
         },
+        "stale_observation": stale_observation,
         "progress": {
             "running": bool(progress_running),
             "url": str(monitor_status.get("url") or state.progress_url),

--- a/necst/web/operator_console.py
+++ b/necst/web/operator_console.py
@@ -103,6 +103,8 @@ MOUNT_COMMAND_TARGET_REACHED_TOL_DEG = 7.5e-4
 # console status; it does not send telescope commands or delete data.
 STALE_OBSERVATION_PROGRESS_SEC = float(os.environ.get("NECST_CONSOLE_STALE_OBSERVATION_SEC", "60.0"))
 ABORT_STUCK_OBSERVATION_SEC = float(os.environ.get("NECST_CONSOLE_ABORT_STUCK_OBSERVATION_SEC", "15.0"))
+LAUNCHER_FAILURE_TAIL_BYTES = int(os.environ.get("NECST_CONSOLE_LAUNCHER_FAILURE_TAIL_BYTES", "65536"))
+LAUNCHER_FAILURE_SUMMARY_MAX_CHARS = int(os.environ.get("NECST_CONSOLE_LAUNCHER_FAILURE_SUMMARY_MAX_CHARS", "600"))
 
 LIVE_ACTION_GUARD_MESSAGE = (
     "live write actions are guarded by --guard-live-actions; "
@@ -214,6 +216,10 @@ class OperatorConsoleState:
     node_health_cache: JsonDict = field(default_factory=lambda: {"enabled": False})
     node_health_checked_at_unix: float = 0.0
     last_node_health_event_key: str = ""
+    # Last failed local launcher summary shown near the top of the console.
+    # This is intentionally a compact pointer to stdout/stderr logs, not the
+    # full log body, so /api/status stays lightweight.
+    last_launcher_failure: JsonDict = field(default_factory=dict)
     lock: threading.RLock = field(default_factory=threading.RLock)
 
     def add_log(
@@ -1185,6 +1191,113 @@ def run_self_check(state: OperatorConsoleState, *, include_progress_health: bool
     )
 
 
+
+def _truncate_for_status(text: Any, *, max_chars: int = LAUNCHER_FAILURE_SUMMARY_MAX_CHARS) -> str:
+    value = str(text or "").strip()
+    if len(value) <= int(max_chars):
+        return value
+    return value[: max(0, int(max_chars) - 1)].rstrip() + "…"
+
+
+def _read_log_tail_for_summary(path_value: Any, *, max_bytes: int = LAUNCHER_FAILURE_TAIL_BYTES) -> Tuple[str, int, bool, str]:
+    """Return a bounded text tail for launcher failure summarization.
+
+    This is used only for log files that the console itself assigned to a local
+    launcher subprocess.  It never raises: failures are reported as a short
+    reason string so /api/status and process reaping remain robust.
+    """
+
+    raw = str(path_value or "").strip()
+    if not raw:
+        return "", 0, False, "log path is not configured"
+    try:
+        path = Path(raw).expanduser()
+        if not path.exists() or not path.is_file():
+            return "", 0, False, f"log file does not exist: {path}"
+        size = path.stat().st_size
+        max_b = max(1024, min(int(max_bytes or LAUNCHER_FAILURE_TAIL_BYTES), 1024 * 1024))
+        with path.open("rb") as fh:
+            if size > max_b:
+                fh.seek(size - max_b)
+            data = fh.read(max_b)
+        return data.decode("utf-8", errors="replace"), int(size), bool(size > max_b), ""
+    except Exception as exc:
+        return "", 0, False, str(exc)
+
+
+def _extract_failure_summary_from_text(text: Any) -> str:
+    """Extract a compact, human-useful error line from stdout/stderr text."""
+
+    lines = [line.strip() for line in str(text or "").splitlines() if line.strip()]
+    if not lines:
+        return ""
+
+    # Python tracebacks normally end with the actual exception line.  Prefer that
+    # last semantic line and skip stack-frame/context lines where possible.
+    skip_prefixes = (
+        "File ",
+        "Traceback ",
+        "During handling of the above exception",
+        "The above exception was the direct cause",
+        "^",
+    )
+    for line in reversed(lines):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if any(stripped.startswith(prefix) for prefix in skip_prefixes):
+            continue
+        if stripped.startswith("~") and set(stripped) <= {"~", "^", " ", "|"}:
+            continue
+        return _truncate_for_status(stripped)
+
+    return _truncate_for_status(lines[-1])
+
+
+def _launcher_failure_payload(record: process_manager.ManagedProcessRecord) -> JsonDict:
+    """Build a compact failure summary for a finalized local launcher."""
+
+    stderr_tail, stderr_size, stderr_truncated, stderr_error = _read_log_tail_for_summary(record.stderr_path)
+    stdout_tail, stdout_size, stdout_truncated, stdout_error = _read_log_tail_for_summary(record.stdout_path)
+    stderr_summary = _extract_failure_summary_from_text(stderr_tail)
+    stdout_summary = _extract_failure_summary_from_text(stdout_tail)
+    stream = "stderr" if stderr_summary else ("stdout" if stdout_summary else "")
+    summary = stderr_summary or stdout_summary
+    if not summary:
+        if record.status == "lost":
+            summary = "local launcher handle was lost before the exit reason could be read"
+        else:
+            summary = f"launcher exited with return code {record.returncode}"
+        if stderr_error and stdout_error:
+            summary += f"; stderr/stdout unavailable ({stderr_error}; {stdout_error})"
+    payload: JsonDict = {
+        "ok": False,
+        "category": str(record.category or ""),
+        "label": str(record.label or record.action or record.category or "launcher"),
+        "action": str(record.action or ""),
+        "pid": int(record.pid),
+        "status": str(record.status or ""),
+        "returncode": record.returncode,
+        "summary": _truncate_for_status(summary),
+        "stream": stream,
+        "stdout_path": record.stdout_path,
+        "stderr_path": record.stderr_path,
+        "stdout_size_bytes": stdout_size,
+        "stderr_size_bytes": stderr_size,
+        "stdout_truncated_head": stdout_truncated,
+        "stderr_truncated_head": stderr_truncated,
+        "stdout_read_error": stdout_error,
+        "stderr_read_error": stderr_error,
+        "finished_at": record.finished_at,
+        "time": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+    payload["message"] = _truncate_for_status(
+        f"{payload['label']} failed: {payload['summary']}"
+        if payload["summary"]
+        else f"{payload['label']} failed"
+    )
+    return payload
+
 def _refresh_processes_and_log(state: OperatorConsoleState) -> None:
     """Reap child launcher processes and log newly observed final states."""
 
@@ -1194,6 +1307,7 @@ def _refresh_processes_and_log(state: OperatorConsoleState) -> None:
             continue
         record.final_logged = True
         ok = record.returncode in (0, None) and record.status != "lost"
+        failure_payload: Optional[JsonDict] = None
         if record.status == "exited":
             message = (
                 f"{record.label} pid={record.pid} exited with return code "
@@ -1201,7 +1315,14 @@ def _refresh_processes_and_log(state: OperatorConsoleState) -> None:
             )
         else:
             message = f"{record.label} pid={record.pid} is no longer tracked"
-        state.add_log(ok, message, action="process_exit", data=record.to_dict())
+        record_data = record.to_dict()
+        if not ok:
+            failure_payload = _launcher_failure_payload(record)
+            state.last_launcher_failure = dict(failure_payload)
+            summary = failure_payload.get("summary") or "see launcher logs"
+            message = f"{message}: {summary}"
+            record_data["failure"] = failure_payload
+        state.add_log(ok, message, action="process_exit", data=record_data)
         if state.observation_log is not None and record.category in {"observation", "calibration"}:
             label = str(getattr(record, "label", "") or "")
             result_text = "success" if ok else "failed"
@@ -1220,8 +1341,12 @@ def _refresh_processes_and_log(state: OperatorConsoleState) -> None:
             else:
                 mode = label.split(":", 1)[1] if ":" in label else "Calibration"
                 event = f"{mode.lower()}_finished" if ok else f"{mode.lower()}_failed"
+            failure_comment = ""
+            if failure_payload is not None and result_text == "failed":
+                failure_comment = str(failure_payload.get("summary") or "")
             written = state.observation_log.write_event(
                 _observation_log_context(state),
+                comment=failure_comment,
                 mode=mode,
                 event=event,
                 action_or_obsfile=label or getattr(record, "category", ""),
@@ -1952,6 +2077,15 @@ def dispatch_action(
         state.log.clear()
         return True, "operation log cleared", {"action": action}
 
+    if action == "clear_launcher_failure":
+        had_failure = bool(state.last_launcher_failure)
+        state.last_launcher_failure = {}
+        return True, "last launcher error display cleared", {
+            "action": action,
+            "cleared": had_failure,
+            "note": "Display-only clear. Launcher stdout/stderr files, internal operator log, and Observation Log CSV are kept.",
+        }
+
     if action == "obslog_status":
         data = _obslog_status_payload(state)
         return bool(data.get("ok")), "observation CSV log status", data
@@ -2298,6 +2432,7 @@ def dispatch_action(
                 message="target tracking",
             )
             _clear_safety_release_request(state)
+            state.last_launcher_failure = {}
             state.last_command_az = None
             state.last_command_el = None
             _clear_last_mount_target(state)
@@ -2399,6 +2534,7 @@ def dispatch_action(
                 message=f"observation {mode}",
             )
             _clear_safety_release_request(state)
+            state.last_launcher_failure = {}
             state.last_command_az = None
             state.last_command_el = None
             _clear_last_mount_target(state)
@@ -2451,6 +2587,7 @@ def dispatch_action(
                 message="RSky",
             )
             _clear_safety_release_request(state)
+            state.last_launcher_failure = {}
             state.last_command_az = None
             state.last_command_el = None
             _clear_last_mount_target(state)
@@ -2503,6 +2640,7 @@ def dispatch_action(
                 message="SkyDip",
             )
             _clear_safety_release_request(state)
+            state.last_launcher_failure = {}
             state.last_command_az = None
             state.last_command_el = None
             _clear_last_mount_target(state)
@@ -2875,6 +3013,7 @@ def _operator_status_to_v7_status(
         "launcher_log_choices": log_reader.launcher_log_choices([
             r.to_dict() for r in state.process_registry.all_records(refresh=False)
         ]),
+        "last_launcher_failure": dict(state.last_launcher_failure or {}),
         "shutdown": _shutdown_snapshot(state),
         "self_check_endpoint": "/api/self-check",
         "operator_log_path": str(state.operator_log_path) if state.operator_log_path is not None else None,
@@ -3105,6 +3244,7 @@ def build_minimal_rescue_status(state: OperatorConsoleState, exc: BaseException)
         "processes": processes,
         "process_counts": process_counts,
         "launcher_log_choices": [],
+        "last_launcher_failure": dict(getattr(state, "last_launcher_failure", {}) or {}),
         "shutdown": _shutdown_snapshot(state),
         "self_check_endpoint": "/api/self-check",
         "operator_log_path": str(state.operator_log_path) if state.operator_log_path is not None else None,

--- a/necst/web/operator_console.py
+++ b/necst/web/operator_console.py
@@ -3519,15 +3519,31 @@ def run_server(
             reason="console startup --reset-local-state" + ("/--rescue" if rescue else ""),
         )
     resolved_obs_roots = resolve_obs_roots(obs_roots)
+    obslog_site_config = dict(getattr(site_summary, "observation_log", {}) or {})
+    obslog_record_roots = obslog_site_config.get("record_roots")
+    if not isinstance(obslog_record_roots, list):
+        obslog_record_roots = None
     observer_csv_log = observation_log.ObservationLogManager.create(
         configured_dir=obslog_dir,
+        site_configured_dir=obslog_site_config.get("directory"),
         # Do not use --obs-root here: it is an obs-file browser location, not
-        # necessarily the data/record root.  ObservationLogManager still uses
-        # NECST_CONSOLE_PC_RECORD_ROOT, NECST_RECORD_ROOT, etc. for
-        # <record root>/obslogs before falling back to ~/.necst.
-        record_roots=None,
-        prefix=obslog_prefix or os.environ.get("NECST_OBSLOG_PREFIX", observation_log.DEFAULT_PREFIX),
-        observer=obslog_user or os.environ.get("NECST_OBSLOG_USER", observation_log.DEFAULT_OBSERVER),
+        # necessarily the data/record root.  If a record-root candidate is put
+        # in [console.observation_log], it is used only as a fallback for
+        # <record root>/obslogs, after explicit CLI/env/TOML log directories.
+        # Prefer [console.observation_log].directory for a console-writable path.
+        record_roots=obslog_record_roots,
+        prefix=(
+            obslog_prefix
+            or os.environ.get("NECST_OBSLOG_PREFIX")
+            or obslog_site_config.get("prefix")
+            or observation_log.DEFAULT_PREFIX
+        ),
+        observer=(
+            obslog_user
+            or os.environ.get("NECST_OBSLOG_USER")
+            or obslog_site_config.get("user")
+            or observation_log.DEFAULT_OBSERVER
+        ),
         telescope=telescope,
     )
     progress_script = Path(__file__).resolve().parents[2] / "bin" / "progress.py"
@@ -3697,6 +3713,7 @@ def run_server(
     print(f"  ROS node health monitor: {'enabled' if site_summary.health.enabled else 'disabled'}")
     print(f"  operator log: {operator_log_path}")
     print(f"  observation CSV log: {observer_csv_log.status().get('csv_path')}")
+    print(f"  observation CSV log source: {observer_csv_log.status().get('log_dir_source')}")
     print(f"  observation CSV meta: {observer_csv_log.status().get('meta_path')}")
     print(f"  launcher logs: {resolved_launcher_log_dir}")
     print(f"  progress logs: {resolved_progress_log_dir}")

--- a/necst/web/operator_console.py
+++ b/necst/web/operator_console.py
@@ -159,6 +159,10 @@ class OperatorConsoleState:
     last_mount_target_el: Optional[float] = None
     last_mount_target_started_at: Optional[float] = None
     last_mount_target_reached_since: Optional[float] = None
+    # Last safety release request sent from this console.  STOP/ABORT are
+    # operator intent to release the current manual/observation control, not a
+    # request to keep waiting for the previous fixed Az/El target.
+    last_safety_release_requested_at: Optional[float] = None
     last_manual_state: str = "idle"
     last_active_task: str = "none"
     last_chopper_state: str = "unknown"
@@ -1027,6 +1031,29 @@ def _clear_last_mount_target(state: OperatorConsoleState) -> None:
     state.last_mount_target_reached_since = None
 
 
+def _mark_safety_release_request(state: OperatorConsoleState) -> None:
+    state.last_safety_release_requested_at = time.time()
+
+
+def _clear_safety_release_request(state: OperatorConsoleState) -> None:
+    state.last_safety_release_requested_at = None
+
+
+def _recent_safety_release_request_age_sec(
+    state: OperatorConsoleState, *, max_age_sec: float = 180.0
+) -> Optional[float]:
+    started = state.last_safety_release_requested_at
+    if started is None:
+        return None
+    try:
+        age = max(0.0, time.time() - float(started))
+    except Exception:
+        return None
+    if age > float(max_age_sec):
+        state.last_safety_release_requested_at = None
+        return None
+    return age
+
 
 
 def _prune_exclusive_start_guard(state: OperatorConsoleState) -> None:
@@ -1143,6 +1170,18 @@ def _operator_status_operation_conflict(
             and motion.get("live_motion_active") is False
         )
         antenna = op.get("antenna") if isinstance(op.get("antenna"), Mapping) else {}
+        command_absent = antenna.get("command_az_deg") is None and antenna.get("command_el_deg") is None
+        motion_source_lower = str(motion.get("live_motion_source") or "").strip().lower()
+        safety_release_age = _recent_safety_release_request_age_sec(state)
+        safety_release_idle = bool(
+            state.action_mode != "dry-run"
+            and safety_release_age is not None
+            and sys_state in {"", "idle", "unknown", "finished", "aborted", "error", "failed"}
+            and command_absent
+            and motion_source_lower != "encoder_delta"
+        )
+        if safety_release_idle:
+            at_target_idle = True
         operator_target_idle = False
         if sys_state in {"", "idle", "unknown", "finished", "aborted", "error", "failed"}:
             operator_target_idle = _last_mount_target_reached(
@@ -1526,6 +1565,7 @@ def dispatch_action(
                 session_id=session_id,
                 message=f"mount move Az={az:.4f} deg El={el:.4f} deg",
             )
+            _clear_safety_release_request(state)
             state.last_command_az = az
             state.last_command_el = el
             state.last_mount_target_az = az
@@ -1549,6 +1589,7 @@ def dispatch_action(
         data.update(safety_data)
         if ok:
             _clear_exclusive_start_guard(state)
+            _mark_safety_release_request(state)
             state.last_manual_state = "stopped"
             state.last_active_task = "none"
             state.last_command_az = None
@@ -1583,6 +1624,7 @@ def dispatch_action(
                 session_id=session_id,
                 message="target tracking",
             )
+            _clear_safety_release_request(state)
             state.last_command_az = None
             state.last_command_el = None
             _clear_last_mount_target(state)
@@ -1603,6 +1645,7 @@ def dispatch_action(
         data.update(safety_data)
         if ok:
             _clear_exclusive_start_guard(state)
+            _mark_safety_release_request(state)
             state.last_manual_state = "stopped"
             state.last_active_task = "none"
             state.last_command_az = None
@@ -1623,6 +1666,7 @@ def dispatch_action(
         data.update(safety_data)
         if ok:
             _clear_exclusive_start_guard(state)
+            _mark_safety_release_request(state)
             state.last_manual_state = "stopped"
             state.last_active_task = "none"
             state.last_command_az = None
@@ -1672,6 +1716,7 @@ def dispatch_action(
                 session_id=session_id,
                 message=f"observation {mode}",
             )
+            _clear_safety_release_request(state)
             state.last_command_az = None
             state.last_command_el = None
             _clear_last_mount_target(state)
@@ -1723,6 +1768,7 @@ def dispatch_action(
                 session_id=session_id,
                 message="RSky",
             )
+            _clear_safety_release_request(state)
             state.last_command_az = None
             state.last_command_el = None
             _clear_last_mount_target(state)
@@ -1774,6 +1820,7 @@ def dispatch_action(
                 session_id=session_id,
                 message="SkyDip",
             )
+            _clear_safety_release_request(state)
             state.last_command_az = None
             state.last_command_el = None
             _clear_last_mount_target(state)
@@ -1969,6 +2016,25 @@ def _operator_status_to_v7_status(
         if cmd_el is None:
             cmd_el = state.last_command_el
 
+    command_absent = cmd_az is None and cmd_el is None
+    safety_release_age = _recent_safety_release_request_age_sec(state)
+    safety_release_idle = bool(
+        state.action_mode != "dry-run"
+        and safety_release_age is not None
+        and sys_state in {"", "idle", "unknown", "finished", "aborted", "error", "failed"}
+        and command_absent
+        and motion_source_lower != "encoder_delta"
+    )
+    if safety_release_idle:
+        # STOP/ABORT means the operator intentionally released the current
+        # manual control.  If the command topic is gone and encoder-delta does
+        # not indicate real motion, stale SKY/section_status must not keep the
+        # UI locked just because the previous fixed Az/El target was not reached.
+        manual_state = "idle"
+        active_task = "none"
+        motion_live_active = False
+        motion_mount_hold_at_target = False
+
     if state.action_mode == "dry-run":
         chopper_state = str(chopper.get("state") or state.last_chopper_state or "unknown")
         chopper_position = chopper.get("position")
@@ -2012,6 +2078,8 @@ def _operator_status_to_v7_status(
         "operator_last_mount_target_az": state.last_mount_target_az,
         "operator_last_mount_target_el": state.last_mount_target_el,
         "operator_last_mount_target_reached_since": state.last_mount_target_reached_since,
+        "operator_safety_release_idle": bool(safety_release_idle),
+        "operator_safety_release_age_sec": safety_release_age,
         "mount_target_reached_tol_deg": motion.get("mount_target_reached_tol_deg"),
         "encoder_motion_deadband_deg": motion.get("encoder_motion_deadband_deg"),
         "encoder_motion_delta_az_deg": motion.get("encoder_motion_delta_az_deg"),

--- a/necst/web/operator_console.py
+++ b/necst/web/operator_console.py
@@ -18,6 +18,7 @@ import sys
 import json
 import math
 import os
+import shutil
 import threading
 import time
 import uuid
@@ -88,6 +89,14 @@ EXCLUSIVE_START_STATUS_SEC = 15.0
 # This prevents STOP REQUESTED from degrading into ATTENTION while the telescope
 # is already stopped and ready for the next command.
 SAFETY_RELEASE_ASSUME_IDLE_AFTER_SEC = 1.0
+
+# A progress sidecar can remain in a non-final lifecycle if an observation
+# launcher dies or blocks before writing its final snapshot.  Do not keep the
+# operator UI in OBSERVATION RUNNING forever when no local launcher is active
+# and the sidecar has not been updated for this long.  This only changes the
+# console status; it does not send telescope commands or delete data.
+STALE_OBSERVATION_PROGRESS_SEC = float(os.environ.get("NECST_CONSOLE_STALE_OBSERVATION_SEC", "60.0"))
+ABORT_STUCK_OBSERVATION_SEC = float(os.environ.get("NECST_CONSOLE_ABORT_STUCK_OBSERVATION_SEC", "15.0"))
 
 LIVE_ACTION_GUARD_MESSAGE = (
     "live write actions are guarded by --guard-live-actions; "
@@ -977,6 +986,198 @@ def _active_launcher_summary(
     return "active launcher already exists: " + ", ".join(labels)
 
 
+
+def _active_launcher_categories(state: OperatorConsoleState) -> set[str]:
+    """Return active launcher categories currently owned by this console."""
+
+    return {
+        str(record.category or "").strip().lower()
+        for record in state.process_registry.active()
+        if str(record.category or "").strip()
+    }
+
+
+def _progress_snapshot_update_age_sec(status_state: Mapping[str, Any]) -> Optional[float]:
+    """Return age of the current progress snapshot update, if known."""
+
+    now = time.time()
+    snapshot = status_state.get("snapshot") if isinstance(status_state, Mapping) else {}
+    snapshot = snapshot if isinstance(snapshot, Mapping) else {}
+    timing = snapshot.get("time") if isinstance(snapshot.get("time"), Mapping) else {}
+    candidates = [
+        timing.get("updated_at_unix"),
+        timing.get("last_update_unix"),
+        timing.get("server_time_unix"),
+    ]
+    raw = status_state.get("raw_snapshot") if isinstance(status_state, Mapping) else {}
+    raw = raw if isinstance(raw, Mapping) else {}
+    raw_timing = raw.get("time") if isinstance(raw.get("time"), Mapping) else {}
+    candidates.extend([
+        raw_timing.get("updated_at_unix"),
+        raw_timing.get("last_update_unix"),
+    ])
+    for value in candidates:
+        try:
+            ts = float(value)
+        except Exception:
+            continue
+        if math.isfinite(ts) and ts > 0:
+            return max(0.0, now - ts)
+    try:
+        path = Path(str((status_state.get("paths") or {}).get("snapshot") or ""))
+        if path.exists():
+            return max(0.0, now - path.stat().st_mtime)
+    except Exception:
+        pass
+    return None
+
+
+def _stale_observation_state(
+    state: OperatorConsoleState,
+    status_state: Mapping[str, Any],
+    operator_status: Optional[Mapping[str, Any]] = None,
+) -> JsonDict:
+    """Classify stale or stuck observation-running state.
+
+    ``running_stale`` means the progress pointer still says running, but no
+    local observation/calibration launcher is active and the sidecar is old.
+    ``launcher_stuck`` means a local observation launcher is still active, but
+    the system is in error/failed state or ABORT/STOP has not completed for a
+    while.  The latter must be shown as ATTENTION, not OBSERVATION RUNNING.
+    """
+
+    op = operator_status if isinstance(operator_status, Mapping) else {}
+    if not op:
+        op = status_state.get("operator_status") if isinstance(status_state, Mapping) else {}
+        op = op if isinstance(op, Mapping) else {}
+    system = op.get("system") if isinstance(op.get("system"), Mapping) else {}
+    progress = op.get("progress") if isinstance(op.get("progress"), Mapping) else {}
+    observation = op.get("observation") if isinstance(op.get("observation"), Mapping) else {}
+    lifecycle = str(system.get("state") or "unknown").strip().lower()
+    percent = progress.get("percent")
+    nonfinal_lifecycle = lifecycle not in {"", "idle", "unknown", "finished", "aborted", "error", "failed"}
+    progress_running = bool(nonfinal_lifecycle or percent is not None)
+    active_categories = _active_launcher_categories(state)
+    active_launcher = bool(active_categories.intersection({"observation", "calibration"}))
+    age = _progress_snapshot_update_age_sec(status_state)
+    threshold = max(5.0, float(STALE_OBSERVATION_PROGRESS_SEC))
+    safety_age = _recent_safety_release_request_age_sec(state, max_age_sec=3600.0)
+    abort_stuck_threshold = max(3.0, float(ABORT_STUCK_OBSERVATION_SEC))
+
+    running_stale = bool(
+        progress_running
+        and not active_launcher
+        and age is not None
+        and age >= threshold
+    )
+    error_like_lifecycle = lifecycle in {"error", "failed"}
+    abort_stalled = bool(
+        active_launcher
+        and safety_age is not None
+        and safety_age >= abort_stuck_threshold
+    )
+    launcher_stuck = bool(active_launcher and (error_like_lifecycle or abort_stalled))
+
+    reason = ""
+    if launcher_stuck:
+        if abort_stalled:
+            reason = (
+                "ABORT/STOP was requested, but a console-owned observation launcher "
+                "is still active after the timeout"
+            )
+        else:
+            reason = (
+                "system lifecycle is error/failed while a console-owned observation "
+                "launcher is still active"
+            )
+    elif running_stale:
+        reason = (
+            "progress sidecar is non-final/still-running, but no console-owned "
+            "observation launcher is active and the sidecar update is stale"
+        )
+
+    return {
+        "running_stale": running_stale,
+        "launcher_stuck": launcher_stuck,
+        "abort_stalled": abort_stalled,
+        "progress_running": bool(progress_running),
+        "active_launcher": active_launcher,
+        "active_launcher_categories": sorted(active_categories),
+        "age_sec": age,
+        "threshold_sec": threshold,
+        "abort_stuck_threshold_sec": abort_stuck_threshold,
+        "safety_release_age_sec": safety_age,
+        "lifecycle_state": lifecycle,
+        "record_name": observation.get("record_name"),
+        "progress_record_dir": observation.get("progress_record_dir"),
+        "reason": reason,
+        "can_clear": bool(running_stale and not active_launcher),
+        "can_terminate_launcher": bool(launcher_stuck and active_launcher),
+    }
+
+def _clear_stale_observation_state(state: OperatorConsoleState) -> Tuple[bool, str, JsonDict]:
+    """Archive stale current-observation pointers so the console can return READY.
+
+    This is an explicit operator recovery action.  It never sends hardware
+    commands and it does not delete the per-record progress directory or data.
+    It only moves the global current-observation pointer files out of the way.
+    """
+
+    active = _active_launcher_categories(state).intersection({"observation", "calibration"})
+    if active:
+        return False, (
+            "cannot clear stale observation state while a console-owned launcher "
+            f"is still active: {', '.join(sorted(active))}. Terminate the local "
+            "observation launcher first after confirming the hardware is safe."
+        ), {"active_launcher_categories": sorted(active), "cleared": False}
+
+    root = state.progress_root
+    stamp = time.strftime("%Y%m%d_%H%M%S", time.localtime())
+    archive_dir = root / "stale_console_clear" / stamp
+    moved: List[Dict[str, str]] = []
+    missing: List[str] = []
+    errors: List[str] = []
+    for name in ("current_observation_progress.json", "current_observation_record.txt"):
+        src = root / name
+        if not src.exists():
+            missing.append(str(src))
+            continue
+        try:
+            archive_dir.mkdir(parents=True, exist_ok=True)
+            dst = archive_dir / name
+            shutil.move(str(src), str(dst))
+            moved.append({"from": str(src), "to": str(dst)})
+        except Exception as exc:
+            errors.append(f"{src}: {exc}")
+    if errors:
+        return False, "failed to clear one or more stale progress pointer files", {
+            "cleared": False,
+            "moved": moved,
+            "missing": missing,
+            "errors": errors,
+            "archive_dir": str(archive_dir),
+        }
+
+    _clear_exclusive_start_guard(state)
+    _clear_safety_release_request(state)
+    _clear_last_mount_target(state)
+    state.last_manual_state = "idle"
+    state.last_active_task = "none"
+    state.last_command_az = None
+    state.last_command_el = None
+    message = "stale observation state cleared"
+    if moved:
+        message += f"; archived {len(moved)} current progress pointer file(s)"
+    else:
+        message += "; no current progress pointer files were present"
+    return True, message, {
+        "cleared": True,
+        "moved": moved,
+        "missing": missing,
+        "archive_dir": str(archive_dir) if moved else None,
+        "note": "per-record progress/data directories were not deleted",
+    }
+
 def _last_mount_target_reached(
     state: OperatorConsoleState,
     *,
@@ -1167,6 +1368,17 @@ def _operator_status_operation_conflict(
         )
         op = status_state.get("operator_status") if isinstance(status_state, Mapping) else {}
         op = op if isinstance(op, Mapping) else {}
+        stale = _stale_observation_state(state, status_state, op)
+        if stale.get("running_stale") or stale.get("launcher_stuck"):
+            if stale.get("launcher_stuck"):
+                return (
+                    f"cannot start {requested_action}: observation launcher appears stuck "
+                    f"for record {stale.get('record_name') or 'unknown'}; terminate the local observation launcher first"
+                )
+            return (
+                f"cannot start {requested_action}: stale observation state remains "
+                f"for record {stale.get('record_name') or 'unknown'}; use Clear stale observation state"
+            )
         system = op.get("system") if isinstance(op.get("system"), Mapping) else {}
         motion = op.get("motion") if isinstance(op.get("motion"), Mapping) else {}
         sys_state = str(system.get("state") or "").strip().lower()
@@ -1399,6 +1611,11 @@ def dispatch_action(
             ),
             "shutdown": _shutdown_snapshot(state),
         }
+
+    if action == "clear_stale_observation_state":
+        ok, message, data = _clear_stale_observation_state(state)
+        data["action"] = action
+        return ok, message, data
 
     live_allowed, live_reason, live_data = _live_write_guard(state, action)
     if not live_allowed:
@@ -1930,7 +2147,14 @@ def _operator_status_to_v7_status(
         for record in process_records
         if bool(record.is_active())
     }
-    if sys_state == "idle":
+    stale_observation = _stale_observation_state(state, status_state, op)
+    if stale_observation.get("running_stale") or stale_observation.get("launcher_stuck"):
+        sys_state = "stale_observation"
+        warnings = list(warnings) + [
+            stale_observation.get("reason")
+            or "stale/stuck observation state remains; recover before starting a new operation"
+        ]
+    elif sys_state == "idle":
         if "observation" in active_process_categories:
             sys_state = "observing"
         elif "calibration" in active_process_categories:
@@ -2103,6 +2327,7 @@ def _operator_status_to_v7_status(
             "position": chopper_position if chopper_position is not None else "unknown",
             "age": age_text,
         },
+        "stale_observation": stale_observation,
         "progress": {
             "running": bool(progress_running),
             "url": str(monitor_status.get("url") or state.progress_url),

--- a/necst/web/operator_console.py
+++ b/necst/web/operator_console.py
@@ -277,6 +277,44 @@ def _optional_positive_int(value: Any, *, name: str) -> Optional[int]:
     return number
 
 
+def _normalize_skydip_tp_range(value: Any) -> str:
+    """Return a normalized START END integer-pair string for the web launcher.
+
+    The empty string means the SkyDip default total-power range.  This mirrors
+    the CLI expectation while giving the operator a clearer web-facing error
+    before the local launcher is started.
+    """
+
+    if value in (None, ""):
+        return ""
+    if isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            return ""
+        tokens = raw.replace(",", " ").split()
+    else:
+        try:
+            tokens = [str(x) for x in value]
+        except TypeError as exc:
+            raise ValueError("SkyDip TP channel range must be blank or integer START END pairs") from exc
+    values: List[int] = []
+    for token in tokens:
+        text = str(token).strip()
+        if not text:
+            continue
+        try:
+            number = int(text)
+        except Exception as exc:
+            raise ValueError(
+                "SkyDip TP channel range must be blank or integer START END pairs "
+                f"(invalid token: {text!r})"
+            ) from exc
+        values.append(number)
+    if len(values) % 2 != 0:
+        raise ValueError("SkyDip TP channel range must contain START END integer pairs")
+    return " ".join(str(x) for x in values)
+
+
 def resolve_site_summary(
     *,
     site_config_path: Optional[os.PathLike[str] | str] = None,
@@ -2607,12 +2645,13 @@ def dispatch_action(
     if action == "run_skydip":
         validate_site_capability(state, "skydip", action_label="SkyDip")
         dry_run = state.action_mode == "dry-run"
+        skydip_tp_range = _normalize_skydip_tp_range(params.get("tp_range"))
         actions = _load_operator_actions()
         if not dry_run:
             preflight = actions.run_skydip(
                 integ=params.get("integ", 2),
                 channel=params.get("ch"),
-                tp_range=params.get("tp_range"),
+                tp_range=skydip_tp_range,
                 background=True,
                 dry_run=True,
             )
@@ -2625,7 +2664,7 @@ def dispatch_action(
         result = actions.run_skydip(
             integ=params.get("integ", 2),
             channel=params.get("ch"),
-            tp_range=params.get("tp_range"),
+            tp_range=skydip_tp_range,
             background=True,
             dry_run=dry_run,
             stdout_path=stdout_path,

--- a/necst/web/operator_console.py
+++ b/necst/web/operator_console.py
@@ -18,7 +18,6 @@ import sys
 import json
 import math
 import os
-import shutil
 import threading
 import time
 import uuid
@@ -89,13 +88,6 @@ EXCLUSIVE_START_STATUS_SEC = 15.0
 # This prevents STOP REQUESTED from degrading into ATTENTION while the telescope
 # is already stopped and ready for the next command.
 SAFETY_RELEASE_ASSUME_IDLE_AFTER_SEC = 1.0
-
-# A progress sidecar can remain in a non-final lifecycle if an observation
-# launcher dies or blocks before writing its final snapshot.  Do not keep the
-# operator UI in OBSERVATION RUNNING forever when no local launcher is active
-# and the sidecar has not been updated for this long.  This only changes the
-# console status; it does not send telescope commands or delete data.
-STALE_OBSERVATION_PROGRESS_SEC = float(os.environ.get("NECST_CONSOLE_STALE_OBSERVATION_SEC", "60.0"))
 
 LIVE_ACTION_GUARD_MESSAGE = (
     "live write actions are guarded by --guard-live-actions; "
@@ -985,169 +977,6 @@ def _active_launcher_summary(
     return "active launcher already exists: " + ", ".join(labels)
 
 
-
-def _active_launcher_categories(state: OperatorConsoleState) -> set[str]:
-    """Return active launcher categories currently owned by this console."""
-
-    return {
-        str(record.category or "").strip().lower()
-        for record in state.process_registry.active()
-        if str(record.category or "").strip()
-    }
-
-
-def _progress_snapshot_update_age_sec(status_state: Mapping[str, Any]) -> Optional[float]:
-    """Return age of the current progress snapshot update, if known."""
-
-    now = time.time()
-    snapshot = status_state.get("snapshot") if isinstance(status_state, Mapping) else {}
-    snapshot = snapshot if isinstance(snapshot, Mapping) else {}
-    timing = snapshot.get("time") if isinstance(snapshot.get("time"), Mapping) else {}
-    candidates = [
-        timing.get("updated_at_unix"),
-        timing.get("last_update_unix"),
-        timing.get("server_time_unix"),
-    ]
-    raw = status_state.get("raw_snapshot") if isinstance(status_state, Mapping) else {}
-    raw = raw if isinstance(raw, Mapping) else {}
-    raw_timing = raw.get("time") if isinstance(raw.get("time"), Mapping) else {}
-    candidates.extend([
-        raw_timing.get("updated_at_unix"),
-        raw_timing.get("last_update_unix"),
-    ])
-    for value in candidates:
-        try:
-            ts = float(value)
-        except Exception:
-            continue
-        if math.isfinite(ts) and ts > 0:
-            return max(0.0, now - ts)
-    try:
-        path = Path(str((status_state.get("paths") or {}).get("snapshot") or ""))
-        if path.exists():
-            return max(0.0, now - path.stat().st_mtime)
-    except Exception:
-        pass
-    return None
-
-
-def _stale_observation_state(
-    state: OperatorConsoleState,
-    status_state: Mapping[str, Any],
-    operator_status: Optional[Mapping[str, Any]] = None,
-) -> JsonDict:
-    """Classify stale observation-running sidecars.
-
-    This is intentionally conservative.  It does not declare a live observation
-    stale while a console-owned observation/calibration launcher is still active.
-    It only marks the status as stale when a progress sidecar still says the
-    lifecycle is non-final but the sidecar has not been refreshed for the
-    configured timeout.
-    """
-
-    op = operator_status if isinstance(operator_status, Mapping) else {}
-    if not op:
-        op = status_state.get("operator_status") if isinstance(status_state, Mapping) else {}
-        op = op if isinstance(op, Mapping) else {}
-    system = op.get("system") if isinstance(op.get("system"), Mapping) else {}
-    progress = op.get("progress") if isinstance(op.get("progress"), Mapping) else {}
-    observation = op.get("observation") if isinstance(op.get("observation"), Mapping) else {}
-    lifecycle = str(system.get("state") or "unknown").strip().lower()
-    percent = progress.get("percent")
-    nonfinal_lifecycle = lifecycle not in {"", "idle", "unknown", "finished", "aborted", "error", "failed"}
-    progress_running = bool(nonfinal_lifecycle or percent is not None)
-    active_categories = _active_launcher_categories(state)
-    active_launcher = bool(active_categories.intersection({"observation", "calibration"}))
-    age = _progress_snapshot_update_age_sec(status_state)
-    threshold = max(5.0, float(STALE_OBSERVATION_PROGRESS_SEC))
-    running_stale = bool(
-        progress_running
-        and not active_launcher
-        and age is not None
-        and age >= threshold
-    )
-    return {
-        "running_stale": running_stale,
-        "progress_running": bool(progress_running),
-        "active_launcher": active_launcher,
-        "active_launcher_categories": sorted(active_categories),
-        "age_sec": age,
-        "threshold_sec": threshold,
-        "lifecycle_state": lifecycle,
-        "record_name": observation.get("record_name"),
-        "progress_record_dir": observation.get("progress_record_dir"),
-        "reason": (
-            "progress sidecar is non-final/still-running, but no console-owned "
-            "observation launcher is active and the sidecar update is stale"
-            if running_stale
-            else ""
-        ),
-        "can_clear": bool(running_stale and not active_launcher),
-    }
-
-
-def _clear_stale_observation_state(state: OperatorConsoleState) -> Tuple[bool, str, JsonDict]:
-    """Archive stale current-observation pointers so the console can return READY.
-
-    This is an explicit operator recovery action.  It never sends hardware
-    commands and it does not delete the per-record progress directory or data.
-    It only moves the global current-observation pointer files out of the way.
-    """
-
-    active = _active_launcher_categories(state).intersection({"observation", "calibration"})
-    if active:
-        return False, (
-            "cannot clear stale observation state while a console-owned launcher "
-            f"is still active: {', '.join(sorted(active))}"
-        ), {"active_launcher_categories": sorted(active), "cleared": False}
-
-    root = state.progress_root
-    stamp = time.strftime("%Y%m%d_%H%M%S", time.localtime())
-    archive_dir = root / "stale_console_clear" / stamp
-    moved: List[Dict[str, str]] = []
-    missing: List[str] = []
-    errors: List[str] = []
-    for name in ("current_observation_progress.json", "current_observation_record.txt"):
-        src = root / name
-        if not src.exists():
-            missing.append(str(src))
-            continue
-        try:
-            archive_dir.mkdir(parents=True, exist_ok=True)
-            dst = archive_dir / name
-            shutil.move(str(src), str(dst))
-            moved.append({"from": str(src), "to": str(dst)})
-        except Exception as exc:
-            errors.append(f"{src}: {exc}")
-    if errors:
-        return False, "failed to clear one or more stale progress pointer files", {
-            "cleared": False,
-            "moved": moved,
-            "missing": missing,
-            "errors": errors,
-            "archive_dir": str(archive_dir),
-        }
-
-    _clear_exclusive_start_guard(state)
-    _clear_safety_release_request(state)
-    _clear_last_mount_target(state)
-    state.last_manual_state = "idle"
-    state.last_active_task = "none"
-    state.last_command_az = None
-    state.last_command_el = None
-    message = "stale observation state cleared"
-    if moved:
-        message += f"; archived {len(moved)} current progress pointer file(s)"
-    else:
-        message += "; no current progress pointer files were present"
-    return True, message, {
-        "cleared": True,
-        "moved": moved,
-        "missing": missing,
-        "archive_dir": str(archive_dir) if moved else None,
-        "note": "per-record progress/data directories were not deleted",
-    }
-
 def _last_mount_target_reached(
     state: OperatorConsoleState,
     *,
@@ -1338,12 +1167,6 @@ def _operator_status_operation_conflict(
         )
         op = status_state.get("operator_status") if isinstance(status_state, Mapping) else {}
         op = op if isinstance(op, Mapping) else {}
-        stale = _stale_observation_state(state, status_state, op)
-        if stale.get("running_stale"):
-            return (
-                f"cannot start {requested_action}: stale observation state remains "
-                f"for record {stale.get('record_name') or 'unknown'}; use Clear stale observation state"
-            )
         system = op.get("system") if isinstance(op.get("system"), Mapping) else {}
         motion = op.get("motion") if isinstance(op.get("motion"), Mapping) else {}
         sys_state = str(system.get("state") or "").strip().lower()
@@ -1576,11 +1399,6 @@ def dispatch_action(
             ),
             "shutdown": _shutdown_snapshot(state),
         }
-
-    if action == "clear_stale_observation_state":
-        ok, message, data = _clear_stale_observation_state(state)
-        data["action"] = action
-        return ok, message, data
 
     live_allowed, live_reason, live_data = _live_write_guard(state, action)
     if not live_allowed:
@@ -2112,13 +1930,7 @@ def _operator_status_to_v7_status(
         for record in process_records
         if bool(record.is_active())
     }
-    stale_observation = _stale_observation_state(state, status_state, op)
-    if stale_observation.get("running_stale"):
-        sys_state = "stale_observation"
-        warnings = list(warnings) + [
-            "stale observation progress state remains; use Clear stale observation state after confirming hardware is safe"
-        ]
-    elif sys_state == "idle":
+    if sys_state == "idle":
         if "observation" in active_process_categories:
             sys_state = "observing"
         elif "calibration" in active_process_categories:
@@ -2291,7 +2103,6 @@ def _operator_status_to_v7_status(
             "position": chopper_position if chopper_position is not None else "unknown",
             "age": age_text,
         },
-        "stale_observation": stale_observation,
         "progress": {
             "running": bool(progress_running),
             "url": str(monitor_status.get("url") or state.progress_url),

--- a/necst/web/operator_console.py
+++ b/necst/web/operator_console.py
@@ -1579,7 +1579,11 @@ def _operator_status_to_v7_status(
 
     raw_active_task = str(motion.get("active_task") or "").strip()
     if raw_active_task.lower() in {"", "idle", "none", "unknown"}:
-        active_task = str(state.last_active_task or "none")
+        # In live mode, do not resurrect the last console-side action.  That
+        # stale fallback made the Manual panel keep showing "moving" after
+        # an abort or after the command/status topics disappeared.  Dry-run
+        # still uses the local action memory because there are no live topics.
+        active_task = str(state.last_active_task or "none") if state.action_mode == "dry-run" else "none"
     else:
         active_task = raw_active_task
     if active_task.lower() in {"", "idle", "unknown"}:
@@ -1587,7 +1591,7 @@ def _operator_status_to_v7_status(
 
     raw_manual_state = str(motion.get("stage") or "").strip()
     if raw_manual_state.lower() in {"", "idle", "none", "unknown"}:
-        manual_state = str(state.last_manual_state or "idle")
+        manual_state = str(state.last_manual_state or "idle") if state.action_mode == "dry-run" else "idle"
     else:
         manual_state = raw_manual_state
     if manual_state.lower() in {"", "none", "unknown"}:
@@ -1605,15 +1609,20 @@ def _operator_status_to_v7_status(
 
     cmd_az = antenna.get("command_az_deg")
     cmd_el = antenna.get("command_el_deg")
-    if cmd_az is None:
-        cmd_az = state.last_command_az
-    if cmd_el is None:
-        cmd_el = state.last_command_el
+    if state.action_mode == "dry-run":
+        if cmd_az is None:
+            cmd_az = state.last_command_az
+        if cmd_el is None:
+            cmd_el = state.last_command_el
 
-    chopper_state = str(chopper.get("state") or state.last_chopper_state or "unknown")
-    chopper_position = chopper.get("position")
-    if chopper_position is None:
-        chopper_position = state.last_chopper_position
+    if state.action_mode == "dry-run":
+        chopper_state = str(chopper.get("state") or state.last_chopper_state or "unknown")
+        chopper_position = chopper.get("position")
+        if chopper_position is None:
+            chopper_position = state.last_chopper_position
+    else:
+        chopper_state = str(chopper.get("state") or "unknown")
+        chopper_position = chopper.get("position")
     chopper_age = chopper.get("age_sec")
     if chopper_age is None:
         age_text = "unknown"

--- a/necst/web/operator_console.py
+++ b/necst/web/operator_console.py
@@ -82,6 +82,13 @@ EXCLUSIVE_START_BLOCK_SEC = 3.0
 # launchers and confirmed live activity supersede it.
 EXCLUSIVE_START_STATUS_SEC = 15.0
 
+# STOP / ABORT are release requests.  After a short grace, if the system
+# lifecycle is final/idle and /ctrl/antenna/altaz has disappeared, the operator
+# UI must stop trusting stale SKY/section_status or encoder-motion hysteresis.
+# This prevents STOP REQUESTED from degrading into ATTENTION while the telescope
+# is already stopped and ready for the next command.
+SAFETY_RELEASE_ASSUME_IDLE_AFTER_SEC = 1.0
+
 LIVE_ACTION_GUARD_MESSAGE = (
     "live write actions are guarded by --guard-live-actions; "
     "use --action-mode dry-run for normal no-hardware validation"
@@ -1178,7 +1185,7 @@ def _operator_status_operation_conflict(
             and safety_release_age is not None
             and sys_state in {"", "idle", "unknown", "finished", "aborted", "error", "failed"}
             and command_absent
-            and motion_source_lower != "encoder_delta"
+            and safety_release_age >= SAFETY_RELEASE_ASSUME_IDLE_AFTER_SEC
         )
         if safety_release_idle:
             at_target_idle = True
@@ -2007,6 +2014,7 @@ def _operator_status_to_v7_status(
         motion_live_active = False
         motion_mount_target_reached = True
         motion_mount_hold_at_target = True
+        motion_source_lower = "operator_mount_target_idle"
 
     cmd_az = antenna.get("command_az_deg")
     cmd_el = antenna.get("command_el_deg")
@@ -2023,17 +2031,19 @@ def _operator_status_to_v7_status(
         and safety_release_age is not None
         and sys_state in {"", "idle", "unknown", "finished", "aborted", "error", "failed"}
         and command_absent
-        and motion_source_lower != "encoder_delta"
+        and safety_release_age >= SAFETY_RELEASE_ASSUME_IDLE_AFTER_SEC
     )
     if safety_release_idle:
         # STOP/ABORT means the operator intentionally released the current
-        # manual control.  If the command topic is gone and encoder-delta does
-        # not indicate real motion, stale SKY/section_status must not keep the
-        # UI locked just because the previous fixed Az/El target was not reached.
+        # manual control.  Once the command topic is gone and the system
+        # lifecycle is final/idle, do not keep waiting for the old target and do
+        # not let stale SKY/section_status or encoder-motion hysteresis trap the
+        # UI in STOP REQUESTED/ATTENTION.
         manual_state = "idle"
         active_task = "none"
         motion_live_active = False
         motion_mount_hold_at_target = False
+        motion_source_lower = "operator_safety_release"
 
     if state.action_mode == "dry-run":
         chopper_state = str(chopper.get("state") or state.last_chopper_state or "unknown")
@@ -2070,7 +2080,7 @@ def _operator_status_to_v7_status(
         "manual_state": manual_state,
         "active_task": active_task,
         "motion_live_active": motion_live_active,
-        "motion_live_source": motion.get("live_motion_source"),
+        "motion_live_source": motion_source_lower or motion.get("live_motion_source"),
         "mount_target_reached": motion_mount_target_reached,
         "mount_hold_at_target": motion_mount_hold_at_target,
         "operator_last_mount_target_reached": bool(operator_mount_target_reached),

--- a/necst/web/operator_console.py
+++ b/necst/web/operator_console.py
@@ -58,6 +58,30 @@ SAFETY_ACTIONS = {
     "abort_observation",
 }
 
+# Operations that should be mutually exclusive from a human-operator point of
+# view. UI disabled states are not sufficient: stale browser tabs, double
+# clicks, or direct /api/action calls must be rejected server-side too.
+EXCLUSIVE_START_ACTIONS = {
+    "mount_move",
+    "start_tracking",
+    "start_observation",
+    "run_rsky",
+    "run_skydip",
+}
+
+# Short server-side mutex for Start-like commands.  This closes the gap where
+# two browsers, a stale tab, or a very fast double-click can submit another
+# Start before ROS/progress/launcher status has had time to reflect the first
+# accepted command.  Keep the hard blocking window short so a quick mount move
+# or an already-complete command does not block normal operation for long.
+EXCLUSIVE_START_BLOCK_SEC = 3.0
+
+# Longer status hint for human operators.  A browser reload or a second browser
+# should still show "STARTING..." while the accepted command is waiting for
+# ROS/progress confirmation.  This is display state, not a long mutex; finished
+# launchers and confirmed live activity supersede it.
+EXCLUSIVE_START_STATUS_SEC = 15.0
+
 LIVE_ACTION_GUARD_MESSAGE = (
     "live write actions are guarded by --guard-live-actions; "
     "use --action-mode dry-run for normal no-hardware validation"
@@ -139,6 +163,10 @@ class OperatorConsoleState:
     shutdown_terminate_launchers: bool = True
     shutdown_launcher_timeout_sec: float = 3.0
     shutdown_launcher_kill_timeout_sec: float = 1.0
+    exclusive_start_action: Optional[str] = None
+    exclusive_start_session_id: Optional[str] = None
+    exclusive_start_started_at: Optional[float] = None
+    exclusive_start_message: str = ""
     lock: threading.RLock = field(default_factory=threading.RLock)
 
     def add_log(
@@ -930,6 +958,131 @@ def _active_launcher_summary(
     return "active launcher already exists: " + ", ".join(labels)
 
 
+
+
+def _prune_exclusive_start_guard(state: OperatorConsoleState) -> None:
+    action = str(state.exclusive_start_action or "").strip()
+    started = state.exclusive_start_started_at
+    if not action or started is None:
+        return
+    try:
+        age = max(0.0, time.time() - float(started))
+    except Exception:
+        age = EXCLUSIVE_START_STATUS_SEC + 1.0
+    if age > EXCLUSIVE_START_STATUS_SEC:
+        state.exclusive_start_action = None
+        state.exclusive_start_session_id = None
+        state.exclusive_start_started_at = None
+        state.exclusive_start_message = ""
+
+
+def _exclusive_start_guard_reason(
+    state: OperatorConsoleState, *, requested_action: str
+) -> Optional[str]:
+    if requested_action not in EXCLUSIVE_START_ACTIONS:
+        return None
+    _prune_exclusive_start_guard(state)
+    action = str(state.exclusive_start_action or "").strip()
+    started = state.exclusive_start_started_at
+    if not action or started is None:
+        return None
+    age = max(0.0, time.time() - float(started))
+    if age > EXCLUSIVE_START_BLOCK_SEC:
+        return None
+    message = state.exclusive_start_message or action
+    return (
+        f"cannot start {requested_action}: {message} was accepted "
+        f"{age:.1f} s ago; wait for READY/status confirmation or use STOP/ABORT"
+    )
+
+
+def _mark_exclusive_start_guard(
+    state: OperatorConsoleState,
+    *,
+    action: str,
+    session_id: str,
+    message: str,
+) -> None:
+    if action not in EXCLUSIVE_START_ACTIONS:
+        return
+    state.exclusive_start_action = str(action)
+    state.exclusive_start_session_id = str(session_id or "")
+    state.exclusive_start_started_at = time.time()
+    state.exclusive_start_message = str(message or action)
+
+
+def _clear_exclusive_start_guard(state: OperatorConsoleState) -> None:
+    state.exclusive_start_action = None
+    state.exclusive_start_session_id = None
+    state.exclusive_start_started_at = None
+    state.exclusive_start_message = ""
+
+
+def _operator_status_operation_conflict(
+    state: OperatorConsoleState, *, requested_action: str
+) -> Optional[str]:
+    """Return a user-facing conflict reason for mutually exclusive starts.
+
+    The browser disables Start-like controls while an operation is active, but
+    the server must also be conservative because operators can double-click, use
+    stale tabs, or trigger actions from another client. Safety actions are not
+    passed here and remain available.
+    """
+
+    if requested_action not in EXCLUSIVE_START_ACTIONS:
+        return None
+
+    active_launcher = _active_launcher_summary(state)
+    if active_launcher is not None:
+        return (
+            f"cannot start {requested_action}: {active_launcher}. "
+            "Use STOP/ABORT or terminate the launcher before starting another operation."
+        )
+
+    recent_guard = _exclusive_start_guard_reason(state, requested_action=requested_action)
+    if recent_guard is not None:
+        return recent_guard
+
+    # Dry-run has no live ROS truth, so use local memory to protect the UI from
+    # conflicting Start-like actions. In live mode this memory is allowed to be
+    # stale, so live/progress truth below is preferred instead.
+    if state.action_mode == "dry-run":
+        task = str(state.last_active_task or "").strip()
+        manual = str(state.last_manual_state or "").strip()
+        if task.lower() not in {"", "none", "idle", "unknown"}:
+            return f"cannot start {requested_action}: active task is {task}; use STOP/ABORT or wait until READY"
+        if manual.lower() in {"moving", "tracking", "calibration", "observing sequence"}:
+            return f"cannot start {requested_action}: manual state is {manual}; use STOP/ABORT or wait until READY"
+        return None
+
+    try:
+        live_payload = state.live_cache.snapshot() if state.live_cache is not None else None
+        status_state = status_model.build_progress_status_state(
+            state.progress_root,
+            events_limit=state.events_limit,
+            live_payload=live_payload,
+        )
+        op = status_state.get("operator_status") if isinstance(status_state, Mapping) else {}
+        op = op if isinstance(op, Mapping) else {}
+        system = op.get("system") if isinstance(op.get("system"), Mapping) else {}
+        motion = op.get("motion") if isinstance(op.get("motion"), Mapping) else {}
+        sys_state = str(system.get("state") or "").strip().lower()
+        if sys_state not in {"", "idle", "unknown", "finished", "aborted", "error", "failed"}:
+            return f"cannot start {requested_action}: system state is {sys_state}; use STOP/ABORT or wait until READY"
+        active_task = str(motion.get("active_task") or "").strip()
+        if active_task.lower() not in {"", "none", "idle", "unknown"}:
+            return f"cannot start {requested_action}: active task is {active_task}; use STOP/ABORT or wait until READY"
+        stage = str(motion.get("stage") or "").strip()
+        if stage.lower() not in {"", "none", "idle", "unknown"}:
+            return f"cannot start {requested_action}: mount/activity stage is {stage}; use STOP/ABORT or wait until READY"
+    except Exception:
+        # If status probing fails, do not block the action solely because the
+        # guard could not inspect telemetry. The action-specific validators and
+        # NECST command layer still run below. The next /api/status will expose
+        # the telemetry problem to the operator.
+        return None
+    return None
+
 def _launcher_log_paths(
     state: OperatorConsoleState,
     action: str,
@@ -1148,6 +1301,10 @@ def dispatch_action(
             kill=False,
         )
 
+    conflict_reason = _operator_status_operation_conflict(state, requested_action=action)
+    if conflict_reason is not None:
+        return False, conflict_reason, {"action": action, "operation_conflict": True}
+
     if action == "progress_status":
         progress = (
             state.progress_monitor.status(check_external=True).to_dict()
@@ -1256,6 +1413,12 @@ def dispatch_action(
         )
         ok, message, data = _result_to_response(result)
         if ok:
+            _mark_exclusive_start_guard(
+                state,
+                action=action,
+                session_id=session_id,
+                message=f"mount move Az={az:.4f} deg El={el:.4f} deg",
+            )
             state.last_command_az = az
             state.last_command_el = el
             state.last_manual_state = "moving"
@@ -1274,6 +1437,7 @@ def dispatch_action(
         ok, message, data = _result_to_response(result)
         data.update(safety_data)
         if ok:
+            _clear_exclusive_start_guard(state)
             state.last_manual_state = "stopped"
             state.last_active_task = "none"
             state.last_command_az = None
@@ -1299,6 +1463,12 @@ def dispatch_action(
         )
         ok, message, data = _result_to_response(result)
         if ok and not dry_run:
+            _mark_exclusive_start_guard(
+                state,
+                action=action,
+                session_id=session_id,
+                message="target tracking",
+            )
             state.last_command_az = None
             state.last_command_el = None
             state.last_manual_state = "tracking"
@@ -1317,6 +1487,7 @@ def dispatch_action(
         ok, message, data = _result_to_response(result)
         data.update(safety_data)
         if ok:
+            _clear_exclusive_start_guard(state)
             state.last_manual_state = "stopped"
             state.last_active_task = "none"
             state.last_command_az = None
@@ -1335,14 +1506,17 @@ def dispatch_action(
         )
         ok, message, data = _result_to_response(result)
         data.update(safety_data)
+        if ok:
+            _clear_exclusive_start_guard(state)
+            state.last_manual_state = "stopped"
+            state.last_active_task = "none"
+            state.last_command_az = None
+            state.last_command_el = None
         return ok, message, data
 
     if action == "start_observation":
         validate_site_capability(state, "observation_start", action_label="observation start")
         mode, path, channel = validate_observation_selection(params)
-        active_reason = _active_launcher_summary(state, category="observation")
-        if active_reason is not None:
-            return False, active_reason, {"action": action, "category": "observation"}
         dry_run = state.action_mode == "dry-run"
         actions = _load_operator_actions()
         if not dry_run:
@@ -1376,6 +1550,12 @@ def dispatch_action(
         )
         ok, message, data = _result_to_response(result)
         if ok and not dry_run:
+            _mark_exclusive_start_guard(
+                state,
+                action=action,
+                session_id=session_id,
+                message=f"observation {mode}",
+            )
             state.last_command_az = None
             state.last_command_el = None
             state.last_manual_state = "observing sequence"
@@ -1393,9 +1573,6 @@ def dispatch_action(
 
     if action == "run_rsky":
         validate_site_capability(state, "rsky", action_label="RSky")
-        active_reason = _active_launcher_summary(state, category="calibration")
-        if active_reason is not None:
-            return False, active_reason, {"action": action, "category": "calibration"}
         dry_run = state.action_mode == "dry-run"
         actions = _load_operator_actions()
         if not dry_run:
@@ -1423,6 +1600,12 @@ def dispatch_action(
         )
         ok, message, data = _result_to_response(result)
         if ok and not dry_run:
+            _mark_exclusive_start_guard(
+                state,
+                action=action,
+                session_id=session_id,
+                message="RSky",
+            )
             state.last_command_az = None
             state.last_command_el = None
             state.last_manual_state = "calibration"
@@ -1440,9 +1623,6 @@ def dispatch_action(
 
     if action == "run_skydip":
         validate_site_capability(state, "skydip", action_label="SkyDip")
-        active_reason = _active_launcher_summary(state, category="calibration")
-        if active_reason is not None:
-            return False, active_reason, {"action": action, "category": "calibration"}
         dry_run = state.action_mode == "dry-run"
         actions = _load_operator_actions()
         if not dry_run:
@@ -1470,6 +1650,12 @@ def dispatch_action(
         )
         ok, message, data = _result_to_response(result)
         if ok and not dry_run:
+            _mark_exclusive_start_guard(
+                state,
+                action=action,
+                session_id=session_id,
+                message="SkyDip",
+            )
             state.last_command_az = None
             state.last_command_el = None
             state.last_manual_state = "calibration"
@@ -1697,6 +1883,19 @@ def _operator_status_to_v7_status(
         "log": [entry.__dict__ for entry in state.log],
         "processes": [r.to_dict() for r in state.process_registry.all_records(refresh=False)],
         "process_counts": state.process_registry.counts(),
+        "exclusive_start_guard": {
+            "action": state.exclusive_start_action,
+            "session_id": state.exclusive_start_session_id,
+            "started_at": state.exclusive_start_started_at,
+            "age_sec": (
+                max(0.0, time.time() - float(state.exclusive_start_started_at))
+                if state.exclusive_start_started_at is not None
+                else None
+            ),
+            "message": state.exclusive_start_message,
+            "guard_sec": EXCLUSIVE_START_STATUS_SEC,
+            "blocking_sec": EXCLUSIVE_START_BLOCK_SEC,
+        },
         "launcher_log_choices": log_reader.launcher_log_choices([
             r.to_dict() for r in state.process_registry.all_records(refresh=False)
         ]),
@@ -1734,6 +1933,7 @@ def build_console_status(state: OperatorConsoleState) -> JsonDict:
     with state.lock:
         _refresh_processes_and_log(state)
         _sync_authority_state(state)
+        _prune_exclusive_start_guard(state)
         live_payload = state.live_cache.snapshot() if state.live_cache is not None else None
         status_state = status_model.build_progress_status_state(
             state.progress_root,

--- a/necst/web/operator_console.py
+++ b/necst/web/operator_console.py
@@ -1069,8 +1069,12 @@ def _operator_status_operation_conflict(
         sys_state = str(system.get("state") or "").strip().lower()
         if sys_state not in {"", "idle", "unknown", "finished", "aborted", "error", "failed"}:
             return f"cannot start {requested_action}: system state is {sys_state}; use STOP/ABORT or wait until READY"
+        at_target_idle = bool(
+            motion.get("mount_target_reached")
+            and motion.get("live_motion_active") is False
+        )
         active_task = str(motion.get("active_task") or "").strip()
-        if active_task.lower() not in {"", "none", "idle", "unknown"}:
+        if active_task.lower() not in {"", "none", "idle", "unknown"} and not at_target_idle:
             return f"cannot start {requested_action}: active task is {active_task}; use STOP/ABORT or wait until READY"
         stage = str(motion.get("stage") or "").strip()
         # Low-level antenna control can report a hold/tracking-like stage after
@@ -1091,7 +1095,7 @@ def _operator_status_operation_conflict(
             "target_hold",
             "target hold",
         }
-        if stage.lower() not in nonblocking_stages:
+        if stage.lower() not in nonblocking_stages and not at_target_idle:
             return f"cannot start {requested_action}: mount/activity stage is {stage}; use STOP/ABORT or wait until READY"
     except Exception:
         # If status probing fails, do not block the action solely because the
@@ -1781,7 +1785,17 @@ def _operator_status_to_v7_status(
         elif "calibration" in active_process_categories:
             sys_state = "calibrating"
 
+    motion_live_active = motion.get("live_motion_active")
+    motion_mount_target_reached = bool(motion.get("mount_target_reached"))
+    motion_mount_hold_at_target = bool(motion.get("mount_hold_at_target"))
+    motion_at_target_idle = bool(
+        (motion_mount_target_reached or motion_mount_hold_at_target)
+        and motion_live_active is False
+    )
+
     raw_active_task = str(motion.get("active_task") or "").strip()
+    if motion_at_target_idle:
+        raw_active_task = "idle"
     if raw_active_task.lower() in {"", "idle", "none", "unknown"}:
         # In live mode, do not resurrect the last console-side action.  That
         # stale fallback made the Manual panel keep showing "moving" after
@@ -1794,6 +1808,8 @@ def _operator_status_to_v7_status(
         active_task = "none"
 
     raw_manual_state = str(motion.get("stage") or "").strip()
+    if motion_at_target_idle:
+        raw_manual_state = "idle"
     if raw_manual_state.lower() in {"", "idle", "none", "unknown"}:
         manual_state = str(state.last_manual_state or "idle") if state.action_mode == "dry-run" else "idle"
     else:
@@ -1866,6 +1882,14 @@ def _operator_status_to_v7_status(
         "state": sys_state,
         "manual_state": manual_state,
         "active_task": active_task,
+        "motion_live_active": motion_live_active,
+        "motion_live_source": motion.get("live_motion_source"),
+        "mount_target_reached": motion_mount_target_reached,
+        "mount_hold_at_target": motion_mount_hold_at_target,
+        "mount_target_reached_tol_deg": motion.get("mount_target_reached_tol_deg"),
+        "encoder_motion_deadband_deg": motion.get("encoder_motion_deadband_deg"),
+        "encoder_motion_delta_az_deg": motion.get("encoder_motion_delta_az_deg"),
+        "encoder_motion_delta_el_deg": motion.get("encoder_motion_delta_el_deg"),
         "az": az,
         "el": el,
         "command_az": cmd_az,

--- a/necst/web/operator_console.py
+++ b/necst/web/operator_console.py
@@ -30,7 +30,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
 
 from . import log_reader, process_manager, progress_manager, self_check, site_config, status_model, live_telemetry
-from ..ctrl.antenna.az_unwrap import assert_mount_az_allowed_when_unwrap_disabled
+from ..az_unwrap_limits import assert_mount_az_allowed_when_unwrap_disabled
 
 
 JsonDict = Dict[str, Any]

--- a/necst/web/operator_console.py
+++ b/necst/web/operator_console.py
@@ -1,0 +1,1892 @@
+"""HTTP helpers for the NECST Operator Console.
+
+This module is the thin boundary between the browser-facing Operator Console
+and the shared read-only status / operator action layers.  It deliberately keeps
+validation and command dispatch small and explicit:
+
+* read-only status is built from :mod:`status_model`;
+* write-like actions are sent only through ``necst.core.operator_actions``;
+* unimplemented or site-disabled actions are rejected before any telescope
+  command can be sent.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import sys
+import json
+import math
+import os
+import threading
+import time
+import uuid
+import webbrowser
+import urllib.parse
+from dataclasses import dataclass, field
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
+
+from . import log_reader, process_manager, progress_manager, self_check, site_config, status_model
+
+
+JsonDict = Dict[str, Any]
+
+
+SUPPORTED_ACTION_MODES = {"live", "dry-run"}
+
+LIVE_WRITE_ACTIONS = {
+    "acquire_authority",
+    "mount_move",
+    "start_tracking",
+    "start_observation",
+    "run_rsky",
+    "run_skydip",
+    "chopper_in",
+    "chopper_out",
+    "chopper_alarm_reset",
+    "chopper_home",
+    "chopper_recover",
+}
+
+SAFETY_ACTIONS = {
+    "stop",
+    "stop_tracking",
+    "abort_observation",
+}
+
+LIVE_ACTION_GUARD_MESSAGE = (
+    "live write actions are guarded by --guard-live-actions; "
+    "use --action-mode dry-run for normal no-hardware validation"
+)
+
+
+@dataclass
+class ConsoleLogEntry:
+    """One operator-log line displayed in the browser and JSONL log."""
+
+    time: str
+    ok: bool
+    message: str
+    action: str = ""
+    session_id: str = ""
+    data: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ConsoleAuthorityState:
+    """Operator-console authority state.
+
+    ``held`` and ``session_id`` are the browser/session gate.  When running in
+    live mode, ``necst_held`` means this console process also holds actual NECST
+    privilege through a persistent Commander.  Observation/RSky/SkyDip launchers
+    run as separate processes, so the console must release actual privilege
+    before starting them to avoid blocking the child process.
+    """
+
+    held: bool = False
+    session_id: Optional[str] = None
+    necst_held: bool = False
+    necst_identity: Optional[str] = None
+    mode: str = "none"
+    note: str = ""
+
+
+@dataclass
+class OperatorConsoleState:
+    """Mutable server state that is not part of NECST telemetry."""
+
+    telescope: str
+    progress_root: Path
+    progress_url: str
+    progress_monitor: Optional[progress_manager.ProgressMonitorManager] = None
+    action_mode: str = "live"
+    live_actions_enabled: bool = True
+    status_refresh_ms: int = 1000
+    quiet: bool = False
+    events_limit: int = 12
+    site_summary: site_config.SiteConfigSummary = field(
+        default_factory=lambda: site_config.resolve_site_config()
+    )
+    mount_limits: Dict[str, float] = field(default_factory=dict)
+    site_capabilities: Dict[str, bool] = field(default_factory=dict)
+    chopper_config: Dict[str, Any] = field(default_factory=dict)
+    operator_log_path: Optional[Path] = None
+    launcher_log_dir: Optional[Path] = None
+    process_registry: process_manager.ProcessRegistry = field(
+        default_factory=process_manager.ProcessRegistry
+    )
+    log: List[ConsoleLogEntry] = field(default_factory=list)
+    authority: ConsoleAuthorityState = field(default_factory=ConsoleAuthorityState)
+    authority_handle: Any = None
+    last_command_az: Optional[float] = None
+    last_command_el: Optional[float] = None
+    last_manual_state: str = "idle"
+    last_active_task: str = "none"
+    last_chopper_state: str = "unknown"
+    last_chopper_position: Optional[float] = None
+    shutdown_requested: bool = False
+    cleanup_started_at: Optional[float] = None
+    cleanup_finished_at: Optional[float] = None
+    cleanup_status: str = "not_started"
+    cleanup_summary: Dict[str, Any] = field(default_factory=dict)
+    shutdown_terminate_launchers: bool = True
+    shutdown_launcher_timeout_sec: float = 3.0
+    shutdown_launcher_kill_timeout_sec: float = 1.0
+    lock: threading.RLock = field(default_factory=threading.RLock)
+
+    def add_log(
+        self,
+        ok: bool,
+        message: str,
+        *,
+        action: str = "",
+        session_id: str = "",
+        data: Optional[Mapping[str, Any]] = None,
+    ) -> None:
+        timestamp = time.strftime("%H:%M:%S", time.localtime())
+        entry = ConsoleLogEntry(
+            timestamp,
+            bool(ok),
+            str(message),
+            str(action or ""),
+            str(session_id or ""),
+            dict(data or {}),
+        )
+        self.log.insert(0, entry)
+        del self.log[200:]
+        if self.operator_log_path is not None:
+            try:
+                self.operator_log_path.parent.mkdir(parents=True, exist_ok=True)
+                payload = dict(entry.__dict__)
+                payload["time_iso"] = time.strftime("%Y-%m-%dT%H:%M:%S%z", time.localtime())
+                with self.operator_log_path.open("a", encoding="utf-8") as fh:
+                    fh.write(json.dumps(payload, ensure_ascii=False, sort_keys=True) + "\n")
+            except Exception:
+                # The browser log must remain usable even if the persistent log
+                # path becomes temporarily unwritable.
+                pass
+
+
+def _finite_float(value: Any, *, name: str) -> float:
+    try:
+        number = float(value)
+    except Exception as exc:
+        raise ValueError(f"{name} is not a finite number") from exc
+    if not math.isfinite(number):
+        raise ValueError(f"{name} is not a finite number")
+    return number
+
+
+def _optional_positive_int(value: Any, *, name: str) -> Optional[int]:
+    if value in (None, ""):
+        return None
+    try:
+        number = int(value)
+    except Exception as exc:
+        raise ValueError(f"{name} must be an integer") from exc
+    if number <= 0:
+        raise ValueError(f"{name} must be positive")
+    return number
+
+
+def resolve_site_summary(
+    *,
+    site_config_path: Optional[os.PathLike[str] | str] = None,
+    az_min: Optional[float] = None,
+    az_max: Optional[float] = None,
+    el_min: Optional[float] = None,
+    el_max: Optional[float] = None,
+) -> site_config.SiteConfigSummary:
+    """Resolve active site settings for console display and validation."""
+
+    return site_config.resolve_site_config(
+        site_config_path=site_config_path,
+        az_min=az_min,
+        az_max=az_max,
+        el_min=el_min,
+        el_max=el_max,
+    )
+
+
+def resolve_mount_limits(
+    *,
+    az_min: Optional[float] = None,
+    az_max: Optional[float] = None,
+    el_min: Optional[float] = None,
+    el_max: Optional[float] = None,
+    site_config_path: Optional[os.PathLike[str] | str] = None,
+) -> Dict[str, float]:
+    """Resolve mount limits from site config, then CLI fallback values."""
+
+    return dict(
+        resolve_site_summary(
+            site_config_path=site_config_path,
+            az_min=az_min,
+            az_max=az_max,
+            el_min=el_min,
+            el_max=el_max,
+        ).mount_limits
+    )
+
+def validate_mount_target(
+    params: Mapping[str, Any], mount_limits: Mapping[str, Any]
+) -> Tuple[float, float]:
+    """Validate mount mechanical Az/El in degrees using site TOML limits."""
+
+    az = _finite_float(params.get("az"), name="Az")
+    el = _finite_float(params.get("el"), name="El")
+    required = ("az_min", "az_max", "el_min", "el_max")
+    if not all(k in mount_limits for k in required):
+        raise ValueError("site TOML mount limits are not available")
+    az_min = _finite_float(mount_limits.get("az_min"), name="Az min")
+    az_max = _finite_float(mount_limits.get("az_max"), name="Az max")
+    el_min = _finite_float(mount_limits.get("el_min"), name="El min")
+    el_max = _finite_float(mount_limits.get("el_max"), name="El max")
+    if az_min >= az_max:
+        raise ValueError("site TOML Az min/max are invalid")
+    if el_min >= el_max:
+        raise ValueError("site TOML El min/max are invalid")
+    if not (az_min <= az <= az_max):
+        raise ValueError(f"Az={az:g} deg is outside site TOML range {az_min:g}..{az_max:g} deg")
+    if not (el_min <= el <= el_max):
+        raise ValueError(f"El={el:g} deg is outside site TOML range {el_min:g}..{el_max:g} deg")
+    return az, el
+
+
+def validate_observation_selection(params: Mapping[str, Any]) -> Tuple[str, str, Optional[int]]:
+    """Static obs-file selection validation; does not touch hardware."""
+
+    mode = str(params.get("mode") or "").strip().lower()
+    allowed_modes = {"otf", "psw", "grid", "radio_pointing"}
+    if mode not in allowed_modes:
+        raise ValueError(f"unsupported observation mode: {mode!r}")
+    path = str(params.get("file") or "").strip()
+    if not path:
+        raise ValueError("obs file path/name is empty")
+    if not path.lower().endswith((".obs", ".toml")):
+        raise ValueError("obs file extension must be .obs or .toml")
+    channel = _optional_positive_int(params.get("channel"), name="channel override")
+    return mode, path, channel
+
+def validate_site_capability(
+    state: OperatorConsoleState,
+    capability: str,
+    *,
+    action_label: Optional[str] = None,
+) -> None:
+    """Reject actions disabled by the active site config before command dispatch."""
+
+    if bool(state.site_capabilities.get(capability, False)):
+        return
+    label = action_label or capability
+    observatory = state.site_summary.observatory or "unknown site"
+    raise ValueError(
+        f"{label} is not enabled for {observatory} by the active site config"
+    )
+
+
+def chopper_dry_run_payload(state: OperatorConsoleState, command: str) -> JsonDict:
+    """Return dry-run details using configured chopper endpoints."""
+
+    chopper = state.chopper_config
+    key = "insert_position" if command == "in" else "remove_position"
+    return {
+        "command": command,
+        "target_position": chopper.get(key),
+        "site_config": state.site_summary.to_dict(),
+    }
+
+
+def _load_operator_actions() -> Any:
+    """Import the shared action module lazily.
+
+    Importing NECST may require ROS/neclib.  Delaying the import keeps
+    ``/health`` and read-only ``/api/status`` usable in reduced environments.
+    When the full package import is unavailable, a file-based fallback with
+    minimal stubs is used so dry-run console tests can still exercise validation
+    and command construction.  Live execution on a real system should use the
+    normal installed NECST package path.
+    """
+
+    try:
+        return importlib.import_module("necst.core.operator_actions")
+    except Exception:
+        import types
+
+        module_name = "necst.core.operator_actions"
+        if module_name in sys.modules:
+            return sys.modules[module_name]
+
+        necst_pkg = sys.modules.setdefault("necst", types.ModuleType("necst"))
+        core_pkg = sys.modules.setdefault("necst.core", types.ModuleType("necst.core"))
+        setattr(necst_pkg, "core", core_pkg)
+
+        config_mod = sys.modules.setdefault("necst.config", types.ModuleType("necst.config"))
+        if not hasattr(config_mod, "chopper_motor_position"):
+            config_mod.chopper_motor_position = {"insert": 4750, "remove": 19700}
+        if not hasattr(config_mod, "simulator"):
+            config_mod.simulator = False
+        setattr(necst_pkg, "config", config_mod)
+
+        commander_mod = sys.modules.setdefault(
+            "necst.core.commander", types.ModuleType("necst.core.commander")
+        )
+        if not hasattr(commander_mod, "Commander"):
+            class _UnavailableCommander:  # pragma: no cover - fallback only
+                def __init__(self, *args: Any, **kwargs: Any) -> None:
+                    raise RuntimeError("Commander is unavailable in reduced environment")
+
+            commander_mod.Commander = _UnavailableCommander
+
+        core_path = Path(__file__).resolve().parents[1] / "core"
+        core_pkg.__path__ = [str(core_path)]  # type: ignore[attr-defined]
+
+        obs_check_name = "necst.core.observation_check"
+        if obs_check_name not in sys.modules:
+            obs_check_path = core_path / "observation_check.py"
+            obs_spec = importlib.util.spec_from_file_location(obs_check_name, obs_check_path)
+            if obs_spec is None or obs_spec.loader is None:
+                raise RuntimeError(f"failed to load observation_check.py from {obs_check_path}")
+            obs_module = importlib.util.module_from_spec(obs_spec)
+            sys.modules[obs_check_name] = obs_module
+            setattr(core_pkg, "observation_check", obs_module)
+            obs_spec.loader.exec_module(obs_module)
+
+        module_path = core_path / "operator_actions.py"
+        spec = importlib.util.spec_from_file_location(module_name, module_path)
+        if spec is None or spec.loader is None:
+            raise RuntimeError(f"failed to load operator_actions.py from {module_path}")
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+        setattr(core_pkg, "operator_actions", module)
+        spec.loader.exec_module(module)
+        return module
+
+
+def _result_to_response(result: Any) -> Tuple[bool, str, JsonDict]:
+    success = bool(getattr(result, "success", False))
+    message = str(getattr(result, "message", "") or "")
+    data = getattr(result, "data", {})
+    if not isinstance(data, dict):
+        data = {"result": data}
+    return success, message, dict(data)
+
+
+def _reject_not_connected(action: str) -> Tuple[bool, str, JsonDict]:
+    return (
+        False,
+        f"{action} is not connected yet in this phase; no command was sent",
+        {"action": action, "connected": False},
+    )
+
+
+def _live_write_guard(state: OperatorConsoleState, action: str) -> Tuple[bool, str, JsonDict]:
+    """Return whether a write-like live action may be dispatched.
+
+    ``--action-mode dry-run`` is the normal no-hardware validation mode.
+    Live mode is intended for normal operation and therefore allows write-like
+    actions by default.  ``--guard-live-actions`` can still be used as an
+    explicit diagnostic/read-only live guard; safety actions are handled
+    separately and remain available.
+    """
+
+    if state.action_mode != "live":
+        return True, "dry-run mode", {"live_write_guard": "not_live"}
+    if action not in LIVE_WRITE_ACTIONS:
+        return True, "read-only/local/safety action", {"live_write_guard": "not_write_action"}
+    if state.live_actions_enabled:
+        return True, "live write actions enabled", {
+            "live_write_guard": "enabled",
+            "live_actions_enabled": True,
+        }
+    return False, LIVE_ACTION_GUARD_MESSAGE, {
+        "action": action,
+        "live_write_guard": "blocked",
+        "live_actions_enabled": False,
+        "guard_option": "--guard-live-actions",
+        "safety_actions_still_available": sorted(SAFETY_ACTIONS),
+    }
+
+
+def _authority_allows(state: OperatorConsoleState, session_id: str) -> Tuple[bool, str]:
+    if not state.authority.held:
+        return True, "temporary NECST privilege will be acquired by the action layer"
+    if state.authority.session_id == session_id:
+        return True, "using this console session's authority"
+    return False, "authority is held by another browser session"
+
+
+def _held_commander_for_session(
+    state: OperatorConsoleState, session_id: str
+) -> Optional[Any]:
+    """Return the persistent Commander only for the owning browser session."""
+
+    if state.action_mode == "dry-run":
+        return None
+    if not state.authority.held or state.authority.session_id != session_id:
+        return None
+    return _any_held_commander(state)
+
+
+def _any_held_commander(state: OperatorConsoleState) -> Optional[Any]:
+    """Return this console's held Commander, regardless of browser session.
+
+    This is intentionally used only by safety actions such as STOP, ABORT,
+    and Stop tracking.  Those actions must remain available even when another
+    browser tab/session has explicitly acquired authority through this console.
+    Non-safety actions continue to require the owning browser session.
+    """
+
+    if state.action_mode == "dry-run":
+        return None
+    handle = state.authority_handle
+    if handle is None:
+        return None
+    try:
+        if bool(getattr(handle, "held", False)):
+            return handle.commander
+    except Exception:
+        return None
+    return None
+
+
+def _safety_authority_bypass_data(
+    state: OperatorConsoleState, session_id: str
+) -> JsonDict:
+    """Describe whether a safety action bypassed the browser authority gate."""
+
+    if not state.authority.held:
+        return {"authority_gate": "free"}
+    if state.authority.session_id == session_id:
+        return {"authority_gate": "owner_session"}
+    return {
+        "authority_gate": "safety_override",
+        "authority_owner_session_id": state.authority.session_id,
+        "safety_override_reason": "STOP/ABORT must remain available across browser sessions",
+    }
+
+
+def _clear_authority_state(state: OperatorConsoleState) -> None:
+    state.authority.held = False
+    state.authority.session_id = None
+    state.authority.necst_held = False
+    state.authority.necst_identity = None
+    state.authority.mode = "none"
+    state.authority.note = ""
+    state.authority_handle = None
+
+
+def _sync_authority_state(
+    state: OperatorConsoleState,
+    *,
+    log_if_cleared: bool = True,
+) -> JsonDict:
+    """Synchronize browser authority state with the held NECST handle.
+
+    The browser-session gate is meaningful only while the underlying
+    OperatorAuthoritySession still reports that it holds privilege.  If the
+    authorizer restarted, the node lost privilege, or a reduced/stub
+    environment reports the handle as not held, clear the browser gate so other
+    sessions are not blocked by stale state.
+    """
+
+    if not state.authority.held and state.authority_handle is None:
+        _clear_authority_state(state)
+        return {"changed": False, "held": False, "reason": "already_free"}
+
+    handle = state.authority_handle
+    if handle is None:
+        note = "authority browser gate had no backing handle; cleared stale state"
+        _clear_authority_state(state)
+        if log_if_cleared:
+            state.add_log(False, note, action="authority_sync")
+        return {"changed": True, "held": False, "reason": "missing_handle"}
+
+    try:
+        handle_held = bool(getattr(handle, "held", False))
+    except Exception as exc:
+        note = f"authority handle status check failed; cleared stale state: {exc}"
+        _clear_authority_state(state)
+        if log_if_cleared:
+            state.add_log(False, note, action="authority_sync")
+        return {"changed": True, "held": False, "reason": "status_check_failed"}
+
+    if not handle_held:
+        note = "authority handle no longer reports NECST privilege; cleared browser gate"
+        _clear_authority_state(state)
+        if log_if_cleared:
+            state.add_log(False, note, action="authority_sync")
+        return {"changed": True, "held": False, "reason": "handle_not_held"}
+
+    try:
+        identity = getattr(handle, "identity", None)
+    except Exception:
+        identity = state.authority.necst_identity
+
+    state.authority.held = True
+    state.authority.necst_held = state.action_mode != "dry-run"
+    state.authority.necst_identity = None if identity is None else str(identity)
+    state.authority.mode = "dry-run" if state.action_mode == "dry-run" else "necst"
+    return {
+        "changed": False,
+        "held": True,
+        "reason": "held",
+        "identity": state.authority.necst_identity,
+    }
+
+
+def _release_console_authority(
+    state: OperatorConsoleState,
+    *,
+    session_id: Optional[str] = None,
+    force: bool = False,
+) -> Tuple[bool, str, JsonDict]:
+    """Release browser/session authority and any persistent NECST privilege."""
+
+    if not state.authority.held and state.authority_handle is None:
+        _clear_authority_state(state)
+        return True, "authority was already free", {"held": False}
+    if (
+        not force
+        and session_id is not None
+        and state.authority.session_id not in {None, session_id}
+    ):
+        return False, "cannot release authority held by another browser session", {}
+
+    release_data: JsonDict = {}
+    release_message = "authority released"
+    handle = state.authority_handle
+    if handle is not None:
+        try:
+            result = handle.release()
+            ok, message, data = _result_to_response(result)
+            release_data = data
+            release_message = message or release_message
+            if not ok:
+                return False, release_message, release_data
+        finally:
+            _clear_authority_state(state)
+    else:
+        _clear_authority_state(state)
+    return True, release_message, release_data
+
+
+def _release_before_subprocess_if_needed(
+    state: OperatorConsoleState, session_id: str
+) -> Optional[str]:
+    """Release persistent NECST privilege before starting a child launcher."""
+
+    if state.action_mode == "dry-run":
+        return None
+    if not state.authority.held or state.authority.session_id != session_id:
+        return None
+    if state.authority_handle is None:
+        return None
+    ok, message, _data = _release_console_authority(state, session_id=session_id)
+    if not ok:
+        raise RuntimeError(message)
+    return "console NECST privilege was released before starting the launcher process"
+
+
+def _console_time_iso(ts: Optional[float]) -> Optional[str]:
+    if ts is None:
+        return None
+    try:
+        return time.strftime("%Y-%m-%dT%H:%M:%S%z", time.localtime(float(ts)))
+    except Exception:
+        return None
+
+
+def _shutdown_snapshot(state: OperatorConsoleState) -> JsonDict:
+    return {
+        "requested": bool(state.shutdown_requested),
+        "status": state.cleanup_status,
+        "terminate_launchers": bool(state.shutdown_terminate_launchers),
+        "launcher_timeout_sec": float(state.shutdown_launcher_timeout_sec),
+        "launcher_kill_timeout_sec": float(state.shutdown_launcher_kill_timeout_sec),
+        "cleanup_started_at": state.cleanup_started_at,
+        "cleanup_started_at_iso": _console_time_iso(state.cleanup_started_at),
+        "cleanup_finished_at": state.cleanup_finished_at,
+        "cleanup_finished_at_iso": _console_time_iso(state.cleanup_finished_at),
+        "summary": dict(state.cleanup_summary),
+    }
+
+def run_self_check(state: OperatorConsoleState, *, include_progress_health: bool = True) -> JsonDict:
+    """Run read-only console self-checks without sending telescope commands."""
+
+    return self_check.run_console_self_check(
+        telescope=state.telescope,
+        action_mode=state.action_mode,
+        live_actions_enabled=state.live_actions_enabled,
+        progress_root=state.progress_root,
+        site_summary=state.site_summary,
+        mount_limits=state.mount_limits,
+        capabilities=state.site_capabilities,
+        chopper_config=state.chopper_config,
+        operator_log_path=state.operator_log_path,
+        launcher_log_dir=state.launcher_log_dir,
+        process_registry=state.process_registry,
+        progress_monitor=state.progress_monitor,
+        events_limit=state.events_limit,
+        include_progress_health=include_progress_health,
+    )
+
+
+def _refresh_processes_and_log(state: OperatorConsoleState) -> None:
+    """Reap child launcher processes and log newly observed final states."""
+
+    finalized = state.process_registry.refresh()
+    for record in finalized:
+        if record.final_logged:
+            continue
+        record.final_logged = True
+        ok = record.returncode in (0, None) and record.status != "lost"
+        if record.status == "exited":
+            message = (
+                f"{record.label} pid={record.pid} exited with return code "
+                f"{record.returncode}"
+            )
+        else:
+            message = f"{record.label} pid={record.pid} is no longer tracked"
+        state.add_log(ok, message, action="process_exit", data=record.to_dict())
+        if record.category == "observation" and not state.process_registry.active(category="observation"):
+            if state.last_active_task == "observation":
+                state.last_active_task = "none"
+            if state.last_manual_state == "observing sequence":
+                state.last_manual_state = "idle"
+        if record.category == "calibration" and not state.process_registry.active(category="calibration"):
+            if state.last_active_task in {"RSky", "SkyDip"}:
+                state.last_active_task = "none"
+            if state.last_manual_state == "calibration":
+                state.last_manual_state = "idle"
+
+
+def _active_launcher_summary(
+    state: OperatorConsoleState, *, category: Optional[str] = None
+) -> Optional[str]:
+    active = state.process_registry.active(category=category)
+    if not active:
+        return None
+    labels = [f"{r.label}(pid={r.pid})" for r in active]
+    if category:
+        return f"active {category} launcher already exists: " + ", ".join(labels)
+    return "active launcher already exists: " + ", ".join(labels)
+
+
+def _launcher_log_paths(
+    state: OperatorConsoleState,
+    action: str,
+) -> Tuple[Optional[Path], Optional[Path]]:
+    if state.launcher_log_dir is None:
+        return None, None
+    return process_manager.make_launcher_log_paths(state.launcher_log_dir, action)
+
+
+def _register_launcher_if_needed(
+    state: OperatorConsoleState,
+    *,
+    action: str,
+    category: str,
+    data: Mapping[str, Any],
+    label: str,
+) -> Optional[process_manager.ManagedProcessRecord]:
+    record = state.process_registry.register_from_action_result(
+        action=action,
+        category=category,
+        result_data=data,
+        label=label,
+    )
+    # Keep Popen handles inside ProcessRegistry only; never expose them in JSON.
+    try:
+        data.pop("_popen", None)  # type: ignore[attr-defined]
+    except Exception:
+        pass
+    if record is not None:
+        state.add_log(
+            True,
+            f"{label} launcher registered: pid={record.pid}",
+            action="process_start",
+            data=record.to_dict(),
+        )
+    return record
+
+
+
+def _request_launcher_stop(
+    state: OperatorConsoleState,
+    *,
+    action: str,
+    params: Mapping[str, Any],
+    category: Optional[str] = None,
+    kill: bool = False,
+) -> Tuple[bool, str, JsonDict]:
+    """Terminate local launcher subprocesses started by this console only."""
+
+    pid_value = params.get("pid")
+    pid: Optional[int] = None
+    if pid_value not in (None, ""):
+        try:
+            pid = int(pid_value)
+        except Exception as exc:
+            raise ValueError(f"invalid launcher pid: {pid_value!r}") from exc
+    if pid is None and params.get("category") not in (None, ""):
+        category = str(params.get("category"))
+    records = state.process_registry.request_stop(
+        pid=pid,
+        category=category,
+        kill=kill,
+        reason=f"operator console action {action}",
+    )
+    if not records:
+        selector = f"pid={pid}" if pid is not None else f"category={category or 'any'}"
+        return False, f"no active launcher matched {selector}; no local process was terminated", {
+            "action": action,
+            "pid": pid,
+            "category": category,
+            "kill": bool(kill),
+            "terminated": [],
+        }
+    signal_name = "SIGKILL" if kill else "SIGTERM"
+    data = {
+        "action": action,
+        "pid": pid,
+        "category": category,
+        "kill": bool(kill),
+        "signal": signal_name,
+        "terminated": [record.to_dict() for record in records],
+        "note": "local launcher termination only; telescope STOP/ABORT is a separate action",
+    }
+    labels = ", ".join(f"{r.label}(pid={r.pid})" for r in records)
+    return True, f"requested {signal_name} for local launcher(s): {labels}", data
+
+
+def dispatch_action(
+    state: OperatorConsoleState,
+    action: str,
+    params: Mapping[str, Any],
+    session_id: str,
+) -> Tuple[bool, str, JsonDict]:
+    """Validate and dispatch one browser action.
+
+    Return ``(ok, message, data)``.  Invalid or not-yet-connected actions return
+    ``ok=False`` before any operator command is sent.
+    """
+
+    action = str(action or "").strip()
+    params = params if isinstance(params, Mapping) else {}
+    _refresh_processes_and_log(state)
+    _sync_authority_state(state)
+
+    if action == "clear_log":
+        state.log.clear()
+        return True, "operation log cleared", {"action": action}
+
+    if action == "launch_progress":
+        if state.progress_monitor is None:
+            return True, f"progress monitor URL: {state.progress_url}", {
+                "action": action,
+                "url": state.progress_url,
+                "progress_url": state.progress_url,
+                "managed": False,
+            }
+        ok, message, data = state.progress_monitor.launch()
+        data = dict(data)
+        data["action"] = action
+        data["url"] = data.get("url") or state.progress_url
+        data["progress_url"] = data.get("progress_url") or data.get("url") or state.progress_url
+        state.progress_url = str(data["progress_url"])
+        return ok, message, data
+
+    if action == "list_processes":
+        records = [r.to_dict() for r in state.process_registry.all_records(refresh=True)]
+        return True, f"{len(records)} launcher process record(s)", {
+            "action": action,
+            "processes": records,
+            "process_counts": state.process_registry.counts(),
+            "launcher_log_choices": log_reader.launcher_log_choices(records),
+            "shutdown": _shutdown_snapshot(state),
+        }
+
+    if action == "read_operator_log":
+        limit = params.get("limit", 100)
+        data = log_reader.read_operator_log(state.operator_log_path, limit=limit)
+        data["action"] = action
+        return bool(data.get("ok")), str(data.get("reason") or "operator log read"), data
+
+    if action == "read_log_file":
+        extra_roots = []
+        if state.progress_monitor is not None and getattr(state.progress_monitor, "log_dir", None) is not None:
+            extra_roots.append(Path(state.progress_monitor.log_dir))
+        data = log_reader.read_text_log(
+            params.get("path"),
+            launcher_log_dir=state.launcher_log_dir,
+            operator_log_path=state.operator_log_path,
+            max_bytes=params.get("max_bytes", 32768),
+            extra_roots=extra_roots,
+        )
+        data["action"] = action
+        return bool(data.get("ok")), str(data.get("reason") or "log file read"), data
+
+    if action == "cleanup_status":
+        records = [r.to_dict() for r in state.process_registry.all_records(refresh=True)]
+        return True, "console cleanup status", {
+            "action": action,
+            "processes": records,
+            "process_counts": state.process_registry.counts(),
+            "progress_monitor": (
+                state.progress_monitor.status(check_external=True).to_dict()
+                if state.progress_monitor is not None
+                else {"url": state.progress_url, "running": False, "owned_by_console": False}
+            ),
+            "shutdown": _shutdown_snapshot(state),
+        }
+
+    live_allowed, live_reason, live_data = _live_write_guard(state, action)
+    if not live_allowed:
+        return False, live_reason, live_data
+
+    if action == "self_check":
+        include_progress_health = params.get("include_progress_health", True)
+        result = run_self_check(
+            state,
+            include_progress_health=bool(include_progress_health),
+        )
+        return bool(result.get("ok")), "operator console self-check completed", {
+            "action": action,
+            "self_check": result,
+        }
+
+    if action in {"terminate_process", "kill_process"}:
+        return _request_launcher_stop(
+            state,
+            action=action,
+            params=params,
+            kill=(action == "kill_process"),
+        )
+
+    if action == "terminate_observation_launcher":
+        return _request_launcher_stop(
+            state,
+            action=action,
+            params=params,
+            category="observation",
+            kill=False,
+        )
+
+    if action == "terminate_calibration_launcher":
+        return _request_launcher_stop(
+            state,
+            action=action,
+            params=params,
+            category="calibration",
+            kill=False,
+        )
+
+    if action == "terminate_all_launchers":
+        return _request_launcher_stop(
+            state,
+            action=action,
+            params=params,
+            category=None,
+            kill=False,
+        )
+
+    if action == "progress_status":
+        progress = (
+            state.progress_monitor.status(check_external=True).to_dict()
+            if state.progress_monitor is not None
+            else {"url": state.progress_url, "running": False, "owned_by_console": False}
+        )
+        return True, "progress monitor status", {
+            "action": action,
+            "progress_monitor": progress,
+            "progress_url": progress.get("url") or state.progress_url,
+        }
+
+    if action == "acquire_authority":
+        if state.authority.held and state.authority.session_id != session_id:
+            return False, "authority is already held by another browser session", {}
+        if state.authority.held and state.authority.session_id == session_id:
+            return True, "authority is already held by this browser session", {
+                "necst_held": state.authority.necst_held,
+                "identity": state.authority.necst_identity,
+                "mode": state.authority.mode,
+            }
+        actions = _load_operator_actions()
+        handle = actions.OperatorAuthoritySession(dry_run=state.action_mode == "dry-run")
+        result = handle.acquire()
+        ok, message, data = _result_to_response(result)
+        if not ok:
+            return ok, message, data
+        state.authority_handle = handle
+        state.authority.held = True
+        state.authority.session_id = session_id
+        state.authority.necst_held = bool(data.get("held")) and state.action_mode != "dry-run"
+        state.authority.necst_identity = data.get("identity")
+        state.authority.mode = "dry-run" if state.action_mode == "dry-run" else "necst"
+        state.authority.note = message
+        return True, message, data
+
+    if action == "release_authority":
+        return _release_console_authority(state, session_id=session_id)
+
+    if action == "check_observation":
+        mode, path, channel = validate_observation_selection(params)
+        result = _load_operator_actions().check_obs_file(
+            mode,
+            path,
+            channel=channel,
+            require_exists=state.action_mode != "dry-run",
+        )
+        ok, message, data = _result_to_response(result)
+        data["action"] = action
+        preview = str(params.get("preview") or "")
+        if preview:
+            data["preview_line_count"] = len(preview.splitlines())
+            data["preview_size_bytes"] = len(preview.encode("utf-8", errors="replace"))
+        return ok, message, data
+
+    if action == "dry_run_observation":
+        mode, path, channel = validate_observation_selection(params)
+        result = _load_operator_actions().dry_run_observation(
+            mode,
+            path,
+            channel=channel,
+            require_exists=state.action_mode != "dry-run",
+        )
+        ok, message, data = _result_to_response(result)
+        data["action"] = action
+        return ok, message, data
+
+    if action in {"mount_move", "start_tracking", "start_observation", "run_rsky", "run_skydip", "chopper_in", "chopper_out", "chopper_alarm_reset", "chopper_home", "chopper_recover"}:
+        allowed, reason = _authority_allows(state, session_id)
+        if not allowed:
+            return False, reason, {"action": action}
+
+    if action == "mount_move_dry_run":
+        validate_site_capability(state, "mount_move", action_label="mount move")
+        az, el = validate_mount_target(params, state.mount_limits)
+        return True, f"dry-run mount move OK: Az={az:.6f} deg, El={el:.6f} deg; no command was sent", {
+            "action": action,
+            "az_deg": az,
+            "el_deg": el,
+            "unit": "deg",
+            "direct_mode": True,
+            "az_target_mode": "mount",
+        }
+
+    if action == "mount_move":
+        validate_site_capability(state, "mount_move", action_label="mount move")
+        az, el = validate_mount_target(params, state.mount_limits)
+        if state.action_mode == "dry-run":
+            state.last_command_az = az
+            state.last_command_el = el
+            return True, f"dry-run mount move: Az={az:.6f} deg, El={el:.6f} deg; no command was sent", {
+                "action": action,
+                "az_deg": az,
+                "el_deg": el,
+                "unit": "deg",
+                "direct_mode": True,
+                "az_target_mode": "mount",
+                "dry_run": True,
+            }
+        result = _load_operator_actions().mount_move(
+            az,
+            el,
+            wait=False,
+            dry_run=False,
+            commander=_held_commander_for_session(state, session_id),
+        )
+        ok, message, data = _result_to_response(result)
+        if ok:
+            state.last_command_az = az
+            state.last_command_el = el
+            state.last_manual_state = "moving"
+            state.last_active_task = "manual mount move"
+        return ok, message, data
+
+    if action == "stop":
+        safety_data = _safety_authority_bypass_data(state, session_id)
+        if state.action_mode == "dry-run":
+            data = {"action": action, "dry_run": True}
+            data.update(safety_data)
+            return True, "dry-run STOP: antenna stop command was not sent", data
+        result = _load_operator_actions().antenna_stop(
+            commander=_any_held_commander(state),
+        )
+        ok, message, data = _result_to_response(result)
+        data.update(safety_data)
+        if ok:
+            state.last_manual_state = "stopped"
+            state.last_active_task = "none"
+            state.last_command_az = None
+            state.last_command_el = None
+        return ok, message, data
+
+    if action == "start_tracking":
+        validate_site_capability(state, "target_tracking", action_label="target tracking")
+        actions = _load_operator_actions()
+        dry_run = state.action_mode == "dry-run"
+        result = actions.start_target_tracking(
+            params.get("kind"),
+            name=params.get("name"),
+            coord1=params.get("coord1"),
+            coord2=params.get("coord2"),
+            offset_frame=params.get("offset_frame", "target_frame"),
+            offset_x_arcsec=params.get("offset_x_arcsec", 0),
+            offset_y_arcsec=params.get("offset_y_arcsec", 0),
+            cos_correction=params.get("cos_correction", True),
+            wait=False,
+            dry_run=dry_run,
+            commander=_held_commander_for_session(state, session_id),
+        )
+        ok, message, data = _result_to_response(result)
+        if ok and not dry_run:
+            state.last_command_az = None
+            state.last_command_el = None
+            state.last_manual_state = "tracking"
+            state.last_active_task = "target tracking"
+        return ok, message, data
+
+    if action == "stop_tracking":
+        safety_data = _safety_authority_bypass_data(state, session_id)
+        if state.action_mode == "dry-run":
+            data = {"action": action, "dry_run": True}
+            data.update(safety_data)
+            return True, "dry-run Stop tracking: antenna stop command was not sent", data
+        result = _load_operator_actions().stop_tracking(
+            commander=_any_held_commander(state),
+        )
+        ok, message, data = _result_to_response(result)
+        data.update(safety_data)
+        if ok:
+            state.last_manual_state = "stopped"
+            state.last_active_task = "none"
+            state.last_command_az = None
+            state.last_command_el = None
+        return ok, message, data
+
+    if action == "abort_observation":
+        safety_data = _safety_authority_bypass_data(state, session_id)
+        if state.action_mode == "dry-run":
+            data = {"action": action, "dry_run": True}
+            data.update(safety_data)
+            return True, "dry-run ABORT: observation abort command was not sent", data
+        result = _load_operator_actions().abort_observation(
+            requester="necst console",
+            commander=_any_held_commander(state),
+        )
+        ok, message, data = _result_to_response(result)
+        data.update(safety_data)
+        return ok, message, data
+
+    if action == "start_observation":
+        validate_site_capability(state, "observation_start", action_label="observation start")
+        mode, path, channel = validate_observation_selection(params)
+        active_reason = _active_launcher_summary(state, category="observation")
+        if active_reason is not None:
+            return False, active_reason, {"action": action, "category": "observation"}
+        dry_run = state.action_mode == "dry-run"
+        actions = _load_operator_actions()
+        if not dry_run:
+            # Validate the launcher command completely before releasing a held
+            # console authority.  Otherwise a typo in the obs-file path could
+            # drop the operator's authority and then fail before starting
+            # anything, which is safe but confusing during operations.
+            preflight = actions.start_observation(
+                mode,
+                path,
+                channel=channel,
+                background=True,
+                dry_run=True,
+                check_exists=True,
+            )
+            pre_ok, pre_message, pre_data = _result_to_response(preflight)
+            if not pre_ok:
+                pre_data["preflight_before_authority_release"] = True
+                return False, pre_message, pre_data
+        release_notice = _release_before_subprocess_if_needed(state, session_id)
+        stdout_path, stderr_path = _launcher_log_paths(state, "start_observation")
+        result = actions.start_observation(
+            mode,
+            path,
+            channel=channel,
+            background=True,
+            dry_run=dry_run,
+            check_exists=not dry_run,
+            stdout_path=stdout_path,
+            stderr_path=stderr_path,
+        )
+        ok, message, data = _result_to_response(result)
+        if ok and not dry_run:
+            state.last_command_az = None
+            state.last_command_el = None
+            state.last_manual_state = "observing sequence"
+            state.last_active_task = "observation"
+            _register_launcher_if_needed(
+                state,
+                action=action,
+                category="observation",
+                data=data,
+                label=f"observation:{mode}",
+            )
+            if release_notice:
+                message = f"{release_notice}; {message}"
+        return ok, message, data
+
+    if action == "run_rsky":
+        validate_site_capability(state, "rsky", action_label="RSky")
+        active_reason = _active_launcher_summary(state, category="calibration")
+        if active_reason is not None:
+            return False, active_reason, {"action": action, "category": "calibration"}
+        dry_run = state.action_mode == "dry-run"
+        actions = _load_operator_actions()
+        if not dry_run:
+            preflight = actions.run_rsky(
+                n=params.get("n", 1),
+                integ=params.get("integ", 2),
+                channel=params.get("ch"),
+                background=True,
+                dry_run=True,
+            )
+            pre_ok, pre_message, pre_data = _result_to_response(preflight)
+            if not pre_ok:
+                pre_data["preflight_before_authority_release"] = True
+                return False, pre_message, pre_data
+        release_notice = _release_before_subprocess_if_needed(state, session_id)
+        stdout_path, stderr_path = _launcher_log_paths(state, "run_rsky")
+        result = actions.run_rsky(
+            n=params.get("n", 1),
+            integ=params.get("integ", 2),
+            channel=params.get("ch"),
+            background=True,
+            dry_run=dry_run,
+            stdout_path=stdout_path,
+            stderr_path=stderr_path,
+        )
+        ok, message, data = _result_to_response(result)
+        if ok and not dry_run:
+            state.last_command_az = None
+            state.last_command_el = None
+            state.last_manual_state = "calibration"
+            state.last_active_task = "RSky"
+            _register_launcher_if_needed(
+                state,
+                action=action,
+                category="calibration",
+                data=data,
+                label="calibration:RSky",
+            )
+            if release_notice:
+                message = f"{release_notice}; {message}"
+        return ok, message, data
+
+    if action == "run_skydip":
+        validate_site_capability(state, "skydip", action_label="SkyDip")
+        active_reason = _active_launcher_summary(state, category="calibration")
+        if active_reason is not None:
+            return False, active_reason, {"action": action, "category": "calibration"}
+        dry_run = state.action_mode == "dry-run"
+        actions = _load_operator_actions()
+        if not dry_run:
+            preflight = actions.run_skydip(
+                integ=params.get("integ", 2),
+                channel=params.get("ch"),
+                tp_range=params.get("tp_range"),
+                background=True,
+                dry_run=True,
+            )
+            pre_ok, pre_message, pre_data = _result_to_response(preflight)
+            if not pre_ok:
+                pre_data["preflight_before_authority_release"] = True
+                return False, pre_message, pre_data
+        release_notice = _release_before_subprocess_if_needed(state, session_id)
+        stdout_path, stderr_path = _launcher_log_paths(state, "run_skydip")
+        result = actions.run_skydip(
+            integ=params.get("integ", 2),
+            channel=params.get("ch"),
+            tp_range=params.get("tp_range"),
+            background=True,
+            dry_run=dry_run,
+            stdout_path=stdout_path,
+            stderr_path=stderr_path,
+        )
+        ok, message, data = _result_to_response(result)
+        if ok and not dry_run:
+            state.last_command_az = None
+            state.last_command_el = None
+            state.last_manual_state = "calibration"
+            state.last_active_task = "SkyDip"
+            _register_launcher_if_needed(
+                state,
+                action=action,
+                category="calibration",
+                data=data,
+                label="calibration:SkyDip",
+            )
+            if release_notice:
+                message = f"{release_notice}; {message}"
+        return ok, message, data
+
+    if action == "chopper_status":
+        validate_site_capability(state, "chopper_status", action_label="chopper status")
+        if state.action_mode == "dry-run":
+            return True, "dry-run chopper status: no telemetry query was sent", {
+                "action": action,
+                "dry_run": True,
+                "site_config": state.site_summary.to_dict(),
+            }
+        result = _load_operator_actions().chopper_status(
+            commander=_held_commander_for_session(state, session_id),
+        )
+        ok, message, data = _result_to_response(result)
+        if ok:
+            state.last_chopper_state = str(data.get("state") or state.last_chopper_state)
+        return ok, message, data
+
+    if action in {"chopper_in", "chopper_out"}:
+        validate_site_capability(state, "chopper_move", action_label="chopper move")
+        command = "in" if action == "chopper_in" else "out"
+        if state.action_mode == "dry-run":
+            data = chopper_dry_run_payload(state, command)
+            data.update({"action": action, "dry_run": True})
+            return True, f"dry-run chopper {command.upper()}: command was not sent", data
+        result = _load_operator_actions().chopper_move(
+            command,
+            wait=False,
+            commander=_held_commander_for_session(state, session_id),
+        )
+        ok, message, data = _result_to_response(result)
+        if ok:
+            state.last_chopper_state = "IN" if command == "in" else "OUT"
+            if data.get("target_position") is not None:
+                state.last_chopper_position = float(data["target_position"])
+        return ok, message, data
+
+    if action in {"chopper_alarm_reset", "chopper_home", "chopper_recover"}:
+        validate_site_capability(
+            state, "chopper_maintenance", action_label="chopper maintenance"
+        )
+        maintenance = {
+            "chopper_alarm_reset": "alarm-reset",
+            "chopper_home": "home",
+            "chopper_recover": "recover",
+        }[action]
+        if state.action_mode == "dry-run":
+            return True, f"dry-run chopper {maintenance}: command was not sent", {
+                "action": action,
+                "dry_run": True,
+                "command": maintenance,
+            }
+        result = _load_operator_actions().chopper_maintenance(
+            maintenance,
+            commander=_held_commander_for_session(state, session_id),
+        )
+        return _result_to_response(result)
+
+    return False, f"unknown action: {action!r}", {"action": action}
+
+
+def _operator_status_to_v7_status(
+    state: OperatorConsoleState, status_state: Mapping[str, Any]
+) -> JsonDict:
+    """Adapt canonical operator_status to the v7 console-demo JSON shape."""
+
+    op = status_state.get("operator_status") if isinstance(status_state, Mapping) else {}
+    if not isinstance(op, Mapping):
+        op = {}
+    system = op.get("system") if isinstance(op.get("system"), Mapping) else {}
+    motion = op.get("motion") if isinstance(op.get("motion"), Mapping) else {}
+    antenna = op.get("antenna") if isinstance(op.get("antenna"), Mapping) else {}
+    chopper = op.get("chopper") if isinstance(op.get("chopper"), Mapping) else {}
+    progress = op.get("progress") if isinstance(op.get("progress"), Mapping) else {}
+    warnings = op.get("warnings") if isinstance(op.get("warnings"), list) else []
+
+    sys_state = str(system.get("state") or "unknown").lower()
+    if sys_state in {"", "unknown"}:
+        sys_state = "idle"
+
+    process_records = state.process_registry.all_records(refresh=False)
+    active_process_categories = {
+        str(record.category or "")
+        for record in process_records
+        if bool(record.is_active())
+    }
+    if sys_state == "idle":
+        if "observation" in active_process_categories:
+            sys_state = "observing"
+        elif "calibration" in active_process_categories:
+            sys_state = "calibrating"
+
+    raw_active_task = str(motion.get("active_task") or "").strip()
+    if raw_active_task.lower() in {"", "idle", "none", "unknown"}:
+        active_task = str(state.last_active_task or "none")
+    else:
+        active_task = raw_active_task
+    if active_task.lower() in {"", "idle", "unknown"}:
+        active_task = "none"
+
+    raw_manual_state = str(motion.get("stage") or "").strip()
+    if raw_manual_state.lower() in {"", "idle", "none", "unknown"}:
+        manual_state = str(state.last_manual_state or "idle")
+    else:
+        manual_state = raw_manual_state
+    if manual_state.lower() in {"", "none", "unknown"}:
+        manual_state = "idle"
+
+    current_az = antenna.get("current_az_deg")
+    current_el = antenna.get("current_el_deg")
+    try:
+        az = float(current_az) if current_az is not None else 0.0
+        el = float(current_el) if current_el is not None else 0.0
+    except Exception:
+        az, el = 0.0, 0.0
+        warnings = list(warnings) + ["antenna current Az/El is unavailable"]
+
+    cmd_az = antenna.get("command_az_deg")
+    cmd_el = antenna.get("command_el_deg")
+    if cmd_az is None:
+        cmd_az = state.last_command_az
+    if cmd_el is None:
+        cmd_el = state.last_command_el
+
+    chopper_state = str(chopper.get("state") or state.last_chopper_state or "unknown")
+    chopper_position = chopper.get("position")
+    if chopper_position is None:
+        chopper_position = state.last_chopper_position
+    chopper_age = chopper.get("age_sec")
+    if chopper_age is None:
+        age_text = "unknown"
+    else:
+        try:
+            age_text = f"{float(chopper_age):.1f}s"
+        except Exception:
+            age_text = "unknown"
+
+    percent = progress.get("percent")
+    observation_progress_running = (
+        sys_state not in {"idle", "finished", "aborted", "error", "unknown"}
+        or percent is not None
+    )
+    monitor_status = (
+        state.progress_monitor.status(check_external=False).to_dict()
+        if state.progress_monitor is not None
+        else {"url": state.progress_url, "running": False, "owned_by_console": False}
+    )
+    progress_running = bool(monitor_status.get("running")) or bool(observation_progress_running)
+
+    return {
+        "telescope": state.telescope,
+        "state": sys_state,
+        "manual_state": manual_state,
+        "active_task": active_task,
+        "az": az,
+        "el": el,
+        "command_az": cmd_az,
+        "command_el": cmd_el,
+        "chopper": {
+            "state": chopper_state,
+            "position": chopper_position if chopper_position is not None else "unknown",
+            "age": age_text,
+        },
+        "progress": {
+            "running": bool(progress_running),
+            "url": str(monitor_status.get("url") or state.progress_url),
+            "percent": percent,
+            "label": progress.get("label"),
+            "observation_running": bool(observation_progress_running),
+            "monitor": monitor_status,
+            "owned_by_console": bool(monitor_status.get("owned_by_console")),
+            "monitor_status": monitor_status.get("status"),
+        },
+        "authority": {
+            "held": state.authority.held,
+            "session_id": state.authority.session_id,
+            "necst_held": state.authority.necst_held,
+            "necst_identity": state.authority.necst_identity,
+            "mode": state.authority.mode,
+            "note": state.authority.note,
+            "sync_reason": (
+                _sync_authority_state(state, log_if_cleared=False).get("reason")
+                if state.authority.held or state.authority_handle is not None
+                else "already_free"
+            ),
+            "safety_actions_bypass_browser_gate": True,
+            "safety_actions": ["stop", "stop_tracking", "abort_observation", "terminate_*_launcher"],
+        },
+        "mount_limits": dict(state.mount_limits),
+        "site": state.site_summary.to_dict(),
+        "capabilities": dict(state.site_capabilities),
+        "warning_count": len(warnings) + len(state.site_summary.warnings),
+        "warnings": list(warnings) + list(state.site_summary.warnings),
+        "log": [entry.__dict__ for entry in state.log],
+        "processes": [r.to_dict() for r in state.process_registry.all_records(refresh=False)],
+        "process_counts": state.process_registry.counts(),
+        "launcher_log_choices": log_reader.launcher_log_choices([
+            r.to_dict() for r in state.process_registry.all_records(refresh=False)
+        ]),
+        "shutdown": _shutdown_snapshot(state),
+        "self_check_endpoint": "/api/self-check",
+        "operator_log_path": str(state.operator_log_path) if state.operator_log_path is not None else None,
+        "launcher_log_dir": str(state.launcher_log_dir) if state.launcher_log_dir is not None else None,
+        "action_mode": state.action_mode,
+        "live_actions": {
+            "enabled": bool(state.live_actions_enabled),
+            "guarded": state.action_mode == "live" and not state.live_actions_enabled,
+            "write_actions": sorted(LIVE_WRITE_ACTIONS),
+            "safety_actions": sorted(SAFETY_ACTIONS),
+            "message": (
+                "live write actions enabled by default in live mode"
+                if state.action_mode == "live" and state.live_actions_enabled
+                else (
+                    "live write actions blocked by --guard-live-actions"
+                    if state.action_mode == "live"
+                    else "dry-run mode: no live command is sent"
+                )
+            ),
+        },
+        "status_refresh_ms": int(state.status_refresh_ms),
+        "operator_status": op,
+    }
+
+
+def build_console_status(state: OperatorConsoleState) -> JsonDict:
+    with state.lock:
+        _refresh_processes_and_log(state)
+        _sync_authority_state(state)
+        status_state = status_model.build_progress_status_state(
+            state.progress_root,
+            events_limit=state.events_limit,
+        )
+        return _operator_status_to_v7_status(state, status_state)
+
+
+def load_demo_html(status_refresh_ms: int = 1000) -> str:
+    """Load the v7 demo HTML so the real console keeps the approved layout."""
+
+    demo_path = Path(__file__).resolve().parents[2] / "bin" / "console-demo.py"
+    text = demo_path.read_text(encoding="utf-8")
+    marker = 'HTML = r"""'
+    start = text.find(marker)
+    if start < 0:
+        raise RuntimeError("failed to find HTML block in bin/console-demo.py")
+    start += len(marker)
+    end = text.find('"""', start)
+    if end < 0:
+        raise RuntimeError("failed to find end of HTML block in bin/console-demo.py")
+    html = text[start:end]
+    html = html.replace(
+        "NECST Operator Console Demo",
+        "NECST Operator Console",
+    ).replace(
+        "standalone layout preview / no ROS / no telescope command",
+        "real console entry point / actions use necst.core.operator_actions",
+    )
+    config_script = (
+        "<script>window.NECST_CONSOLE_CONFIG = "
+        + json.dumps({"statusRefreshMs": int(status_refresh_ms)})
+        + ";</script>\n"
+    )
+    return html.replace("</head>", config_script + "</head>")
+
+
+class OperatorConsoleHTTPServer(ThreadingHTTPServer):
+    daemon_threads = True
+    allow_reuse_address = True
+
+    def __init__(
+        self,
+        server_address: Tuple[str, int],
+        handler_class: type[BaseHTTPRequestHandler],
+        *,
+        state: OperatorConsoleState,
+        html: Optional[str] = None,
+    ) -> None:
+        super().__init__(server_address, handler_class)
+        self.state = state
+        self.html = html if html is not None else load_demo_html(state.status_refresh_ms)
+
+
+class OperatorConsoleHandler(BaseHTTPRequestHandler):
+    server: OperatorConsoleHTTPServer
+
+    def log_message(self, fmt: str, *args: Any) -> None:
+        if not self.server.state.quiet:
+            super().log_message(fmt, *args)
+
+    def _send_json(self, payload: Mapping[str, Any], status: int = 200) -> None:
+        body = json.dumps(payload, ensure_ascii=False, sort_keys=True).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _send_text(self, text: str, content_type: str = "text/html; charset=utf-8") -> None:
+        body = text.encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self) -> None:  # noqa: N802 - stdlib method name
+        if self.path in {"/", "/index.html"}:
+            self._send_text(self.server.html)
+            return
+        if self.path == "/health":
+            self._send_json({
+                "ok": True,
+                "action_mode": self.server.state.action_mode,
+                "live_actions_enabled": bool(self.server.state.live_actions_enabled),
+                "status_refresh_ms": int(self.server.state.status_refresh_ms),
+            })
+            return
+        if self.path == "/api/status":
+            self._send_json(build_console_status(self.server.state))
+            return
+        if self.path == "/api/operator-status":
+            state = self.server.state
+            status_state = status_model.build_progress_status_state(
+                state.progress_root,
+                events_limit=state.events_limit,
+            )
+            self._send_json(status_state.get("operator_status", {}))
+            return
+        parsed = urllib.parse.urlparse(self.path)
+        query = urllib.parse.parse_qs(parsed.query)
+        if parsed.path == "/api/processes":
+            state = self.server.state
+            with state.lock:
+                _refresh_processes_and_log(state)
+                process_records = [r.to_dict() for r in state.process_registry.all_records(refresh=False)]
+                self._send_json({
+                    "processes": process_records,
+                    "process_counts": state.process_registry.counts(),
+                    "launcher_log_choices": log_reader.launcher_log_choices(process_records),
+                    "progress_monitor": (
+                        state.progress_monitor.status(check_external=True).to_dict()
+                        if state.progress_monitor is not None
+                        else {"url": state.progress_url, "running": False, "owned_by_console": False}
+                    ),
+                    "shutdown": _shutdown_snapshot(state),
+                    "operator_log_path": str(state.operator_log_path) if state.operator_log_path is not None else None,
+                    "launcher_log_dir": str(state.launcher_log_dir) if state.launcher_log_dir is not None else None,
+                })
+            return
+        if parsed.path == "/api/operator-log":
+            state = self.server.state
+            with state.lock:
+                _refresh_processes_and_log(state)
+                limit = (query.get("limit") or [100])[0]
+                self._send_json(log_reader.read_operator_log(state.operator_log_path, limit=limit))
+            return
+        if parsed.path == "/api/log-file":
+            state = self.server.state
+            with state.lock:
+                path = (query.get("path") or [""])[0]
+                max_bytes = (query.get("max_bytes") or [32768])[0]
+                extra_roots = []
+                if state.progress_monitor is not None and getattr(state.progress_monitor, "log_dir", None) is not None:
+                    extra_roots.append(Path(state.progress_monitor.log_dir))
+                self._send_json(log_reader.read_text_log(
+                    path,
+                    launcher_log_dir=state.launcher_log_dir,
+                    operator_log_path=state.operator_log_path,
+                    max_bytes=max_bytes,
+                    extra_roots=extra_roots,
+                ))
+            return
+        if parsed.path == "/api/self-check":
+            state = self.server.state
+            with state.lock:
+                _refresh_processes_and_log(state)
+                self._send_json(run_self_check(state, include_progress_health=True))
+            return
+        self.send_error(HTTPStatus.NOT_FOUND, "not found")
+
+    def do_POST(self) -> None:  # noqa: N802 - stdlib method name
+        if self.path != "/api/action":
+            self.send_error(HTTPStatus.NOT_FOUND, "not found")
+            return
+        try:
+            length = int(self.headers.get("Content-Length", "0"))
+            payload = json.loads(self.rfile.read(length).decode("utf-8") or "{}")
+        except Exception as exc:
+            self._send_json({"ok": False, "reason": f"invalid JSON: {exc}"}, status=400)
+            return
+        action = str(payload.get("action") or "")
+        params = payload.get("params") if isinstance(payload.get("params"), dict) else {}
+        session_id = str(payload.get("session_id") or uuid.uuid4())
+        with self.server.state.lock:
+            try:
+                ok, reason, data = dispatch_action(
+                    self.server.state,
+                    action,
+                    params,
+                    session_id,
+                )
+            except Exception as exc:
+                ok, reason, data = False, str(exc), {"exception_type": type(exc).__name__}
+            self.server.state.add_log(ok, reason, action=action, session_id=session_id, data=data)
+        response: JsonDict = {"ok": ok, "reason": reason, "data": data}
+        if isinstance(data, Mapping):
+            if data.get("progress_url") is not None:
+                response["progress_url"] = data.get("progress_url")
+            elif data.get("url") is not None and action == "launch_progress":
+                response["progress_url"] = data.get("url")
+        self._send_json(response)
+
+
+
+def _run_shutdown_cleanup(state: OperatorConsoleState) -> JsonDict:
+    """Release console-owned resources during process shutdown.
+
+    This is local cleanup only.  It does not send telescope STOP/ABORT.  Active
+    launcher children started by this console are terminated so they are not
+    orphaned when the console process exits.
+    """
+
+    state.shutdown_requested = True
+    state.cleanup_started_at = time.time()
+    state.cleanup_finished_at = None
+    state.cleanup_status = "running"
+    summary: JsonDict = {
+        "authority": {},
+        "progress_monitor": {},
+        "launchers": {},
+    }
+
+    ok, message, data = _release_console_authority(state, force=True)
+    summary["authority"] = {"ok": ok, "message": message, "data": data}
+    state.add_log(ok, f"console shutdown: {message}", action="authority_release", data=data)
+
+    if state.shutdown_terminate_launchers:
+        launcher_summary = state.process_registry.graceful_shutdown(
+            timeout_sec=float(state.shutdown_launcher_timeout_sec),
+            kill_timeout_sec=float(state.shutdown_launcher_kill_timeout_sec),
+            reason="operator console shutdown",
+        )
+        summary["launchers"] = launcher_summary
+        state.add_log(
+            bool(launcher_summary.get("ok")),
+            "console shutdown: " + str(launcher_summary.get("message")),
+            action="launcher_shutdown_cleanup",
+            data=launcher_summary,
+        )
+    else:
+        remaining = [r.to_dict() for r in state.process_registry.active()]
+        launcher_summary = {
+            "ok": not bool(remaining),
+            "message": "launcher shutdown cleanup disabled",
+            "remaining": remaining,
+            "counts": state.process_registry.counts(),
+        }
+        summary["launchers"] = launcher_summary
+        state.add_log(
+            bool(launcher_summary.get("ok")),
+            "console shutdown: launcher cleanup disabled",
+            action="launcher_shutdown_cleanup",
+            data=launcher_summary,
+        )
+
+    if state.progress_monitor is not None:
+        p_ok, p_message, p_data = state.progress_monitor.stop_if_owned()
+        summary["progress_monitor"] = {
+            "ok": p_ok,
+            "message": p_message,
+            "data": p_data,
+        }
+        state.add_log(
+            p_ok,
+            f"console shutdown: {p_message}",
+            action="progress_monitor_stop",
+            data=p_data,
+        )
+    else:
+        summary["progress_monitor"] = {
+            "ok": True,
+            "message": "no progress monitor manager",
+            "data": {},
+        }
+
+    state.cleanup_finished_at = time.time()
+    state.cleanup_status = "finished"
+    state.cleanup_summary = summary
+    return summary
+
+def run_server(
+    *,
+    host: str,
+    port: int,
+    telescope: str,
+    progress_root: Path,
+    progress_url: str,
+    progress_host: str = "127.0.0.1",
+    progress_port: int = 8091,
+    progress_refresh_ms: int = 500,
+    progress_no_ros: bool = False,
+    progress_log_dir: Optional[os.PathLike[str] | str] = None,
+    action_mode: str = "live",
+    live_actions_enabled: bool = True,
+    status_refresh_ms: int = 1000,
+    quiet: bool = False,
+    open_browser: bool = False,
+    events_limit: int = 12,
+    site_config_path: Optional[os.PathLike[str] | str] = None,
+    operator_log_dir: Optional[os.PathLike[str] | str] = None,
+    launcher_log_dir: Optional[os.PathLike[str] | str] = None,
+    shutdown_terminate_launchers: bool = True,
+    shutdown_launcher_timeout_sec: float = 3.0,
+    shutdown_launcher_kill_timeout_sec: float = 1.0,
+    az_min: Optional[float] = None,
+    az_max: Optional[float] = None,
+    el_min: Optional[float] = None,
+    el_max: Optional[float] = None,
+    stop_event: Optional[threading.Event] = None,
+) -> int:
+    if action_mode not in SUPPORTED_ACTION_MODES:
+        raise ValueError(f"action_mode must be one of {sorted(SUPPORTED_ACTION_MODES)}")
+    site_summary = resolve_site_summary(
+        site_config_path=site_config_path,
+        az_min=az_min,
+        az_max=az_max,
+        el_min=el_min,
+        el_max=el_max,
+    )
+    limits = dict(site_summary.mount_limits)
+    resolved_operator_log_dir = (
+        Path(operator_log_dir)
+        if operator_log_dir not in (None, "")
+        else Path(progress_root) / "operator_console"
+    )
+    resolved_launcher_log_dir = (
+        Path(launcher_log_dir)
+        if launcher_log_dir not in (None, "")
+        else resolved_operator_log_dir / "launcher_logs"
+    )
+    resolved_progress_log_dir = (
+        Path(progress_log_dir)
+        if progress_log_dir not in (None, "")
+        else resolved_operator_log_dir / "progress_logs"
+    )
+    resolved_operator_log_dir.mkdir(parents=True, exist_ok=True)
+    resolved_launcher_log_dir.mkdir(parents=True, exist_ok=True)
+    resolved_progress_log_dir.mkdir(parents=True, exist_ok=True)
+    operator_log_path = resolved_operator_log_dir / "operator_console.jsonl"
+    progress_script = Path(__file__).resolve().parents[2] / "bin" / "progress.py"
+    progress_monitor = progress_manager.ProgressMonitorManager(
+        progress_script=progress_script,
+        progress_root=Path(progress_root),
+        host=str(progress_host),
+        port=int(progress_port),
+        url=str(progress_url),
+        log_dir=resolved_progress_log_dir,
+        refresh_ms=int(progress_refresh_ms),
+        no_ros=bool(progress_no_ros),
+        quiet=True,
+    )
+    state = OperatorConsoleState(
+        telescope=telescope,
+        progress_root=Path(progress_root),
+        progress_url=progress_url,
+        progress_monitor=progress_monitor,
+        action_mode=action_mode,
+        live_actions_enabled=bool(live_actions_enabled),
+        status_refresh_ms=max(200, int(status_refresh_ms)),
+        quiet=quiet,
+        events_limit=int(events_limit),
+        site_summary=site_summary,
+        mount_limits=limits,
+        site_capabilities=dict(site_summary.capabilities),
+        chopper_config=dict(site_summary.chopper),
+        operator_log_path=operator_log_path,
+        launcher_log_dir=resolved_launcher_log_dir,
+        shutdown_terminate_launchers=bool(shutdown_terminate_launchers),
+        shutdown_launcher_timeout_sec=float(shutdown_launcher_timeout_sec),
+        shutdown_launcher_kill_timeout_sec=float(shutdown_launcher_kill_timeout_sec),
+    )
+    state.add_log(True, f"console started in action_mode={action_mode}")
+    if action_mode == "live" and not live_actions_enabled:
+        state.add_log(False, LIVE_ACTION_GUARD_MESSAGE, action="live_write_guard")
+    if action_mode == "live" and live_actions_enabled:
+        state.add_log(True, "live write actions enabled by default in live mode", action="live_write_guard")
+    state.add_log(
+        True,
+        "site config: "
+        f"source={site_summary.source}"
+        + (f", path={site_summary.source_path}" if site_summary.source_path else "")
+        + (f", observatory={site_summary.observatory}" if site_summary.observatory else ""),
+    )
+    for warning in site_summary.warnings:
+        state.add_log(False, warning)
+    if not limits:
+        state.add_log(False, "site TOML mount limits are unavailable; mount move will be rejected")
+
+    server = OperatorConsoleHTTPServer(
+        (str(host), int(port)),
+        OperatorConsoleHandler,
+        state=state,
+    )
+    url = f"http://{host}:{port}/"
+    print("NECST operator console")
+    print(f"  URL: {url}")
+    print(f"  progress root: {Path(progress_root)}")
+    print(f"  progress URL: {progress_url}")
+    print(f"  managed progress bind: {progress_host}:{int(progress_port)}")
+    print(f"  action mode: {action_mode}")
+    print(f"  live write actions enabled: {bool(live_actions_enabled)}")
+    if action_mode == "live" and not live_actions_enabled:
+        print("  live write guard: ON by --guard-live-actions (write actions blocked; STOP/ABORT remain available)")
+    print(f"  status refresh: {max(200, int(status_refresh_ms))} ms")
+    print(f"  operator log: {operator_log_path}")
+    print(f"  launcher logs: {resolved_launcher_log_dir}")
+    print(f"  progress logs: {resolved_progress_log_dir}")
+    print(
+        "  shutdown cleanup: "
+        f"terminate_launchers={bool(shutdown_terminate_launchers)}, "
+        f"timeout={float(shutdown_launcher_timeout_sec)}s, "
+        f"kill_timeout={float(shutdown_launcher_kill_timeout_sec)}s"
+    )
+    print(f"  site config source: {site_summary.source}" + (f" ({site_summary.source_path})" if site_summary.source_path else ""))
+    print(f"  observatory: {site_summary.observatory or 'unknown'}")
+    if limits:
+        print(
+            "  mount limits: "
+            f"Az {limits.get('az_min')}..{limits.get('az_max')} deg, "
+            f"El {limits.get('el_min')}..{limits.get('el_max')} deg"
+        )
+    else:
+        print("  mount limits: unavailable")
+    print(
+        "  chopper: "
+        f"available={site_summary.chopper.get('available')}, "
+        f"IN={site_summary.chopper.get('insert_position')}, "
+        f"OUT={site_summary.chopper.get('remove_position')}, "
+        f"maintenance_supported={site_summary.chopper.get('maintenance_supported')}"
+    )
+    disabled = sorted(k for k, v in site_summary.capabilities.items() if not v)
+    if disabled:
+        print("  disabled capabilities: " + ", ".join(disabled))
+    if open_browser:
+        try:
+            webbrowser.open(url)
+        except Exception:
+            pass
+
+    thread = threading.Thread(target=server.serve_forever, name="necst-console", daemon=True)
+    thread.start()
+    event = stop_event or threading.Event()
+    try:
+        while not event.wait(0.2):
+            pass
+    finally:
+        with state.lock:
+            _run_shutdown_cleanup(state)
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2.0)
+    return 0

--- a/necst/web/operator_console.py
+++ b/necst/web/operator_console.py
@@ -28,7 +28,7 @@ from dataclasses import dataclass, field
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
+from typing import Any, Dict, List, Mapping, Optional, Tuple
 
 from . import (
     log_reader,
@@ -2212,9 +2212,6 @@ def _operator_status_operation_conflict(
         command_absent = (
             antenna.get("command_az_deg") is None
             and antenna.get("command_el_deg") is None
-        )
-        motion_source_lower = (
-            str(motion.get("live_motion_source") or "").strip().lower()
         )
         safety_release_age = _recent_safety_release_request_age_sec(state)
         safety_release_idle = bool(

--- a/necst/web/operator_console.py
+++ b/necst/web/operator_console.py
@@ -30,9 +30,18 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
 
-from . import log_reader, observation_log, process_manager, progress_manager, self_check, site_config, status_model, live_telemetry, node_health
+from . import (
+    log_reader,
+    observation_log,
+    process_manager,
+    progress_manager,
+    self_check,
+    site_config,
+    status_model,
+    live_telemetry,
+    node_health,
+)
 from ..az_unwrap_limits import assert_mount_az_allowed_when_unwrap_disabled
-
 
 JsonDict = Dict[str, Any]
 
@@ -101,10 +110,18 @@ MOUNT_COMMAND_TARGET_REACHED_TOL_DEG = 7.5e-4
 # operator UI in OBSERVATION RUNNING forever when no local launcher is active
 # and the sidecar has not been updated for this long.  This only changes the
 # console status; it does not send telescope commands or delete data.
-STALE_OBSERVATION_PROGRESS_SEC = float(os.environ.get("NECST_CONSOLE_STALE_OBSERVATION_SEC", "60.0"))
-ABORT_STUCK_OBSERVATION_SEC = float(os.environ.get("NECST_CONSOLE_ABORT_STUCK_OBSERVATION_SEC", "15.0"))
-LAUNCHER_FAILURE_TAIL_BYTES = int(os.environ.get("NECST_CONSOLE_LAUNCHER_FAILURE_TAIL_BYTES", "65536"))
-LAUNCHER_FAILURE_SUMMARY_MAX_CHARS = int(os.environ.get("NECST_CONSOLE_LAUNCHER_FAILURE_SUMMARY_MAX_CHARS", "600"))
+STALE_OBSERVATION_PROGRESS_SEC = float(
+    os.environ.get("NECST_CONSOLE_STALE_OBSERVATION_SEC", "60.0")
+)
+ABORT_STUCK_OBSERVATION_SEC = float(
+    os.environ.get("NECST_CONSOLE_ABORT_STUCK_OBSERVATION_SEC", "15.0")
+)
+LAUNCHER_FAILURE_TAIL_BYTES = int(
+    os.environ.get("NECST_CONSOLE_LAUNCHER_FAILURE_TAIL_BYTES", "65536")
+)
+LAUNCHER_FAILURE_SUMMARY_MAX_CHARS = int(
+    os.environ.get("NECST_CONSOLE_LAUNCHER_FAILURE_SUMMARY_MAX_CHARS", "600")
+)
 
 LIVE_ACTION_GUARD_MESSAGE = (
     "live write actions are guarded by --guard-live-actions; "
@@ -246,9 +263,13 @@ class OperatorConsoleState:
             try:
                 self.operator_log_path.parent.mkdir(parents=True, exist_ok=True)
                 payload = dict(entry.__dict__)
-                payload["time_iso"] = time.strftime("%Y-%m-%dT%H:%M:%S%z", time.localtime())
+                payload["time_iso"] = time.strftime(
+                    "%Y-%m-%dT%H:%M:%S%z", time.localtime()
+                )
                 with self.operator_log_path.open("a", encoding="utf-8") as fh:
-                    fh.write(json.dumps(payload, ensure_ascii=False, sort_keys=True) + "\n")
+                    fh.write(
+                        json.dumps(payload, ensure_ascii=False, sort_keys=True) + "\n"
+                    )
             except Exception:
                 # The browser log must remain usable even if the persistent log
                 # path becomes temporarily unwritable.
@@ -296,7 +317,9 @@ def _normalize_skydip_tp_range(value: Any) -> str:
         try:
             tokens = [str(x) for x in value]
         except TypeError as exc:
-            raise ValueError("SkyDip TP channel range must be blank or integer START END pairs") from exc
+            raise ValueError(
+                "SkyDip TP channel range must be blank or integer START END pairs"
+            ) from exc
     values: List[int] = []
     for token in tokens:
         text = str(token).strip()
@@ -354,6 +377,7 @@ def resolve_mount_limits(
         ).mount_limits
     )
 
+
 def validate_mount_target(
     params: Mapping[str, Any], mount_limits: Mapping[str, Any]
 ) -> Tuple[float, float]:
@@ -373,16 +397,22 @@ def validate_mount_target(
     if el_min >= el_max:
         raise ValueError("site TOML El min/max are invalid")
     if not (az_min <= az <= az_max):
-        raise ValueError(f"Az={az:g} deg is outside site TOML range {az_min:g}..{az_max:g} deg")
+        raise ValueError(
+            f"Az={az:g} deg is outside site TOML range {az_min:g}..{az_max:g} deg"
+        )
     assert_mount_az_allowed_when_unwrap_disabled(
         az, action_label="operator console mount move"
     )
     if not (el_min <= el <= el_max):
-        raise ValueError(f"El={el:g} deg is outside site TOML range {el_min:g}..{el_max:g} deg")
+        raise ValueError(
+            f"El={el:g} deg is outside site TOML range {el_min:g}..{el_max:g} deg"
+        )
     return az, el
 
 
-def validate_observation_selection(params: Mapping[str, Any]) -> Tuple[str, str, Optional[int]]:
+def validate_observation_selection(
+    params: Mapping[str, Any],
+) -> Tuple[str, str, Optional[int]]:
     """Static obs-file selection validation; does not touch hardware."""
 
     mode = str(params.get("mode") or "").strip().lower()
@@ -441,7 +471,11 @@ def _auto_obs_root_candidates() -> List[Path]:
         os.environ.get("NECST_OBS_BASE", ""),
         os.environ.get("NECST_RECORD_ROOT", ""),
         os.environ.get("ROS2_WS", ""),
-        os.environ.get("COLCON_PREFIX_PATH", "").split(os.pathsep)[0] if os.environ.get("COLCON_PREFIX_PATH") else "",
+        (
+            os.environ.get("COLCON_PREFIX_PATH", "").split(os.pathsep)[0]
+            if os.environ.get("COLCON_PREFIX_PATH")
+            else ""
+        ),
         str(Path.cwd()),
         str(Path.home()),
         str(Path.home() / "obs"),
@@ -472,7 +506,14 @@ def _auto_obs_root_candidates() -> List[Path]:
     # Put obs-like directories first when they exist, but do not hide the
     # broader filesystem roots.  Users can still narrow the chooser by passing
     # --obs-root or NECST_CONSOLE_OBS_ROOTS.
-    obs_names = ("obs", "obsfiles", "obs_files", "observation", "observations", "observation_files")
+    obs_names = (
+        "obs",
+        "obsfiles",
+        "obs_files",
+        "observation",
+        "observations",
+        "observation_files",
+    )
     expanded: List[Path] = []
     for raw in raw_candidates:
         try:
@@ -486,7 +527,9 @@ def _auto_obs_root_candidates() -> List[Path]:
     return expanded
 
 
-def resolve_obs_roots(configured_roots: Optional[List[os.PathLike[str] | str]] = None) -> List[Path]:
+def resolve_obs_roots(
+    configured_roots: Optional[List[os.PathLike[str] | str]] = None,
+) -> List[Path]:
     """Return NECST-side browse roots for preview and obs selection.
 
     If ``--obs-root`` or ``NECST_CONSOLE_OBS_ROOTS`` is supplied, those paths
@@ -560,7 +603,9 @@ def _path_under_root(path: Path, roots: List[Path]) -> bool:
 
 def _safe_obs_path(raw_path: str, roots: List[Path]) -> Path:
     if not roots:
-        raise ValueError("no NECST-side locations are available; check filesystem permissions or set --obs-root")
+        raise ValueError(
+            "no NECST-side locations are available; check filesystem permissions or set --obs-root"
+        )
     if not str(raw_path or "").strip():
         raise ValueError("obs path is empty")
     path = Path(str(raw_path)).expanduser()
@@ -572,14 +617,18 @@ def _safe_obs_path(raw_path: str, roots: List[Path]) -> Path:
         raise ValueError(f"cannot resolve NECST-side path: {exc}") from exc
     if not _path_under_root(resolved, roots):
         root_text = ", ".join(str(r) for r in roots)
-        raise ValueError(f"NECST-side path is outside configured locations: {resolved}; roots={root_text}")
+        raise ValueError(
+            f"NECST-side path is outside configured locations: {resolved}; roots={root_text}"
+        )
     return resolved
 
 
 def obs_roots_payload(roots: List[Path]) -> JsonDict:
     return {
         "ok": True,
-        "roots": [{"path": str(root), "label": _obs_root_label(root)} for root in roots],
+        "roots": [
+            {"path": str(root), "label": _obs_root_label(root)} for root in roots
+        ],
         "message": (
             "NECST-side locations are paths visible to the process running this console"
             if roots
@@ -591,32 +640,54 @@ def obs_roots_payload(roots: List[Path]) -> JsonDict:
 def list_server_obs_files(roots: List[Path], directory: str = "") -> JsonDict:
     browse_dir = _safe_obs_path(directory or (str(roots[0]) if roots else ""), roots)
     if not browse_dir.exists() or not browse_dir.is_dir():
-        raise ValueError(f"NECST-side directory does not exist or is not a directory: {browse_dir}")
+        raise ValueError(
+            f"NECST-side directory does not exist or is not a directory: {browse_dir}"
+        )
     entries: List[JsonDict] = []
     parent = browse_dir.parent
     if parent != browse_dir and _path_under_root(parent, roots):
-        entries.append({"type": "directory", "name": "..", "path": str(parent), "size": None})
+        entries.append(
+            {"type": "directory", "name": "..", "path": str(parent), "size": None}
+        )
     try:
         children = list(browse_dir.iterdir())
     except Exception as exc:
-        raise ValueError(f"failed to list NECST-side directory {browse_dir}: {exc}") from exc
+        raise ValueError(
+            f"failed to list NECST-side directory {browse_dir}: {exc}"
+        ) from exc
     for child in sorted(children, key=lambda p: (not p.is_dir(), p.name.lower())):
         try:
             if child.is_dir():
-                entries.append({"type": "directory", "name": child.name, "path": str(child.resolve()), "size": None})
+                entries.append(
+                    {
+                        "type": "directory",
+                        "name": child.name,
+                        "path": str(child.resolve()),
+                        "size": None,
+                    }
+                )
             elif child.is_file() and child.suffix.lower() in {".obs", ".toml"}:
-                entries.append({
-                    "type": "file",
-                    "name": child.name,
-                    "path": str(child.resolve()),
-                    "size": int(child.stat().st_size),
-                })
+                entries.append(
+                    {
+                        "type": "file",
+                        "name": child.name,
+                        "path": str(child.resolve()),
+                        "size": int(child.stat().st_size),
+                    }
+                )
         except Exception:
             continue
-    return {"ok": True, "directory": str(browse_dir), "entries": entries, "root_count": len(roots)}
+    return {
+        "ok": True,
+        "directory": str(browse_dir),
+        "entries": entries,
+        "root_count": len(roots),
+    }
 
 
-def preview_server_obs_file(roots: List[Path], path: str, *, max_bytes: int = 65536) -> JsonDict:
+def preview_server_obs_file(
+    roots: List[Path], path: str, *, max_bytes: int = 65536
+) -> JsonDict:
     obs_path = _safe_obs_path(path, roots)
     if obs_path.suffix.lower() not in {".obs", ".toml", ".txt"}:
         raise ValueError("NECST-side preview only allows .obs, .toml, or .txt files")
@@ -638,6 +709,7 @@ def preview_server_obs_file(roots: List[Path], path: str, *, max_bytes: int = 65
         "line_count": len(preview_text.splitlines()),
         "truncated": bool(truncated),
     }
+
 
 def validate_site_capability(
     state: OperatorConsoleState,
@@ -692,7 +764,9 @@ def _load_operator_actions() -> Any:
         core_pkg = sys.modules.setdefault("necst.core", types.ModuleType("necst.core"))
         setattr(necst_pkg, "core", core_pkg)
 
-        config_mod = sys.modules.setdefault("necst.config", types.ModuleType("necst.config"))
+        config_mod = sys.modules.setdefault(
+            "necst.config", types.ModuleType("necst.config")
+        )
         if not hasattr(config_mod, "chopper_motor_position"):
             config_mod.chopper_motor_position = {"insert": 4750, "remove": 19700}
         if not hasattr(config_mod, "simulator"):
@@ -703,9 +777,12 @@ def _load_operator_actions() -> Any:
             "necst.core.commander", types.ModuleType("necst.core.commander")
         )
         if not hasattr(commander_mod, "Commander"):
+
             class _UnavailableCommander:  # pragma: no cover - fallback only
                 def __init__(self, *args: Any, **kwargs: Any) -> None:
-                    raise RuntimeError("Commander is unavailable in reduced environment")
+                    raise RuntimeError(
+                        "Commander is unavailable in reduced environment"
+                    )
 
             commander_mod.Commander = _UnavailableCommander
 
@@ -715,9 +792,13 @@ def _load_operator_actions() -> Any:
         obs_check_name = "necst.core.observation_check"
         if obs_check_name not in sys.modules:
             obs_check_path = core_path / "observation_check.py"
-            obs_spec = importlib.util.spec_from_file_location(obs_check_name, obs_check_path)
+            obs_spec = importlib.util.spec_from_file_location(
+                obs_check_name, obs_check_path
+            )
             if obs_spec is None or obs_spec.loader is None:
-                raise RuntimeError(f"failed to load observation_check.py from {obs_check_path}")
+                raise RuntimeError(
+                    f"failed to load observation_check.py from {obs_check_path}"
+                )
             obs_module = importlib.util.module_from_spec(obs_spec)
             sys.modules[obs_check_name] = obs_module
             setattr(core_pkg, "observation_check", obs_module)
@@ -751,7 +832,9 @@ def _reject_not_connected(action: str) -> Tuple[bool, str, JsonDict]:
     )
 
 
-def _live_write_guard(state: OperatorConsoleState, action: str) -> Tuple[bool, str, JsonDict]:
+def _live_write_guard(
+    state: OperatorConsoleState, action: str
+) -> Tuple[bool, str, JsonDict]:
     """Return whether a write-like live action may be dispatched.
 
     ``--action-mode dry-run`` is the normal no-hardware validation mode.
@@ -764,19 +847,31 @@ def _live_write_guard(state: OperatorConsoleState, action: str) -> Tuple[bool, s
     if state.action_mode != "live":
         return True, "dry-run mode", {"live_write_guard": "not_live"}
     if action not in LIVE_WRITE_ACTIONS:
-        return True, "read-only/local/safety action", {"live_write_guard": "not_write_action"}
+        return (
+            True,
+            "read-only/local/safety action",
+            {"live_write_guard": "not_write_action"},
+        )
     if state.live_actions_enabled:
-        return True, "live write actions enabled", {
-            "live_write_guard": "enabled",
-            "live_actions_enabled": True,
-        }
-    return False, LIVE_ACTION_GUARD_MESSAGE, {
-        "action": action,
-        "live_write_guard": "blocked",
-        "live_actions_enabled": False,
-        "guard_option": "--guard-live-actions",
-        "safety_actions_still_available": sorted(SAFETY_ACTIONS),
-    }
+        return (
+            True,
+            "live write actions enabled",
+            {
+                "live_write_guard": "enabled",
+                "live_actions_enabled": True,
+            },
+        )
+    return (
+        False,
+        LIVE_ACTION_GUARD_MESSAGE,
+        {
+            "action": action,
+            "live_write_guard": "blocked",
+            "live_actions_enabled": False,
+            "guard_option": "--guard-live-actions",
+            "safety_actions_still_available": sorted(SAFETY_ACTIONS),
+        },
+    )
 
 
 def _authority_allows(state: OperatorConsoleState, session_id: str) -> Tuple[bool, str]:
@@ -883,7 +978,9 @@ def _sync_authority_state(
         return {"changed": True, "held": False, "reason": "status_check_failed"}
 
     if not handle_held:
-        note = "authority handle no longer reports NECST authority; cleared browser gate"
+        note = (
+            "authority handle no longer reports NECST authority; cleared browser gate"
+        )
         _clear_authority_state(state)
         if log_if_cleared:
             state.add_log(False, note, action="authority_sync")
@@ -994,10 +1091,18 @@ def _observation_log_context(state: OperatorConsoleState) -> JsonDict:
     }
     live_payload = state.live_cache.snapshot() if state.live_cache is not None else {}
     if isinstance(live_payload, Mapping):
-        encoder = live_payload.get("encoder") if isinstance(live_payload.get("encoder"), Mapping) else {}
+        encoder = (
+            live_payload.get("encoder")
+            if isinstance(live_payload.get("encoder"), Mapping)
+            else {}
+        )
         context["enc_az_deg"] = encoder.get("encoder_lon_deg")
         context["enc_el_deg"] = encoder.get("encoder_lat_deg")
-        weather = live_payload.get("weather") if isinstance(live_payload.get("weather"), Mapping) else {}
+        weather = (
+            live_payload.get("weather")
+            if isinstance(live_payload.get("weather"), Mapping)
+            else {}
+        )
         context["weather"] = dict(weather)
     try:
         status_state = status_model.build_progress_status_state(
@@ -1005,14 +1110,24 @@ def _observation_log_context(state: OperatorConsoleState) -> JsonDict:
             events_limit=1,
             live_payload=live_payload if isinstance(live_payload, Mapping) else None,
         )
-        op = status_state.get("operator_status") if isinstance(status_state, Mapping) else {}
+        op = (
+            status_state.get("operator_status")
+            if isinstance(status_state, Mapping)
+            else {}
+        )
         if isinstance(op, Mapping):
-            antenna = op.get("antenna") if isinstance(op.get("antenna"), Mapping) else {}
+            antenna = (
+                op.get("antenna") if isinstance(op.get("antenna"), Mapping) else {}
+            )
             if context.get("enc_az_deg") is None:
                 context["enc_az_deg"] = antenna.get("current_az_deg")
             if context.get("enc_el_deg") is None:
                 context["enc_el_deg"] = antenna.get("current_el_deg")
-            observation = op.get("observation") if isinstance(op.get("observation"), Mapping) else {}
+            observation = (
+                op.get("observation")
+                if isinstance(op.get("observation"), Mapping)
+                else {}
+            )
             paths = op.get("paths") if isinstance(op.get("paths"), Mapping) else {}
             context["record_dir"] = (
                 observation.get("local_recording_dir")
@@ -1023,7 +1138,11 @@ def _observation_log_context(state: OperatorConsoleState) -> JsonDict:
                 or paths.get("progress_record_dir")
                 or ""
             )
-        weather_state = status_state.get("weather") if isinstance(status_state.get("weather"), Mapping) else {}
+        weather_state = (
+            status_state.get("weather")
+            if isinstance(status_state.get("weather"), Mapping)
+            else {}
+        )
         if weather_state and not context.get("weather"):
             context["weather"] = dict(weather_state)
     except Exception:
@@ -1047,7 +1166,10 @@ def _obslog_result(ok: bool, action: str, data: Mapping[str, Any]) -> str:
 
 def _active_process_labels(state: OperatorConsoleState, *, category: str) -> List[str]:
     try:
-        return [str(record.label or record.category or "") for record in state.process_registry.active(category=category)]
+        return [
+            str(record.label or record.category or "")
+            for record in state.process_registry.active(category=category)
+        ]
     except Exception:
         return []
 
@@ -1069,7 +1191,11 @@ def _active_observation_mode(state: OperatorConsoleState) -> str:
 
 
 def _active_observation_text(state: OperatorConsoleState, *, fallback: str) -> str:
-    labels = [label for label in _active_process_labels(state, category="observation") if label]
+    labels = [
+        label
+        for label in _active_process_labels(state, category="observation")
+        if label
+    ]
     if labels:
         return ", ".join(labels)
     return fallback
@@ -1126,7 +1252,12 @@ def _obslog_mode_for_action(
         return "SkyDip"
     if action.startswith("chopper_"):
         return "Chopper"
-    if action in {"stop", "abort_observation", "clear_stale_observation_state", "reset_local_console_state"}:
+    if action in {
+        "stop",
+        "abort_observation",
+        "clear_stale_observation_state",
+        "reset_local_console_state",
+    }:
         return "Console"
     if action.startswith("terminate_") or action in {"kill_process"}:
         return "Recovery"
@@ -1140,7 +1271,9 @@ def _obslog_action_text(
     state: Optional[OperatorConsoleState] = None,
 ) -> str:
     if action in {"check_observation", "dry_run_observation", "start_observation"}:
-        return observation_log.obsfile_name_for_csv(data.get("obs_path") or params.get("file") or "")
+        return observation_log.obsfile_name_for_csv(
+            data.get("obs_path") or params.get("file") or ""
+        )
     if action in {"abort_observation", "stop"} and state is not None:
         labels = _active_process_labels(state, category="observation")
         if labels:
@@ -1148,7 +1281,13 @@ def _obslog_action_text(
     if action in {"mount_move", "mount_move_dry_run"}:
         return f"Az={params.get('az', '')}, El={params.get('el', '')}"
     if action == "start_tracking":
-        target = params.get("target") or params.get("target_kind") or params.get("kind") or params.get("name") or "target"
+        target = (
+            params.get("target")
+            or params.get("target_kind")
+            or params.get("kind")
+            or params.get("name")
+            or "target"
+        )
         return str(target)
     if action in {"run_rsky", "run_skydip"}:
         return ", ".join(f"{k}={v}" for k, v in params.items() if v not in (None, ""))
@@ -1179,7 +1318,11 @@ def _write_observation_log_for_action(
     context = _observation_log_context(state)
     record_dir = None
     if action == "start_observation":
-        record_dir = data.get("recording_dir") or data.get("local_recording_dir") or data.get("progress_record_dir")
+        record_dir = (
+            data.get("recording_dir")
+            or data.get("local_recording_dir")
+            or data.get("progress_record_dir")
+        )
     written = manager.write_event(
         context,
         mode=_obslog_mode_for_action(action, params, data, state),
@@ -1203,7 +1346,10 @@ def _obslog_status_payload(state: OperatorConsoleState) -> JsonDict:
         return {"ok": False, "reason": "observation CSV log is not configured"}
     return {"ok": True, "observation_log": manager.status()}
 
-def run_self_check(state: OperatorConsoleState, *, include_progress_health: bool = True) -> JsonDict:
+
+def run_self_check(
+    state: OperatorConsoleState, *, include_progress_health: bool = True
+) -> JsonDict:
     """Run read-only console self-checks without sending telescope commands."""
 
     return self_check.run_console_self_check(
@@ -1229,15 +1375,18 @@ def run_self_check(state: OperatorConsoleState, *, include_progress_health: bool
     )
 
 
-
-def _truncate_for_status(text: Any, *, max_chars: int = LAUNCHER_FAILURE_SUMMARY_MAX_CHARS) -> str:
+def _truncate_for_status(
+    text: Any, *, max_chars: int = LAUNCHER_FAILURE_SUMMARY_MAX_CHARS
+) -> str:
     value = str(text or "").strip()
     if len(value) <= int(max_chars):
         return value
     return value[: max(0, int(max_chars) - 1)].rstrip() + "…"
 
 
-def _read_log_tail_for_summary(path_value: Any, *, max_bytes: int = LAUNCHER_FAILURE_TAIL_BYTES) -> Tuple[str, int, bool, str]:
+def _read_log_tail_for_summary(
+    path_value: Any, *, max_bytes: int = LAUNCHER_FAILURE_TAIL_BYTES
+) -> Tuple[str, int, bool, str]:
     """Return a bounded text tail for launcher failure summarization.
 
     This is used only for log files that the console itself assigned to a local
@@ -1253,7 +1402,9 @@ def _read_log_tail_for_summary(path_value: Any, *, max_bytes: int = LAUNCHER_FAI
         if not path.exists() or not path.is_file():
             return "", 0, False, f"log file does not exist: {path}"
         size = path.stat().st_size
-        max_b = max(1024, min(int(max_bytes or LAUNCHER_FAILURE_TAIL_BYTES), 1024 * 1024))
+        max_b = max(
+            1024, min(int(max_bytes or LAUNCHER_FAILURE_TAIL_BYTES), 1024 * 1024)
+        )
         with path.open("rb") as fh:
             if size > max_b:
                 fh.seek(size - max_b)
@@ -1295,15 +1446,21 @@ def _extract_failure_summary_from_text(text: Any) -> str:
 def _launcher_failure_payload(record: process_manager.ManagedProcessRecord) -> JsonDict:
     """Build a compact failure summary for a finalized local launcher."""
 
-    stderr_tail, stderr_size, stderr_truncated, stderr_error = _read_log_tail_for_summary(record.stderr_path)
-    stdout_tail, stdout_size, stdout_truncated, stdout_error = _read_log_tail_for_summary(record.stdout_path)
+    stderr_tail, stderr_size, stderr_truncated, stderr_error = (
+        _read_log_tail_for_summary(record.stderr_path)
+    )
+    stdout_tail, stdout_size, stdout_truncated, stdout_error = (
+        _read_log_tail_for_summary(record.stdout_path)
+    )
     stderr_summary = _extract_failure_summary_from_text(stderr_tail)
     stdout_summary = _extract_failure_summary_from_text(stdout_tail)
     stream = "stderr" if stderr_summary else ("stdout" if stdout_summary else "")
     summary = stderr_summary or stdout_summary
     if not summary:
         if record.status == "lost":
-            summary = "local launcher handle was lost before the exit reason could be read"
+            summary = (
+                "local launcher handle was lost before the exit reason could be read"
+            )
         else:
             summary = f"launcher exited with return code {record.returncode}"
         if stderr_error and stdout_error:
@@ -1336,6 +1493,7 @@ def _launcher_failure_payload(record: process_manager.ManagedProcessRecord) -> J
     )
     return payload
 
+
 def _refresh_processes_and_log(state: OperatorConsoleState) -> None:
     """Reap child launcher processes and log newly observed final states."""
 
@@ -1361,17 +1519,28 @@ def _refresh_processes_and_log(state: OperatorConsoleState) -> None:
             message = f"{message}: {summary}"
             record_data["failure"] = failure_payload
         state.add_log(ok, message, action="process_exit", data=record_data)
-        if state.observation_log is not None and record.category in {"observation", "calibration"}:
+        if state.observation_log is not None and record.category in {
+            "observation",
+            "calibration",
+        }:
             label = str(getattr(record, "label", "") or "")
             result_text = "success" if ok else "failed"
             if record.category == "observation":
                 mode = label.split(":", 1)[1].upper() if ":" in label else "Observation"
-                safety_labels = list(getattr(state, "last_observation_safety_labels", []) or [])
+                safety_labels = list(
+                    getattr(state, "last_observation_safety_labels", []) or []
+                )
                 safety_matches = (not safety_labels) or (label in safety_labels)
-                if state.last_observation_abort_requested_at is not None and safety_matches:
+                if (
+                    state.last_observation_abort_requested_at is not None
+                    and safety_matches
+                ):
                     event = "observation_aborted"
                     result_text = "aborted"
-                elif state.last_observation_stop_requested_at is not None and safety_matches:
+                elif (
+                    state.last_observation_stop_requested_at is not None
+                    and safety_matches
+                ):
                     event = "observation_stopped"
                     result_text = "stopped"
                 else:
@@ -1397,7 +1566,9 @@ def _refresh_processes_and_log(state: OperatorConsoleState) -> None:
                     action="observation_csv_log",
                     data={"source_action": "process_exit", "label": label},
                 )
-        if record.category == "observation" and not state.process_registry.active(category="observation"):
+        if record.category == "observation" and not state.process_registry.active(
+            category="observation"
+        ):
             state.last_observation_abort_requested_at = None
             state.last_observation_stop_requested_at = None
             state.last_observation_safety_labels = []
@@ -1405,7 +1576,9 @@ def _refresh_processes_and_log(state: OperatorConsoleState) -> None:
                 state.last_active_task = "none"
             if state.last_manual_state == "observing sequence":
                 state.last_manual_state = "idle"
-        if record.category == "calibration" and not state.process_registry.active(category="calibration"):
+        if record.category == "calibration" and not state.process_registry.active(
+            category="calibration"
+        ):
             if state.last_active_task in {"RSky", "SkyDip"}:
                 state.last_active_task = "none"
             if state.last_manual_state == "calibration":
@@ -1424,7 +1597,6 @@ def _active_launcher_summary(
     return "active launcher already exists: " + ", ".join(labels)
 
 
-
 def _active_launcher_categories(state: OperatorConsoleState) -> set[str]:
     """Return active launcher categories currently owned by this console."""
 
@@ -1435,7 +1607,9 @@ def _active_launcher_categories(state: OperatorConsoleState) -> set[str]:
     }
 
 
-def _progress_snapshot_update_age_sec(status_state: Mapping[str, Any]) -> Optional[float]:
+def _progress_snapshot_update_age_sec(
+    status_state: Mapping[str, Any],
+) -> Optional[float]:
     """Return age of the current progress snapshot update, if known."""
 
     now = time.time()
@@ -1450,10 +1624,12 @@ def _progress_snapshot_update_age_sec(status_state: Mapping[str, Any]) -> Option
     raw = status_state.get("raw_snapshot") if isinstance(status_state, Mapping) else {}
     raw = raw if isinstance(raw, Mapping) else {}
     raw_timing = raw.get("time") if isinstance(raw.get("time"), Mapping) else {}
-    candidates.extend([
-        raw_timing.get("updated_at_unix"),
-        raw_timing.get("last_update_unix"),
-    ])
+    candidates.extend(
+        [
+            raw_timing.get("updated_at_unix"),
+            raw_timing.get("last_update_unix"),
+        ]
+    )
     for value in candidates:
         try:
             ts = float(value)
@@ -1468,7 +1644,6 @@ def _progress_snapshot_update_age_sec(status_state: Mapping[str, Any]) -> Option
     except Exception:
         pass
     return None
-
 
 
 def _utc_reset_stamp() -> str:
@@ -1505,7 +1680,9 @@ def reset_local_console_state_files(
                 continue
             target = archive_dir / path.name
             if target.exists():
-                target = archive_dir / f"{path.stem}_{uuid.uuid4().hex[:6]}{path.suffix}"
+                target = (
+                    archive_dir / f"{path.stem}_{uuid.uuid4().hex[:6]}{path.suffix}"
+                )
             shutil.move(str(path), str(target))
             moved.append({"from": str(path), "to": str(target)})
         except Exception as exc:
@@ -1531,13 +1708,21 @@ def reset_local_console_state_files(
                 pass
         payload["manifest"] = str(manifest)
     except Exception as exc:
-        payload.setdefault("errors", []).append({"path": str(archive_dir / "reset_manifest.json"), "error": str(exc)})
+        payload.setdefault("errors", []).append(
+            {"path": str(archive_dir / "reset_manifest.json"), "error": str(exc)}
+        )
         payload["ok"] = False
     return payload
 
 
-def _reset_local_console_state(state: OperatorConsoleState, *, reason: str = "operator request") -> Tuple[bool, str, JsonDict]:
-    operator_dir = state.operator_log_path.parent if state.operator_log_path is not None else Path.home() / ".necst" / "operator_console"
+def _reset_local_console_state(
+    state: OperatorConsoleState, *, reason: str = "operator request"
+) -> Tuple[bool, str, JsonDict]:
+    operator_dir = (
+        state.operator_log_path.parent
+        if state.operator_log_path is not None
+        else Path.home() / ".necst" / "operator_console"
+    )
     data = reset_local_console_state_files(
         progress_root=state.progress_root,
         operator_log_dir=operator_dir,
@@ -1563,6 +1748,7 @@ def _reset_local_console_state(state: OperatorConsoleState, *, reason: str = "op
         message = "local console state reset had errors; no hardware command sent"
     return bool(data.get("ok")), message, data
 
+
 def _stale_observation_state(
     state: OperatorConsoleState,
     status_state: Mapping[str, Any],
@@ -1579,17 +1765,33 @@ def _stale_observation_state(
 
     op = operator_status if isinstance(operator_status, Mapping) else {}
     if not op:
-        op = status_state.get("operator_status") if isinstance(status_state, Mapping) else {}
+        op = (
+            status_state.get("operator_status")
+            if isinstance(status_state, Mapping)
+            else {}
+        )
         op = op if isinstance(op, Mapping) else {}
     system = op.get("system") if isinstance(op.get("system"), Mapping) else {}
     progress = op.get("progress") if isinstance(op.get("progress"), Mapping) else {}
-    observation = op.get("observation") if isinstance(op.get("observation"), Mapping) else {}
+    observation = (
+        op.get("observation") if isinstance(op.get("observation"), Mapping) else {}
+    )
     lifecycle = str(system.get("state") or "unknown").strip().lower()
     percent = progress.get("percent")
-    nonfinal_lifecycle = lifecycle not in {"", "idle", "unknown", "finished", "aborted", "error", "failed"}
+    nonfinal_lifecycle = lifecycle not in {
+        "",
+        "idle",
+        "unknown",
+        "finished",
+        "aborted",
+        "error",
+        "failed",
+    }
     progress_running = bool(nonfinal_lifecycle or percent is not None)
     active_categories = _active_launcher_categories(state)
-    active_launcher = bool(active_categories.intersection({"observation", "calibration"}))
+    active_launcher = bool(
+        active_categories.intersection({"observation", "calibration"})
+    )
     age = _progress_snapshot_update_age_sec(status_state)
     threshold = max(5.0, float(STALE_OBSERVATION_PROGRESS_SEC))
     safety_age = _recent_safety_release_request_age_sec(state, max_age_sec=3600.0)
@@ -1646,7 +1848,10 @@ def _stale_observation_state(
         "can_terminate_launcher": bool(launcher_stuck and active_launcher),
     }
 
-def _clear_stale_observation_state(state: OperatorConsoleState) -> Tuple[bool, str, JsonDict]:
+
+def _clear_stale_observation_state(
+    state: OperatorConsoleState,
+) -> Tuple[bool, str, JsonDict]:
     """Archive stale current-observation pointers so the console can return READY.
 
     This is an explicit operator recovery action.  It never sends hardware
@@ -1654,13 +1859,19 @@ def _clear_stale_observation_state(state: OperatorConsoleState) -> Tuple[bool, s
     It only moves the global current-observation pointer files out of the way.
     """
 
-    active = _active_launcher_categories(state).intersection({"observation", "calibration"})
+    active = _active_launcher_categories(state).intersection(
+        {"observation", "calibration"}
+    )
     if active:
-        return False, (
-            "cannot clear stale observation state while a console-owned launcher "
-            f"is still active: {', '.join(sorted(active))}. Force-kill the local "
-            "observation launcher first after confirming the hardware is safe."
-        ), {"active_launcher_categories": sorted(active), "cleared": False}
+        return (
+            False,
+            (
+                "cannot clear stale observation state while a console-owned launcher "
+                f"is still active: {', '.join(sorted(active))}. Force-kill the local "
+                "observation launcher first after confirming the hardware is safe."
+            ),
+            {"active_launcher_categories": sorted(active), "cleared": False},
+        )
 
     root = state.progress_root
     stamp = time.strftime("%Y%m%d_%H%M%S", time.localtime())
@@ -1681,13 +1892,17 @@ def _clear_stale_observation_state(state: OperatorConsoleState) -> Tuple[bool, s
         except Exception as exc:
             errors.append(f"{src}: {exc}")
     if errors:
-        return False, "failed to clear one or more stale progress pointer files", {
-            "cleared": False,
-            "moved": moved,
-            "missing": missing,
-            "errors": errors,
-            "archive_dir": str(archive_dir),
-        }
+        return (
+            False,
+            "failed to clear one or more stale progress pointer files",
+            {
+                "cleared": False,
+                "moved": moved,
+                "missing": missing,
+                "errors": errors,
+                "archive_dir": str(archive_dir),
+            },
+        )
 
     _clear_exclusive_start_guard(state)
     _clear_safety_release_request(state)
@@ -1701,13 +1916,17 @@ def _clear_stale_observation_state(state: OperatorConsoleState) -> Tuple[bool, s
         message += f"; archived {len(moved)} current progress pointer file(s)"
     else:
         message += "; no current progress pointer files were present"
-    return True, message, {
-        "cleared": True,
-        "moved": moved,
-        "missing": missing,
-        "archive_dir": str(archive_dir) if moved else None,
-        "note": "per-record progress/data directories were not deleted",
-    }
+    return (
+        True,
+        message,
+        {
+            "cleared": True,
+            "moved": moved,
+            "missing": missing,
+            "archive_dir": str(archive_dir) if moved else None,
+            "note": "per-record progress/data directories were not deleted",
+        },
+    )
 
 
 def _mount_target_reached_from_values(
@@ -1732,9 +1951,15 @@ def _mount_target_reached_from_values(
         tel = float(target_el)
     except Exception:
         return None
-    if not (math.isfinite(az) and math.isfinite(el) and math.isfinite(taz) and math.isfinite(tel)):
+    if not (
+        math.isfinite(az)
+        and math.isfinite(el)
+        and math.isfinite(taz)
+        and math.isfinite(tel)
+    ):
         return None
     return bool(abs(az - taz) <= float(tol_deg) and abs(el - tel) <= float(tol_deg))
+
 
 def _last_mount_target_reached(
     state: OperatorConsoleState,
@@ -1766,12 +1991,25 @@ def _last_mount_target_reached(
         if update_state:
             state.last_mount_target_reached_since = None
         return False
-    if not (math.isfinite(az) and math.isfinite(el) and math.isfinite(target_az) and math.isfinite(target_el)):
+    if not (
+        math.isfinite(az)
+        and math.isfinite(el)
+        and math.isfinite(target_az)
+        and math.isfinite(target_el)
+    ):
         if update_state:
             state.last_mount_target_reached_since = None
         return False
 
-    reached_now = bool(_mount_target_reached_from_values(current_az=az, current_el=el, target_az=target_az, target_el=target_el, tol_deg=tol_deg))
+    reached_now = bool(
+        _mount_target_reached_from_values(
+            current_az=az,
+            current_el=el,
+            target_az=target_az,
+            target_el=target_el,
+            tol_deg=tol_deg,
+        )
+    )
     now = time.time()
     if not reached_now:
         if update_state:
@@ -1779,7 +2017,11 @@ def _last_mount_target_reached(
         return False
     if update_state and state.last_mount_target_reached_since is None:
         state.last_mount_target_reached_since = now
-    since = state.last_mount_target_reached_since if state.last_mount_target_reached_since is not None else now
+    since = (
+        state.last_mount_target_reached_since
+        if state.last_mount_target_reached_since is not None
+        else now
+    )
     try:
         settled = (now - float(since)) >= float(require_settle_sec)
     except Exception:
@@ -1819,7 +2061,6 @@ def _recent_safety_release_request_age_sec(
         state.last_safety_release_requested_at = None
         return None
     return age
-
 
 
 def _prune_exclusive_start_guard(state: OperatorConsoleState) -> None:
@@ -1901,7 +2142,9 @@ def _operator_status_operation_conflict(
             "Use STOP/ABORT or force-kill the stuck local launcher before starting another operation."
         )
 
-    recent_guard = _exclusive_start_guard_reason(state, requested_action=requested_action)
+    recent_guard = _exclusive_start_guard_reason(
+        state, requested_action=requested_action
+    )
     if recent_guard is not None:
         return recent_guard
 
@@ -1913,18 +2156,29 @@ def _operator_status_operation_conflict(
         manual = str(state.last_manual_state or "").strip()
         if task.lower() not in {"", "none", "idle", "unknown"}:
             return f"cannot start {requested_action}: active task is {task}; use STOP/ABORT or wait until READY"
-        if manual.lower() in {"moving", "tracking", "calibration", "observing sequence"}:
+        if manual.lower() in {
+            "moving",
+            "tracking",
+            "calibration",
+            "observing sequence",
+        }:
             return f"cannot start {requested_action}: manual state is {manual}; use STOP/ABORT or wait until READY"
         return None
 
     try:
-        live_payload = state.live_cache.snapshot() if state.live_cache is not None else None
+        live_payload = (
+            state.live_cache.snapshot() if state.live_cache is not None else None
+        )
         status_state = status_model.build_progress_status_state(
             state.progress_root,
             events_limit=state.events_limit,
             live_payload=live_payload,
         )
-        op = status_state.get("operator_status") if isinstance(status_state, Mapping) else {}
+        op = (
+            status_state.get("operator_status")
+            if isinstance(status_state, Mapping)
+            else {}
+        )
         op = op if isinstance(op, Mapping) else {}
         stale = _stale_observation_state(state, status_state, op)
         if stale.get("running_stale") or stale.get("launcher_stuck"):
@@ -1940,27 +2194,49 @@ def _operator_status_operation_conflict(
         system = op.get("system") if isinstance(op.get("system"), Mapping) else {}
         motion = op.get("motion") if isinstance(op.get("motion"), Mapping) else {}
         sys_state = str(system.get("state") or "").strip().lower()
-        if sys_state not in {"", "idle", "unknown", "finished", "aborted", "error", "failed"}:
+        if sys_state not in {
+            "",
+            "idle",
+            "unknown",
+            "finished",
+            "aborted",
+            "error",
+            "failed",
+        }:
             return f"cannot start {requested_action}: system state is {sys_state}; use STOP/ABORT or wait until READY"
         at_target_idle = bool(
             motion.get("mount_target_reached")
             and motion.get("live_motion_active") is False
         )
         antenna = op.get("antenna") if isinstance(op.get("antenna"), Mapping) else {}
-        command_absent = antenna.get("command_az_deg") is None and antenna.get("command_el_deg") is None
-        motion_source_lower = str(motion.get("live_motion_source") or "").strip().lower()
+        command_absent = (
+            antenna.get("command_az_deg") is None
+            and antenna.get("command_el_deg") is None
+        )
+        motion_source_lower = (
+            str(motion.get("live_motion_source") or "").strip().lower()
+        )
         safety_release_age = _recent_safety_release_request_age_sec(state)
         safety_release_idle = bool(
             state.action_mode != "dry-run"
             and safety_release_age is not None
-            and sys_state in {"", "idle", "unknown", "finished", "aborted", "error", "failed"}
+            and sys_state
+            in {"", "idle", "unknown", "finished", "aborted", "error", "failed"}
             and command_absent
             and safety_release_age >= SAFETY_RELEASE_ASSUME_IDLE_AFTER_SEC
         )
         if safety_release_idle:
             at_target_idle = True
         operator_target_idle = False
-        if sys_state in {"", "idle", "unknown", "finished", "aborted", "error", "failed"}:
+        if sys_state in {
+            "",
+            "idle",
+            "unknown",
+            "finished",
+            "aborted",
+            "error",
+            "failed",
+        }:
             operator_target_idle = _last_mount_target_reached(
                 state,
                 current_az=antenna.get("current_az_deg"),
@@ -1971,7 +2247,10 @@ def _operator_status_operation_conflict(
         if operator_target_idle:
             at_target_idle = True
         active_task = str(motion.get("active_task") or "").strip()
-        if active_task.lower() not in {"", "none", "idle", "unknown"} and not at_target_idle:
+        if (
+            active_task.lower() not in {"", "none", "idle", "unknown"}
+            and not at_target_idle
+        ):
             return f"cannot start {requested_action}: active task is {active_task}; use STOP/ABORT or wait until READY"
         stage = str(motion.get("stage") or "").strip()
         # Low-level antenna control can report a hold/tracking-like stage after
@@ -2001,6 +2280,7 @@ def _operator_status_operation_conflict(
         # the telemetry problem to the operator.
         return None
     return None
+
 
 def _launcher_log_paths(
     state: OperatorConsoleState,
@@ -2040,7 +2320,6 @@ def _register_launcher_if_needed(
     return record
 
 
-
 def _request_launcher_stop(
     state: OperatorConsoleState,
     *,
@@ -2073,13 +2352,17 @@ def _request_launcher_stop(
     )
     if not records:
         selector = f"pid={pid}" if pid is not None else f"category={category or 'any'}"
-        return False, f"no active launcher matched {selector}; no local launcher process was force-killed", {
-            "action": action,
-            "pid": pid,
-            "category": category,
-            "kill": bool(kill),
-            "terminated": [],
-        }
+        return (
+            False,
+            f"no active launcher matched {selector}; no local launcher process was force-killed",
+            {
+                "action": action,
+                "pid": pid,
+                "category": category,
+                "kill": bool(kill),
+                "terminated": [],
+            },
+        )
     signal_name = "SIGKILL" if kill else "SIGTERM"
     data = {
         "action": action,
@@ -2118,11 +2401,15 @@ def dispatch_action(
     if action == "clear_launcher_failure":
         had_failure = bool(state.last_launcher_failure)
         state.last_launcher_failure = {}
-        return True, "last launcher error display cleared", {
-            "action": action,
-            "cleared": had_failure,
-            "note": "Display-only clear. Launcher stdout/stderr files, internal operator log, and Observation Log CSV are kept.",
-        }
+        return (
+            True,
+            "last launcher error display cleared",
+            {
+                "action": action,
+                "cleared": had_failure,
+                "note": "Display-only clear. Launcher stdout/stderr files, internal operator log, and Observation Log CSV are kept.",
+            },
+        )
 
     if action == "obslog_status":
         data = _obslog_status_payload(state)
@@ -2134,7 +2421,11 @@ def dispatch_action(
             return False, "observation CSV log is not configured", {"action": action}
         comment = str(params.get("comment") or "").strip()
         if not comment:
-            return False, "comment is empty; no observation-log row was written", {"action": action}
+            return (
+                False,
+                "comment is empty; no observation-log row was written",
+                {"action": action},
+            )
         written = manager.write_event(
             _observation_log_context(state),
             comment=comment,
@@ -2144,61 +2435,101 @@ def dispatch_action(
             result="success",
         )
         if not written:
-            return False, f"failed to append observation CSV log comment: {manager.last_error or 'unknown error'}", {
-                "action": action,
-                "observation_log": manager.status(),
-            }
-        return True, "comment appended to observation CSV log", {"action": action, "observation_log": manager.status()}
+            return (
+                False,
+                f"failed to append observation CSV log comment: {manager.last_error or 'unknown error'}",
+                {
+                    "action": action,
+                    "observation_log": manager.status(),
+                },
+            )
+        return (
+            True,
+            "comment appended to observation CSV log",
+            {"action": action, "observation_log": manager.status()},
+        )
 
     if action == "obslog_new":
         manager = state.observation_log
         if manager is None:
             return False, "observation CSV log is not configured", {"action": action}
-        manager.open_new(prefix=params.get("prefix") or manager.prefix, observer=params.get("user") or manager.observer)
-        return True, "new observation CSV log opened", {"action": action, "observation_log": manager.status()}
+        manager.open_new(
+            prefix=params.get("prefix") or manager.prefix,
+            observer=params.get("user") or manager.observer,
+        )
+        return (
+            True,
+            "new observation CSV log opened",
+            {"action": action, "observation_log": manager.status()},
+        )
 
     if action == "obslog_open_existing":
         manager = state.observation_log
         if manager is None:
             return False, "observation CSV log is not configured", {"action": action}
-        manager.open_existing(params.get("path"), observer=params.get("user") or manager.observer)
-        return True, "existing observation CSV log opened for append", {"action": action, "observation_log": manager.status()}
+        manager.open_existing(
+            params.get("path"), observer=params.get("user") or manager.observer
+        )
+        return (
+            True,
+            "existing observation CSV log opened for append",
+            {"action": action, "observation_log": manager.status()},
+        )
 
     if action == "launch_progress":
         if state.progress_monitor is None:
-            return True, f"progress monitor URL: {state.progress_url}", {
-                "action": action,
-                "url": state.progress_url,
-                "progress_url": state.progress_url,
-                "managed": False,
-            }
+            return (
+                True,
+                f"progress monitor URL: {state.progress_url}",
+                {
+                    "action": action,
+                    "url": state.progress_url,
+                    "progress_url": state.progress_url,
+                    "managed": False,
+                },
+            )
         ok, message, data = state.progress_monitor.launch()
         data = dict(data)
         data["action"] = action
         data["url"] = data.get("url") or state.progress_url
-        data["progress_url"] = data.get("progress_url") or data.get("url") or state.progress_url
+        data["progress_url"] = (
+            data.get("progress_url") or data.get("url") or state.progress_url
+        )
         state.progress_url = str(data["progress_url"])
         return ok, message, data
 
     if action == "list_processes":
-        records = [r.to_dict() for r in state.process_registry.all_records(refresh=True)]
-        return True, f"{len(records)} launcher process record(s)", {
-            "action": action,
-            "processes": records,
-            "process_counts": state.process_registry.counts(),
-            "launcher_log_choices": log_reader.launcher_log_choices(records),
-            "shutdown": _shutdown_snapshot(state),
-        }
+        records = [
+            r.to_dict() for r in state.process_registry.all_records(refresh=True)
+        ]
+        return (
+            True,
+            f"{len(records)} launcher process record(s)",
+            {
+                "action": action,
+                "processes": records,
+                "process_counts": state.process_registry.counts(),
+                "launcher_log_choices": log_reader.launcher_log_choices(records),
+                "shutdown": _shutdown_snapshot(state),
+            },
+        )
 
     if action == "read_operator_log":
         limit = params.get("limit", 100)
         data = log_reader.read_operator_log(state.operator_log_path, limit=limit)
         data["action"] = action
-        return bool(data.get("ok")), str(data.get("reason") or "operator log read"), data
+        return (
+            bool(data.get("ok")),
+            str(data.get("reason") or "operator log read"),
+            data,
+        )
 
     if action == "read_log_file":
         extra_roots = []
-        if state.progress_monitor is not None and getattr(state.progress_monitor, "log_dir", None) is not None:
+        if (
+            state.progress_monitor is not None
+            and getattr(state.progress_monitor, "log_dir", None) is not None
+        ):
             extra_roots.append(Path(state.progress_monitor.log_dir))
         data = log_reader.read_text_log(
             params.get("path"),
@@ -2211,18 +2542,28 @@ def dispatch_action(
         return bool(data.get("ok")), str(data.get("reason") or "log file read"), data
 
     if action == "cleanup_status":
-        records = [r.to_dict() for r in state.process_registry.all_records(refresh=True)]
-        return True, "console cleanup status", {
-            "action": action,
-            "processes": records,
-            "process_counts": state.process_registry.counts(),
-            "progress_monitor": (
-                state.progress_monitor.status(check_external=True).to_dict()
-                if state.progress_monitor is not None
-                else {"url": state.progress_url, "running": False, "owned_by_console": False}
-            ),
-            "shutdown": _shutdown_snapshot(state),
-        }
+        records = [
+            r.to_dict() for r in state.process_registry.all_records(refresh=True)
+        ]
+        return (
+            True,
+            "console cleanup status",
+            {
+                "action": action,
+                "processes": records,
+                "process_counts": state.process_registry.counts(),
+                "progress_monitor": (
+                    state.progress_monitor.status(check_external=True).to_dict()
+                    if state.progress_monitor is not None
+                    else {
+                        "url": state.progress_url,
+                        "running": False,
+                        "owned_by_console": False,
+                    }
+                ),
+                "shutdown": _shutdown_snapshot(state),
+            },
+        )
 
     if action == "reset_local_console_state":
         ok, message, data = _reset_local_console_state(state, reason="browser action")
@@ -2244,10 +2585,14 @@ def dispatch_action(
             state,
             include_progress_health=bool(include_progress_health),
         )
-        return bool(result.get("ok")), "operator console self-check completed", {
-            "action": action,
-            "self_check": result,
-        }
+        return (
+            bool(result.get("ok")),
+            "operator console self-check completed",
+            {
+                "action": action,
+                "self_check": result,
+            },
+        )
 
     if action in {"terminate_process", "kill_process"}:
         return _request_launcher_stop(
@@ -2284,7 +2629,9 @@ def dispatch_action(
             kill=False,
         )
 
-    conflict_reason = _operator_status_operation_conflict(state, requested_action=action)
+    conflict_reason = _operator_status_operation_conflict(
+        state, requested_action=action
+    )
     if conflict_reason is not None:
         return False, conflict_reason, {"action": action, "operation_conflict": True}
 
@@ -2292,25 +2639,39 @@ def dispatch_action(
         progress = (
             state.progress_monitor.status(check_external=True).to_dict()
             if state.progress_monitor is not None
-            else {"url": state.progress_url, "running": False, "owned_by_console": False}
+            else {
+                "url": state.progress_url,
+                "running": False,
+                "owned_by_console": False,
+            }
         )
-        return True, "progress monitor status", {
-            "action": action,
-            "progress_monitor": progress,
-            "progress_url": progress.get("url") or state.progress_url,
-        }
+        return (
+            True,
+            "progress monitor status",
+            {
+                "action": action,
+                "progress_monitor": progress,
+                "progress_url": progress.get("url") or state.progress_url,
+            },
+        )
 
     if action == "acquire_authority":
         if state.authority.held and state.authority.session_id != session_id:
             return False, "authority is already held by another browser session", {}
         if state.authority.held and state.authority.session_id == session_id:
-            return True, "authority is already held by this browser session", {
-                "necst_held": state.authority.necst_held,
-                "identity": state.authority.necst_identity,
-                "mode": state.authority.mode,
-            }
+            return (
+                True,
+                "authority is already held by this browser session",
+                {
+                    "necst_held": state.authority.necst_held,
+                    "identity": state.authority.necst_identity,
+                    "mode": state.authority.mode,
+                },
+            )
         actions = _load_operator_actions()
-        handle = actions.OperatorAuthoritySession(dry_run=state.action_mode == "dry-run")
+        handle = actions.OperatorAuthoritySession(
+            dry_run=state.action_mode == "dry-run"
+        )
         result = handle.acquire()
         ok, message, data = _result_to_response(result)
         if not ok:
@@ -2318,7 +2679,9 @@ def dispatch_action(
         state.authority_handle = handle
         state.authority.held = True
         state.authority.session_id = session_id
-        state.authority.necst_held = bool(data.get("held")) and state.action_mode != "dry-run"
+        state.authority.necst_held = (
+            bool(data.get("held")) and state.action_mode != "dry-run"
+        )
         state.authority.necst_identity = data.get("identity")
         state.authority.mode = "dry-run" if state.action_mode == "dry-run" else "necst"
         state.authority.note = message
@@ -2355,7 +2718,18 @@ def dispatch_action(
         data["action"] = action
         return ok, message, data
 
-    if action in {"mount_move", "start_tracking", "start_observation", "run_rsky", "run_skydip", "chopper_in", "chopper_out", "chopper_alarm_reset", "chopper_home", "chopper_recover"}:
+    if action in {
+        "mount_move",
+        "start_tracking",
+        "start_observation",
+        "run_rsky",
+        "run_skydip",
+        "chopper_in",
+        "chopper_out",
+        "chopper_alarm_reset",
+        "chopper_home",
+        "chopper_recover",
+    }:
         allowed, reason = _authority_allows(state, session_id)
         if not allowed:
             return False, reason, {"action": action}
@@ -2363,14 +2737,18 @@ def dispatch_action(
     if action == "mount_move_dry_run":
         validate_site_capability(state, "mount_move", action_label="mount move")
         az, el = validate_mount_target(params, state.mount_limits)
-        return True, f"dry-run mount move OK: Az={az:.6f} deg, El={el:.6f} deg; no command was sent", {
-            "action": action,
-            "az_deg": az,
-            "el_deg": el,
-            "unit": "deg",
-            "direct_mode": True,
-            "az_target_mode": "mount",
-        }
+        return (
+            True,
+            f"dry-run mount move OK: Az={az:.6f} deg, El={el:.6f} deg; no command was sent",
+            {
+                "action": action,
+                "az_deg": az,
+                "el_deg": el,
+                "unit": "deg",
+                "direct_mode": True,
+                "az_target_mode": "mount",
+            },
+        )
 
     if action == "mount_move":
         validate_site_capability(state, "mount_move", action_label="mount move")
@@ -2382,15 +2760,19 @@ def dispatch_action(
             state.last_mount_target_el = el
             state.last_mount_target_started_at = time.time()
             state.last_mount_target_reached_since = None
-            return True, f"dry-run mount move: Az={az:.6f} deg, El={el:.6f} deg; no command was sent", {
-                "action": action,
-                "az_deg": az,
-                "el_deg": el,
-                "unit": "deg",
-                "direct_mode": True,
-                "az_target_mode": "mount",
-                "dry_run": True,
-            }
+            return (
+                True,
+                f"dry-run mount move: Az={az:.6f} deg, El={el:.6f} deg; no command was sent",
+                {
+                    "action": action,
+                    "az_deg": az,
+                    "el_deg": el,
+                    "unit": "deg",
+                    "direct_mode": True,
+                    "az_target_mode": "mount",
+                    "dry_run": True,
+                },
+            )
         result = _load_operator_actions().mount_move(
             az,
             el,
@@ -2445,7 +2827,9 @@ def dispatch_action(
         return ok, message, data
 
     if action == "start_tracking":
-        validate_site_capability(state, "target_tracking", action_label="target tracking")
+        validate_site_capability(
+            state, "target_tracking", action_label="target tracking"
+        )
         actions = _load_operator_actions()
         dry_run = state.action_mode == "dry-run"
         result = actions.start_target_tracking(
@@ -2483,7 +2867,11 @@ def dispatch_action(
         if state.action_mode == "dry-run":
             data = {"action": action, "dry_run": True}
             data.update(safety_data)
-            return True, "dry-run Stop tracking: antenna stop command was not sent", data
+            return (
+                True,
+                "dry-run Stop tracking: antenna stop command was not sent",
+                data,
+            )
         result = _load_operator_actions().stop_tracking(
             commander=_any_held_commander(state),
         )
@@ -2525,7 +2913,9 @@ def dispatch_action(
         return ok, message, data
 
     if action == "start_observation":
-        validate_site_capability(state, "observation_start", action_label="observation start")
+        validate_site_capability(
+            state, "observation_start", action_label="observation start"
+        )
         mode, path, channel = validate_observation_selection(params)
         dry_run = state.action_mode == "dry-run"
         actions = _load_operator_actions()
@@ -2699,17 +3089,23 @@ def dispatch_action(
     if action == "chopper_status":
         validate_site_capability(state, "chopper_status", action_label="chopper status")
         if state.action_mode == "dry-run":
-            return True, "dry-run chopper status: no telemetry query was sent", {
-                "action": action,
-                "dry_run": True,
-                "site_config": state.site_summary.to_dict(),
-            }
+            return (
+                True,
+                "dry-run chopper status: no telemetry query was sent",
+                {
+                    "action": action,
+                    "dry_run": True,
+                    "site_config": state.site_summary.to_dict(),
+                },
+            )
         result = _load_operator_actions().chopper_status(
             commander=_held_commander_for_session(state, session_id),
         )
         ok, message, data = _result_to_response(result)
         if ok:
-            state.last_chopper_state = str(data.get("state") or state.last_chopper_state)
+            state.last_chopper_state = str(
+                data.get("state") or state.last_chopper_state
+            )
         return ok, message, data
 
     if action in {"chopper_in", "chopper_out"}:
@@ -2718,7 +3114,11 @@ def dispatch_action(
         if state.action_mode == "dry-run":
             data = chopper_dry_run_payload(state, command)
             data.update({"action": action, "dry_run": True})
-            return True, f"dry-run chopper {command.upper()}: command was not sent", data
+            return (
+                True,
+                f"dry-run chopper {command.upper()}: command was not sent",
+                data,
+            )
         result = _load_operator_actions().chopper_move(
             command,
             wait=False,
@@ -2741,11 +3141,15 @@ def dispatch_action(
             "chopper_recover": "recover",
         }[action]
         if state.action_mode == "dry-run":
-            return True, f"dry-run chopper {maintenance}: command was not sent", {
-                "action": action,
-                "dry_run": True,
-                "command": maintenance,
-            }
+            return (
+                True,
+                f"dry-run chopper {maintenance}: command was not sent",
+                {
+                    "action": action,
+                    "dry_run": True,
+                    "command": maintenance,
+                },
+            )
         result = _load_operator_actions().chopper_maintenance(
             maintenance,
             commander=_held_commander_for_session(state, session_id),
@@ -2760,7 +3164,9 @@ def _operator_status_to_v7_status(
 ) -> JsonDict:
     """Adapt canonical operator_status to the v7 console-demo JSON shape."""
 
-    op = status_state.get("operator_status") if isinstance(status_state, Mapping) else {}
+    op = (
+        status_state.get("operator_status") if isinstance(status_state, Mapping) else {}
+    )
     if not isinstance(op, Mapping):
         op = {}
     system = op.get("system") if isinstance(op.get("system"), Mapping) else {}
@@ -2768,7 +3174,9 @@ def _operator_status_to_v7_status(
     antenna = op.get("antenna") if isinstance(op.get("antenna"), Mapping) else {}
     chopper = op.get("chopper") if isinstance(op.get("chopper"), Mapping) else {}
     progress = op.get("progress") if isinstance(op.get("progress"), Mapping) else {}
-    observation = op.get("observation") if isinstance(op.get("observation"), Mapping) else {}
+    observation = (
+        op.get("observation") if isinstance(op.get("observation"), Mapping) else {}
+    )
     paths = op.get("paths") if isinstance(op.get("paths"), Mapping) else {}
     warnings = op.get("warnings") if isinstance(op.get("warnings"), list) else []
 
@@ -2787,7 +3195,9 @@ def _operator_status_to_v7_status(
         )
     }
     stale_observation = _stale_observation_state(state, status_state, op)
-    if stale_observation.get("running_stale") or stale_observation.get("launcher_stuck"):
+    if stale_observation.get("running_stale") or stale_observation.get(
+        "launcher_stuck"
+    ):
         sys_state = "stale_observation"
         warnings = list(warnings) + [
             stale_observation.get("reason")
@@ -2815,7 +3225,11 @@ def _operator_status_to_v7_status(
         # stale fallback made the Manual panel keep showing "moving" after
         # an abort or after the command/status topics disappeared.  Dry-run
         # still uses the local action memory because there are no live topics.
-        active_task = str(state.last_active_task or "none") if state.action_mode == "dry-run" else "none"
+        active_task = (
+            str(state.last_active_task or "none")
+            if state.action_mode == "dry-run"
+            else "none"
+        )
     else:
         active_task = raw_active_task
     if active_task.lower() in {"", "idle", "unknown"}:
@@ -2825,7 +3239,11 @@ def _operator_status_to_v7_status(
     if motion_at_target_idle:
         raw_manual_state = "idle"
     if raw_manual_state.lower() in {"", "idle", "none", "unknown"}:
-        manual_state = str(state.last_manual_state or "idle") if state.action_mode == "dry-run" else "idle"
+        manual_state = (
+            str(state.last_manual_state or "idle")
+            if state.action_mode == "dry-run"
+            else "idle"
+        )
     else:
         manual_state = raw_manual_state
     if manual_state.lower() in {"", "none", "unknown"}:
@@ -2857,7 +3275,15 @@ def _operator_status_to_v7_status(
     motion_source_lower = str(motion.get("live_motion_source") or "").strip().lower()
     operator_mount_target_reached = False
     operator_mount_target_idle = False
-    if state.action_mode != "dry-run" and sys_state in {"", "idle", "unknown", "finished", "aborted", "error", "failed"}:
+    if state.action_mode != "dry-run" and sys_state in {
+        "",
+        "idle",
+        "unknown",
+        "finished",
+        "aborted",
+        "error",
+        "failed",
+    }:
         operator_mount_target_reached = _last_mount_target_reached(
             state,
             current_az=az,
@@ -2892,7 +3318,8 @@ def _operator_status_to_v7_status(
     safety_release_idle = bool(
         state.action_mode != "dry-run"
         and safety_release_age is not None
-        and sys_state in {"", "idle", "unknown", "finished", "aborted", "error", "failed"}
+        and sys_state
+        in {"", "idle", "unknown", "finished", "aborted", "error", "failed"}
         and command_absent
         and safety_release_age >= SAFETY_RELEASE_ASSUME_IDLE_AFTER_SEC
     )
@@ -2935,7 +3362,9 @@ def _operator_status_to_v7_status(
         motion_source_lower = "operator_command_target_pending"
 
     if state.action_mode == "dry-run":
-        chopper_state = str(chopper.get("state") or state.last_chopper_state or "unknown")
+        chopper_state = str(
+            chopper.get("state") or state.last_chopper_state or "unknown"
+        )
         chopper_position = chopper.get("position")
         if chopper_position is None:
             chopper_position = state.last_chopper_position
@@ -2961,7 +3390,9 @@ def _operator_status_to_v7_status(
         if state.progress_monitor is not None
         else {"url": state.progress_url, "running": False, "owned_by_console": False}
     )
-    progress_running = bool(monitor_status.get("running")) or bool(observation_progress_running)
+    progress_running = bool(monitor_status.get("running")) or bool(
+        observation_progress_running
+    )
 
     return {
         "telescope": state.telescope,
@@ -3008,10 +3439,15 @@ def _operator_status_to_v7_status(
         "observation": {
             "record_name": observation.get("record_name"),
             "obs_file": observation.get("obs_file"),
-            "recording_dir": observation.get("recording_dir") or paths.get("recording_dir"),
-            "local_recording_dir": observation.get("local_recording_dir") or paths.get("local_recording_dir"),
-            "record_path_display_mode": observation.get("record_path_display_mode") or paths.get("record_path_display_mode") or "local",
-            "progress_record_dir": observation.get("progress_record_dir") or paths.get("progress_record_dir"),
+            "recording_dir": observation.get("recording_dir")
+            or paths.get("recording_dir"),
+            "local_recording_dir": observation.get("local_recording_dir")
+            or paths.get("local_recording_dir"),
+            "record_path_display_mode": observation.get("record_path_display_mode")
+            or paths.get("record_path_display_mode")
+            or "local",
+            "progress_record_dir": observation.get("progress_record_dir")
+            or paths.get("progress_record_dir"),
         },
         "authority": {
             "held": state.authority.held,
@@ -3026,7 +3462,12 @@ def _operator_status_to_v7_status(
                 else "already_free"
             ),
             "safety_actions_bypass_browser_gate": True,
-            "safety_actions": ["stop", "stop_tracking", "abort_observation", "terminate_*_launcher"],
+            "safety_actions": [
+                "stop",
+                "stop_tracking",
+                "abort_observation",
+                "terminate_*_launcher",
+            ],
         },
         "mount_limits": dict(state.mount_limits),
         "site": state.site_summary.to_dict(),
@@ -3034,7 +3475,9 @@ def _operator_status_to_v7_status(
         "warning_count": len(warnings) + len(state.site_summary.warnings),
         "warnings": list(warnings) + list(state.site_summary.warnings),
         "log": [entry.__dict__ for entry in state.log],
-        "processes": [r.to_dict() for r in state.process_registry.all_records(refresh=False)],
+        "processes": [
+            r.to_dict() for r in state.process_registry.all_records(refresh=False)
+        ],
         "process_counts": state.process_registry.counts(),
         "exclusive_start_guard": {
             "action": state.exclusive_start_action,
@@ -3049,15 +3492,25 @@ def _operator_status_to_v7_status(
             "guard_sec": EXCLUSIVE_START_STATUS_SEC,
             "blocking_sec": EXCLUSIVE_START_BLOCK_SEC,
         },
-        "launcher_log_choices": log_reader.launcher_log_choices([
-            r.to_dict() for r in state.process_registry.all_records(refresh=False)
-        ]),
+        "launcher_log_choices": log_reader.launcher_log_choices(
+            [r.to_dict() for r in state.process_registry.all_records(refresh=False)]
+        ),
         "last_launcher_failure": dict(state.last_launcher_failure or {}),
         "shutdown": _shutdown_snapshot(state),
         "self_check_endpoint": "/api/self-check",
-        "operator_log_path": str(state.operator_log_path) if state.operator_log_path is not None else None,
-        "launcher_log_dir": str(state.launcher_log_dir) if state.launcher_log_dir is not None else None,
-        "observation_log": (state.observation_log.status() if state.observation_log is not None else {"ok": False}),
+        "operator_log_path": (
+            str(state.operator_log_path)
+            if state.operator_log_path is not None
+            else None
+        ),
+        "launcher_log_dir": (
+            str(state.launcher_log_dir) if state.launcher_log_dir is not None else None
+        ),
+        "observation_log": (
+            state.observation_log.status()
+            if state.observation_log is not None
+            else {"ok": False}
+        ),
         "action_mode": state.action_mode,
         "live_actions": {
             "enabled": bool(state.live_actions_enabled),
@@ -3089,7 +3542,9 @@ def _build_console_status_unchecked(state: OperatorConsoleState) -> JsonDict:
         _refresh_processes_and_log(state)
         _sync_authority_state(state)
         _prune_exclusive_start_guard(state)
-        live_payload = state.live_cache.snapshot() if state.live_cache is not None else None
+        live_payload = (
+            state.live_cache.snapshot() if state.live_cache is not None else None
+        )
         status_state = status_model.build_progress_status_state(
             state.progress_root,
             events_limit=state.events_limit,
@@ -3105,7 +3560,10 @@ def _build_console_status_unchecked(state: OperatorConsoleState) -> JsonDict:
             payload["warning_count"] = len(payload.get("warnings") or [])
         payload["node_health"] = _node_health_snapshot(state)
         if state.local_state_reset_archive:
-            payload["local_state_reset"] = dict(state.local_state_reset_summary or {"archive_dir": state.local_state_reset_archive})
+            payload["local_state_reset"] = dict(
+                state.local_state_reset_summary
+                or {"archive_dir": state.local_state_reset_archive}
+            )
         return payload
 
 
@@ -3154,12 +3612,14 @@ def _node_health_snapshot(state: OperatorConsoleState) -> JsonDict:
     try:
         missing_required = tuple(payload.get("missing_required") or [])
         missing_optional = tuple(payload.get("missing_optional") or [])
-        event_key = "|".join([
-            str(payload.get("system") or ""),
-            ",".join(missing_required),
-            ",".join(missing_optional),
-            str(payload.get("error") or ""),
-        ])
+        event_key = "|".join(
+            [
+                str(payload.get("system") or ""),
+                ",".join(missing_required),
+                ",".join(missing_optional),
+                str(payload.get("error") or ""),
+            ]
+        )
         if event_key != state.last_node_health_event_key:
             state.last_node_health_event_key = event_key
             if payload.get("system") in {"NG", "UNKNOWN"} or missing_optional:
@@ -3195,7 +3655,9 @@ def _node_health_rescue_payload(state: OperatorConsoleState, message: str) -> Js
     )
 
 
-def build_minimal_rescue_status(state: OperatorConsoleState, exc: BaseException) -> JsonDict:
+def build_minimal_rescue_status(
+    state: OperatorConsoleState, exc: BaseException
+) -> JsonDict:
     """Return a status payload that is deliberately hard to break.
 
     The browser must keep showing STOP/ABORT and local recovery controls even if
@@ -3210,9 +3672,19 @@ def build_minimal_rescue_status(state: OperatorConsoleState, exc: BaseException)
         process_counts = state.process_registry.counts()
     except Exception as proc_exc:
         processes = []
-        process_counts = {"total": 0, "active": 0, "finished": 0, "by_category": {}, "error": str(proc_exc)}
+        process_counts = {
+            "total": 0,
+            "active": 0,
+            "finished": 0,
+            "by_category": {},
+            "error": str(proc_exc),
+        }
     try:
-        obslog_status = state.observation_log.status() if state.observation_log is not None else {"ok": False}
+        obslog_status = (
+            state.observation_log.status()
+            if state.observation_log is not None
+            else {"ok": False}
+        )
     except Exception as log_exc:
         obslog_status = {"ok": False, "last_error": str(log_exc)}
     try:
@@ -3228,7 +3700,11 @@ def build_minimal_rescue_status(state: OperatorConsoleState, exc: BaseException)
     except Exception:
         mount_limits = {}
     try:
-        progress_status = state.progress_monitor.status().to_dict() if state.progress_monitor is not None else {}
+        progress_status = (
+            state.progress_monitor.status().to_dict()
+            if state.progress_monitor is not None
+            else {}
+        )
     except Exception as progress_exc:
         progress_status = {"status": "error", "message": str(progress_exc)}
     warnings = [
@@ -3263,7 +3739,12 @@ def build_minimal_rescue_status(state: OperatorConsoleState, exc: BaseException)
             "necst_held": bool(getattr(state.authority, "necst_held", False)),
             "mode": getattr(state.authority, "mode", "unknown"),
             "safety_actions_bypass_browser_gate": True,
-            "safety_actions": ["stop", "stop_tracking", "abort_observation", "terminate_*_launcher"],
+            "safety_actions": [
+                "stop",
+                "stop_tracking",
+                "abort_observation",
+                "terminate_*_launcher",
+            ],
         },
         "chopper": {
             "state": getattr(state, "last_chopper_state", "unknown") or "unknown",
@@ -3283,22 +3764,36 @@ def build_minimal_rescue_status(state: OperatorConsoleState, exc: BaseException)
         "processes": processes,
         "process_counts": process_counts,
         "launcher_log_choices": [],
-        "last_launcher_failure": dict(getattr(state, "last_launcher_failure", {}) or {}),
+        "last_launcher_failure": dict(
+            getattr(state, "last_launcher_failure", {}) or {}
+        ),
         "shutdown": _shutdown_snapshot(state),
         "self_check_endpoint": "/api/self-check",
-        "operator_log_path": str(state.operator_log_path) if state.operator_log_path is not None else None,
-        "launcher_log_dir": str(state.launcher_log_dir) if state.launcher_log_dir is not None else None,
+        "operator_log_path": (
+            str(state.operator_log_path)
+            if state.operator_log_path is not None
+            else None
+        ),
+        "launcher_log_dir": (
+            str(state.launcher_log_dir) if state.launcher_log_dir is not None else None
+        ),
         "observation_log": obslog_status,
         "action_mode": state.action_mode,
         "live_actions": {
             "enabled": bool(state.live_actions_enabled),
-            "guarded": state.action_mode == "live" and not bool(state.live_actions_enabled),
+            "guarded": state.action_mode == "live"
+            and not bool(state.live_actions_enabled),
             "write_actions": sorted(LIVE_WRITE_ACTIONS),
             "safety_actions": sorted(SAFETY_ACTIONS),
             "message": "minimal rescue status after status builder failure",
         },
         "status_refresh_ms": int(state.status_refresh_ms),
-        "live_telemetry": {"requested": not bool(state.status_no_ros), "available": False, "spin_mode": "rescue", "error": message},
+        "live_telemetry": {
+            "requested": not bool(state.status_no_ros),
+            "available": False,
+            "spin_mode": "rescue",
+            "error": message,
+        },
         "node_health": _node_health_rescue_payload(state, message),
         "operator_status": {},
         "status_error": {"message": message, "time": now},
@@ -3322,7 +3817,11 @@ def build_console_status(state: OperatorConsoleState) -> JsonDict:
                 if message != last or (time.time() - last_at) > 30.0:
                     state.last_status_exception_message = message
                     state.last_status_exception_at = time.time()
-                    state.add_log(False, f"normal status generation failed; using minimal rescue status: {message}", action="status_rescue")
+                    state.add_log(
+                        False,
+                        f"normal status generation failed; using minimal rescue status: {message}",
+                        action="status_rescue",
+                    )
         except Exception:
             pass
         return build_minimal_rescue_status(state, exc)
@@ -3371,7 +3870,9 @@ class OperatorConsoleHTTPServer(ThreadingHTTPServer):
     ) -> None:
         super().__init__(server_address, handler_class)
         self.state = state
-        self.html = html if html is not None else load_demo_html(state.status_refresh_ms)
+        self.html = (
+            html if html is not None else load_demo_html(state.status_refresh_ms)
+        )
 
 
 class OperatorConsoleHandler(BaseHTTPRequestHandler):
@@ -3389,7 +3890,9 @@ class OperatorConsoleHandler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(body)
 
-    def _send_text(self, text: str, content_type: str = "text/html; charset=utf-8") -> None:
+    def _send_text(
+        self, text: str, content_type: str = "text/html; charset=utf-8"
+    ) -> None:
         body = text.encode("utf-8")
         self.send_response(200)
         self.send_header("Content-Type", content_type)
@@ -3402,18 +3905,26 @@ class OperatorConsoleHandler(BaseHTTPRequestHandler):
             self._send_text(self.server.html)
             return
         if self.path == "/health":
-            self._send_json({
-                "ok": True,
-                "action_mode": self.server.state.action_mode,
-                "live_actions_enabled": bool(self.server.state.live_actions_enabled),
-                "status_refresh_ms": int(self.server.state.status_refresh_ms),
-            })
+            self._send_json(
+                {
+                    "ok": True,
+                    "action_mode": self.server.state.action_mode,
+                    "live_actions_enabled": bool(
+                        self.server.state.live_actions_enabled
+                    ),
+                    "status_refresh_ms": int(self.server.state.status_refresh_ms),
+                }
+            )
             return
         if self.path == "/api/status":
             self._send_json(build_console_status(self.server.state))
             return
         if self.path == "/api/rescue/status":
-            self._send_json(build_minimal_rescue_status(self.server.state, RuntimeError("rescue status requested")))
+            self._send_json(
+                build_minimal_rescue_status(
+                    self.server.state, RuntimeError("rescue status requested")
+                )
+            )
             return
         parsed = urllib.parse.urlparse(self.path)
         query = urllib.parse.parse_qs(parsed.query)
@@ -3423,22 +3934,36 @@ class OperatorConsoleHandler(BaseHTTPRequestHandler):
         if parsed.path == "/api/obs-list":
             try:
                 directory = (query.get("dir") or [""])[0]
-                self._send_json(list_server_obs_files(self.server.state.obs_roots, directory))
+                self._send_json(
+                    list_server_obs_files(self.server.state.obs_roots, directory)
+                )
             except Exception as exc:
-                self._send_json({"ok": False, "reason": str(exc), "entries": []}, status=400)
+                self._send_json(
+                    {"ok": False, "reason": str(exc), "entries": []}, status=400
+                )
             return
         if parsed.path == "/api/obs-preview":
             try:
                 path = (query.get("path") or [""])[0]
                 max_bytes = int((query.get("max_bytes") or [65536])[0])
-                self._send_json(preview_server_obs_file(self.server.state.obs_roots, path, max_bytes=max_bytes))
+                self._send_json(
+                    preview_server_obs_file(
+                        self.server.state.obs_roots, path, max_bytes=max_bytes
+                    )
+                )
             except Exception as exc:
-                self._send_json({"ok": False, "reason": str(exc), "text": ""}, status=400)
+                self._send_json(
+                    {"ok": False, "reason": str(exc), "text": ""}, status=400
+                )
             return
         if self.path == "/api/operator-status":
             state = self.server.state
             try:
-                live_payload = state.live_cache.snapshot() if state.live_cache is not None else None
+                live_payload = (
+                    state.live_cache.snapshot()
+                    if state.live_cache is not None
+                    else None
+                )
                 status_state = status_model.build_progress_status_state(
                     state.progress_root,
                     events_limit=state.events_limit,
@@ -3446,33 +3971,56 @@ class OperatorConsoleHandler(BaseHTTPRequestHandler):
                 )
                 self._send_json(status_state.get("operator_status", {}))
             except Exception as exc:
-                self._send_json({"ok": False, "reason": str(exc), "operator_status": {}}, status=200)
+                self._send_json(
+                    {"ok": False, "reason": str(exc), "operator_status": {}}, status=200
+                )
             return
         if parsed.path == "/api/processes":
             state = self.server.state
             with state.lock:
                 _refresh_processes_and_log(state)
-                process_records = [r.to_dict() for r in state.process_registry.all_records(refresh=False)]
-                self._send_json({
-                    "processes": process_records,
-                    "process_counts": state.process_registry.counts(),
-                    "launcher_log_choices": log_reader.launcher_log_choices(process_records),
-                    "progress_monitor": (
-                        state.progress_monitor.status(check_external=True).to_dict()
-                        if state.progress_monitor is not None
-                        else {"url": state.progress_url, "running": False, "owned_by_console": False}
-                    ),
-                    "shutdown": _shutdown_snapshot(state),
-                    "operator_log_path": str(state.operator_log_path) if state.operator_log_path is not None else None,
-                    "launcher_log_dir": str(state.launcher_log_dir) if state.launcher_log_dir is not None else None,
-                })
+                process_records = [
+                    r.to_dict()
+                    for r in state.process_registry.all_records(refresh=False)
+                ]
+                self._send_json(
+                    {
+                        "processes": process_records,
+                        "process_counts": state.process_registry.counts(),
+                        "launcher_log_choices": log_reader.launcher_log_choices(
+                            process_records
+                        ),
+                        "progress_monitor": (
+                            state.progress_monitor.status(check_external=True).to_dict()
+                            if state.progress_monitor is not None
+                            else {
+                                "url": state.progress_url,
+                                "running": False,
+                                "owned_by_console": False,
+                            }
+                        ),
+                        "shutdown": _shutdown_snapshot(state),
+                        "operator_log_path": (
+                            str(state.operator_log_path)
+                            if state.operator_log_path is not None
+                            else None
+                        ),
+                        "launcher_log_dir": (
+                            str(state.launcher_log_dir)
+                            if state.launcher_log_dir is not None
+                            else None
+                        ),
+                    }
+                )
             return
         if parsed.path == "/api/operator-log":
             state = self.server.state
             with state.lock:
                 _refresh_processes_and_log(state)
                 limit = (query.get("limit") or [100])[0]
-                self._send_json(log_reader.read_operator_log(state.operator_log_path, limit=limit))
+                self._send_json(
+                    log_reader.read_operator_log(state.operator_log_path, limit=limit)
+                )
             return
         if parsed.path == "/api/log-file":
             state = self.server.state
@@ -3480,15 +4028,20 @@ class OperatorConsoleHandler(BaseHTTPRequestHandler):
                 path = (query.get("path") or [""])[0]
                 max_bytes = (query.get("max_bytes") or [32768])[0]
                 extra_roots = []
-                if state.progress_monitor is not None and getattr(state.progress_monitor, "log_dir", None) is not None:
+                if (
+                    state.progress_monitor is not None
+                    and getattr(state.progress_monitor, "log_dir", None) is not None
+                ):
                     extra_roots.append(Path(state.progress_monitor.log_dir))
-                self._send_json(log_reader.read_text_log(
-                    path,
-                    launcher_log_dir=state.launcher_log_dir,
-                    operator_log_path=state.operator_log_path,
-                    max_bytes=max_bytes,
-                    extra_roots=extra_roots,
-                ))
+                self._send_json(
+                    log_reader.read_text_log(
+                        path,
+                        launcher_log_dir=state.launcher_log_dir,
+                        operator_log_path=state.operator_log_path,
+                        max_bytes=max_bytes,
+                        extra_roots=extra_roots,
+                    )
+                )
             return
         if parsed.path == "/api/self-check":
             state = self.server.state
@@ -3509,7 +4062,9 @@ class OperatorConsoleHandler(BaseHTTPRequestHandler):
             self._send_json({"ok": False, "reason": f"invalid JSON: {exc}"}, status=400)
             return
         action = str(payload.get("action") or "")
-        params = payload.get("params") if isinstance(payload.get("params"), dict) else {}
+        params = (
+            payload.get("params") if isinstance(payload.get("params"), dict) else {}
+        )
         session_id = str(payload.get("session_id") or uuid.uuid4())
         with self.server.state.lock:
             try:
@@ -3524,8 +4079,14 @@ class OperatorConsoleHandler(BaseHTTPRequestHandler):
                     session_id,
                 )
             except Exception as exc:
-                ok, reason, data = False, str(exc), {"exception_type": type(exc).__name__}
-            self.server.state.add_log(ok, reason, action=action, session_id=session_id, data=data)
+                ok, reason, data = (
+                    False,
+                    str(exc),
+                    {"exception_type": type(exc).__name__},
+                )
+            self.server.state.add_log(
+                ok, reason, action=action, session_id=session_id, data=data
+            )
             if isinstance(data, Mapping):
                 _write_observation_log_for_action(
                     self.server.state,
@@ -3541,7 +4102,6 @@ class OperatorConsoleHandler(BaseHTTPRequestHandler):
             elif data.get("url") is not None and action == "launch_progress":
                 response["progress_url"] = data.get("url")
         self._send_json(response)
-
 
 
 def _run_shutdown_cleanup(state: OperatorConsoleState) -> JsonDict:
@@ -3564,7 +4124,9 @@ def _run_shutdown_cleanup(state: OperatorConsoleState) -> JsonDict:
 
     ok, message, data = _release_console_authority(state, force=True)
     summary["authority"] = {"ok": ok, "message": message, "data": data}
-    state.add_log(ok, f"console shutdown: {message}", action="authority_release", data=data)
+    state.add_log(
+        ok, f"console shutdown: {message}", action="authority_release", data=data
+    )
 
     if state.shutdown_terminate_launchers:
         launcher_summary = state.process_registry.graceful_shutdown(
@@ -3620,6 +4182,7 @@ def _run_shutdown_cleanup(state: OperatorConsoleState) -> JsonDict:
     state.cleanup_summary = summary
     return summary
 
+
 def run_server(
     *,
     host: str,
@@ -3671,7 +4234,11 @@ def run_server(
     resolved_operator_log_dir = (
         Path(operator_log_dir).expanduser()
         if operator_log_dir not in (None, "")
-        else Path(os.environ.get("NECST_OPERATOR_LOG_DIR", Path.home() / ".necst" / "operator_console")).expanduser()
+        else Path(
+            os.environ.get(
+                "NECST_OPERATOR_LOG_DIR", Path.home() / ".necst" / "operator_console"
+            )
+        ).expanduser()
     )
     resolved_launcher_log_dir = (
         Path(launcher_log_dir)
@@ -3695,7 +4262,8 @@ def run_server(
         local_state_reset_summary = reset_local_console_state_files(
             progress_root=progress_root,
             operator_log_dir=resolved_operator_log_dir,
-            reason="console startup --reset-local-state" + ("/--rescue" if rescue else ""),
+            reason="console startup --reset-local-state"
+            + ("/--rescue" if rescue else ""),
         )
     resolved_obs_roots = resolve_obs_roots(obs_roots)
     obslog_site_config = dict(getattr(site_summary, "observation_log", {}) or {})
@@ -3761,11 +4329,19 @@ def run_server(
         shutdown_launcher_kill_timeout_sec=float(shutdown_launcher_kill_timeout_sec),
         safe_start=bool(safe_start),
         rescue_mode=bool(rescue),
-        local_state_reset_archive=str(local_state_reset_summary.get("archive_dir") or ""),
+        local_state_reset_archive=str(
+            local_state_reset_summary.get("archive_dir") or ""
+        ),
         local_state_reset_summary=dict(local_state_reset_summary),
     )
-    state.live_cache = live_telemetry.LiveTelemetryCache(enabled=not bool(status_no_ros))
-    if state.live_cache is not None and state.live_cache.available and not bool(safe_start):
+    state.live_cache = live_telemetry.LiveTelemetryCache(
+        enabled=not bool(status_no_ros)
+    )
+    if (
+        state.live_cache is not None
+        and state.live_cache.available
+        and not bool(safe_start)
+    ):
         # Wait briefly for the first encoder/pointing sample so the console
         # starts with real Current Az/El whenever ROS status topics are alive.
         # This is read-only; it does not send any telescope command.
@@ -3773,7 +4349,11 @@ def run_server(
             state.live_cache.wait_for_initial_position(timeout_sec=2.0)
         except Exception as exc:
             state.live_cache.error = f"initial live telemetry wait failed: {exc}"
-    state.add_log(True, f"console started in action_mode={action_mode}" + (" (safe/rescue mode)" if (safe_start or rescue) else ""))
+    state.add_log(
+        True,
+        f"console started in action_mode={action_mode}"
+        + (" (safe/rescue mode)" if (safe_start or rescue) else ""),
+    )
     if safe_start or rescue:
         state.add_log(
             True,
@@ -3793,7 +4373,9 @@ def run_server(
                 {},
                 mode="Console",
                 event="local_state_reset",
-                action_or_obsfile=str(local_state_reset_summary.get("archive_dir") or ""),
+                action_or_obsfile=str(
+                    local_state_reset_summary.get("archive_dir") or ""
+                ),
                 result="success" if local_state_reset_summary.get("ok") else "failed",
                 comment="startup reset; no hardware command sent",
             )
@@ -3820,7 +4402,8 @@ def run_server(
     state.add_log(
         bool(resolved_obs_roots),
         (
-            "NECST-side file chooser locations configured: " + ", ".join(str(p) for p in resolved_obs_roots)
+            "NECST-side file chooser locations configured: "
+            + ", ".join(str(p) for p in resolved_obs_roots)
             if resolved_obs_roots
             else "NECST-side file chooser found no existing locations; check filesystem permissions or use --obs-root"
         ),
@@ -3844,17 +4427,29 @@ def run_server(
                 data={"sample_counts": live_snapshot.get("sample_counts", {})},
             )
         else:
-            state.add_log(False, f"live telemetry unavailable: {live_snapshot.get('error', 'disabled')}", action="live_telemetry")
+            state.add_log(
+                False,
+                f"live telemetry unavailable: {live_snapshot.get('error', 'disabled')}",
+                action="live_telemetry",
+            )
     if action_mode == "live" and not live_actions_enabled:
         state.add_log(False, LIVE_ACTION_GUARD_MESSAGE, action="live_write_guard")
     if action_mode == "live" and live_actions_enabled:
-        state.add_log(True, "live write actions enabled by default in live mode", action="live_write_guard")
+        state.add_log(
+            True,
+            "live write actions enabled by default in live mode",
+            action="live_write_guard",
+        )
     state.add_log(
         True,
         "site config: "
         f"source={site_summary.source}"
         + (f", path={site_summary.source_path}" if site_summary.source_path else "")
-        + (f", observatory={site_summary.observatory}" if site_summary.observatory else ""),
+        + (
+            f", observatory={site_summary.observatory}"
+            if site_summary.observatory
+            else ""
+        ),
     )
     if site_summary.health.enabled:
         state.add_log(
@@ -3866,7 +4461,9 @@ def run_server(
     for warning in site_summary.warnings:
         state.add_log(False, warning)
     if not limits:
-        state.add_log(False, "site TOML mount limits are unavailable; mount move will be rejected")
+        state.add_log(
+            False, "site TOML mount limits are unavailable; mount move will be rejected"
+        )
 
     server = OperatorConsoleHTTPServer(
         (str(host), int(port)),
@@ -3884,15 +4481,23 @@ def run_server(
     print(f"  safe start: {bool(safe_start)}")
     print(f"  rescue mode: {bool(rescue)}")
     if local_state_reset_summary:
-        print(f"  local state reset archive: {local_state_reset_summary.get('archive_dir')}")
+        print(
+            f"  local state reset archive: {local_state_reset_summary.get('archive_dir')}"
+        )
     if action_mode == "live" and not live_actions_enabled:
-        print("  live write guard: ON by --guard-live-actions (write actions blocked; STOP/ABORT remain available)")
+        print(
+            "  live write guard: ON by --guard-live-actions (write actions blocked; STOP/ABORT remain available)"
+        )
     print(f"  status refresh: {max(200, int(status_refresh_ms))} ms")
     print(f"  console live telemetry ROS: {'disabled' if status_no_ros else 'enabled'}")
-    print(f"  ROS node health monitor: {'enabled' if site_summary.health.enabled else 'disabled'}")
+    print(
+        f"  ROS node health monitor: {'enabled' if site_summary.health.enabled else 'disabled'}"
+    )
     print(f"  operator log: {operator_log_path}")
     print(f"  observation CSV log: {observer_csv_log.status().get('csv_path')}")
-    print(f"  observation CSV log source: {observer_csv_log.status().get('log_dir_source')}")
+    print(
+        f"  observation CSV log source: {observer_csv_log.status().get('log_dir_source')}"
+    )
     print(f"  observation CSV meta: {observer_csv_log.status().get('meta_path')}")
     print(f"  launcher logs: {resolved_launcher_log_dir}")
     print(f"  progress logs: {resolved_progress_log_dir}")
@@ -3902,7 +4507,10 @@ def run_server(
         f"timeout={float(shutdown_launcher_timeout_sec)}s, "
         f"kill_timeout={float(shutdown_launcher_kill_timeout_sec)}s"
     )
-    print(f"  site config source: {site_summary.source}" + (f" ({site_summary.source_path})" if site_summary.source_path else ""))
+    print(
+        f"  site config source: {site_summary.source}"
+        + (f" ({site_summary.source_path})" if site_summary.source_path else "")
+    )
     print(f"  observatory: {site_summary.observatory or 'unknown'}")
     if limits:
         print(
@@ -3928,7 +4536,9 @@ def run_server(
         except Exception:
             pass
 
-    thread = threading.Thread(target=server.serve_forever, name="necst-console", daemon=True)
+    thread = threading.Thread(
+        target=server.serve_forever, name="necst-console", daemon=True
+    )
     thread.start()
     event = stop_event or threading.Event()
     try:
@@ -3944,17 +4554,29 @@ def run_server(
             try:
                 _refresh_processes_and_log(state)
             except Exception as exc:
-                state.add_log(False, f"failed to refresh launcher exits during shutdown: {exc}", action="process_exit")
+                state.add_log(
+                    False,
+                    f"failed to refresh launcher exits during shutdown: {exc}",
+                    action="process_exit",
+                )
             if state.observation_log is not None:
                 try:
                     state.observation_log.close(write_log_closed=True)
                 except Exception as exc:
-                    state.add_log(False, f"failed to close observation CSV log: {exc}", action="observation_csv_log")
+                    state.add_log(
+                        False,
+                        f"failed to close observation CSV log: {exc}",
+                        action="observation_csv_log",
+                    )
             if state.live_cache is not None:
                 try:
                     state.live_cache.close()
                 except Exception as exc:
-                    state.add_log(False, f"failed to close live telemetry cache: {exc}", action="live_telemetry")
+                    state.add_log(
+                        False,
+                        f"failed to close live telemetry cache: {exc}",
+                        action="live_telemetry",
+                    )
         server.shutdown()
         server.server_close()
         thread.join(timeout=2.0)

--- a/necst/web/process_manager.py
+++ b/necst/web/process_manager.py
@@ -1,0 +1,397 @@
+"""Subprocess lifecycle helpers for the NECST Operator Console.
+
+The operator console starts observation and calibration launchers as child
+processes so HTTP requests return immediately.  This module keeps the small
+piece of lifecycle state needed by the console:
+
+* reject accidental duplicate launcher starts;
+* remember PID, command, cwd, and stdout/stderr log paths;
+* reap child processes without blocking;
+* expose a JSON-serialisable status snapshot.
+
+It intentionally does not send telescope commands.  ABORT/STOP remain normal
+operator actions handled elsewhere.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
+
+
+_RUNNING_STATES = {"running", "terminating", "killing"}
+_FINAL_STATES = {"exited", "lost", "unknown"}
+
+
+def _now() -> float:
+    return time.time()
+
+
+def _iso_timestamp(ts: Optional[float] = None) -> str:
+    value = _now() if ts is None else float(ts)
+    return time.strftime("%Y-%m-%dT%H:%M:%S%z", time.localtime(value))
+
+
+def _safe_name(text: str) -> str:
+    out = []
+    for ch in str(text or "process"):
+        if ch.isalnum() or ch in {"-", "_"}:
+            out.append(ch)
+        else:
+            out.append("_")
+    name = "".join(out).strip("_")
+    return name or "process"
+
+
+@dataclass
+class ManagedProcessRecord:
+    """One launcher process started by the operator console."""
+
+    pid: int
+    action: str
+    category: str
+    command: List[str]
+    cwd: str
+    started_at: float = field(default_factory=_now)
+    stdout_path: Optional[str] = None
+    stderr_path: Optional[str] = None
+    label: str = "launcher"
+    status: str = "running"
+    returncode: Optional[int] = None
+    ended_at: Optional[float] = None
+    final_logged: bool = False
+    termination_requested_at: Optional[float] = None
+    termination_signal: Optional[str] = None
+    termination_reason: Optional[str] = None
+    data: Dict[str, Any] = field(default_factory=dict)
+    popen: Any = None
+
+    def is_active(self) -> bool:
+        return self.status in _RUNNING_STATES
+
+    def to_dict(self) -> Dict[str, Any]:
+        duration = None
+        end = self.ended_at if self.ended_at is not None else _now()
+        try:
+            duration = max(0.0, float(end) - float(self.started_at))
+        except Exception:
+            duration = None
+        return {
+            "pid": self.pid,
+            "action": self.action,
+            "category": self.category,
+            "label": self.label,
+            "status": self.status,
+            "returncode": self.returncode,
+            "command": list(self.command),
+            "cwd": self.cwd,
+            "stdout_path": self.stdout_path,
+            "stderr_path": self.stderr_path,
+            "started_at": self.started_at,
+            "started_at_iso": _iso_timestamp(self.started_at),
+            "ended_at": self.ended_at,
+            "ended_at_iso": _iso_timestamp(self.ended_at) if self.ended_at is not None else None,
+            "duration_sec": duration,
+            "final_logged": self.final_logged,
+            "termination_requested_at": self.termination_requested_at,
+            "termination_requested_at_iso": (
+                _iso_timestamp(self.termination_requested_at)
+                if self.termination_requested_at is not None
+                else None
+            ),
+            "termination_signal": self.termination_signal,
+            "termination_reason": self.termination_reason,
+            "can_terminate": self.is_active(),
+            "data": dict(self.data),
+        }
+
+
+class ProcessRegistry:
+    """Track child launchers started by the console process."""
+
+    def __init__(self) -> None:
+        self._records: Dict[int, ManagedProcessRecord] = {}
+
+    def register_from_action_result(
+        self,
+        *,
+        action: str,
+        category: str,
+        result_data: Mapping[str, Any],
+        label: Optional[str] = None,
+    ) -> Optional[ManagedProcessRecord]:
+        """Register a launcher if an action result contains a child PID."""
+
+        pid_value = result_data.get("pid")
+        if pid_value is None:
+            return None
+        try:
+            pid = int(pid_value)
+        except Exception as exc:
+            raise ValueError(f"invalid launcher pid in action result: {pid_value!r}") from exc
+        command = [str(x) for x in result_data.get("command", [])]
+        cwd = str(result_data.get("cwd") or "")
+        data = dict(result_data)
+        popen = data.pop("_popen", None)
+        record = ManagedProcessRecord(
+            pid=pid,
+            action=str(action),
+            category=str(category),
+            label=str(label or action),
+            command=command,
+            cwd=cwd,
+            stdout_path=(
+                str(result_data.get("stdout_path"))
+                if result_data.get("stdout_path") is not None
+                else None
+            ),
+            stderr_path=(
+                str(result_data.get("stderr_path"))
+                if result_data.get("stderr_path") is not None
+                else None
+            ),
+            data=data,
+            popen=popen,
+        )
+        self._records[pid] = record
+        return record
+
+    def refresh(self) -> List[ManagedProcessRecord]:
+        """Non-blockingly reap children and return records newly finalized."""
+
+        finalized: List[ManagedProcessRecord] = []
+        for record in list(self._records.values()):
+            if not record.is_active():
+                continue
+            if record.popen is not None:
+                returncode = record.popen.poll()
+                if returncode is None:
+                    continue
+                record.ended_at = _now()
+                record.status = "exited"
+                record.returncode = int(returncode)
+                finalized.append(record)
+                continue
+            try:
+                waited_pid, status = os.waitpid(record.pid, os.WNOHANG)
+            except ChildProcessError:
+                if not self._pid_exists(record.pid):
+                    record.status = "lost"
+                    record.ended_at = _now()
+                    finalized.append(record)
+                continue
+            except OSError:
+                if not self._pid_exists(record.pid):
+                    record.status = "lost"
+                    record.ended_at = _now()
+                    finalized.append(record)
+                continue
+            if waited_pid == 0:
+                continue
+            record.ended_at = _now()
+            record.status = "exited"
+            if os.WIFEXITED(status):
+                record.returncode = os.WEXITSTATUS(status)
+            elif os.WIFSIGNALED(status):
+                record.returncode = -os.WTERMSIG(status)
+            else:
+                record.returncode = None
+            finalized.append(record)
+        return finalized
+
+    def active(self, *, category: Optional[str] = None) -> List[ManagedProcessRecord]:
+        self.refresh()
+        records = [r for r in self._records.values() if r.is_active()]
+        if category is not None:
+            records = [r for r in records if r.category == category]
+        return sorted(records, key=lambda r: r.started_at)
+
+    def all_records(self, *, refresh: bool = True) -> List[ManagedProcessRecord]:
+        if refresh:
+            self.refresh()
+        return sorted(self._records.values(), key=lambda r: r.started_at, reverse=True)
+
+    def counts(self) -> Dict[str, int]:
+        self.refresh()
+        out = {
+            "total": 0,
+            "running": 0,
+            "terminating": 0,
+            "killing": 0,
+            "active": 0,
+            "exited": 0,
+            "failed": 0,
+            "lost": 0,
+        }
+        for record in self._records.values():
+            out["total"] += 1
+            if record.status in _RUNNING_STATES:
+                out["active"] += 1
+                out[record.status] = out.get(record.status, 0) + 1
+            elif record.status == "exited":
+                out["exited"] += 1
+                if record.returncode not in (0, None):
+                    out["failed"] += 1
+            elif record.status == "lost":
+                out["lost"] += 1
+        return out
+
+    def request_stop(
+        self,
+        *,
+        pid: Optional[int] = None,
+        category: Optional[str] = None,
+        kill: bool = False,
+        reason: str = "operator requested launcher termination",
+    ) -> List[ManagedProcessRecord]:
+        """Request termination of active launcher children.
+
+        This only acts on local child processes that were started and registered
+        by the operator console.  It does not send telescope STOP or ABORT
+        commands; those remain separate safety/operator actions.
+        """
+
+        self.refresh()
+        if pid is not None:
+            try:
+                pid_int = int(pid)
+            except Exception as exc:
+                raise ValueError(f"invalid launcher pid: {pid!r}") from exc
+            records = [self._records[pid_int]] if pid_int in self._records else []
+        else:
+            records = self.active(category=category)
+        records = [r for r in records if r.is_active()]
+        sig = signal.SIGKILL if kill else signal.SIGTERM
+        sig_name = "SIGKILL" if kill else "SIGTERM"
+        next_state = "killing" if kill else "terminating"
+        now = _now()
+        for record in records:
+            if record.status == "killing":
+                continue
+            try:
+                if record.popen is not None:
+                    if kill:
+                        record.popen.kill()
+                    else:
+                        record.popen.terminate()
+                else:
+                    os.kill(int(record.pid), sig)
+            except ProcessLookupError:
+                record.status = "lost"
+                record.ended_at = _now()
+                continue
+            except Exception as exc:
+                record.termination_reason = f"{reason}; failed to send {sig_name}: {exc}"
+                continue
+            record.status = next_state
+            record.termination_requested_at = now
+            record.termination_signal = sig_name
+            record.termination_reason = reason
+        return records
+
+
+    def graceful_shutdown(
+        self,
+        *,
+        timeout_sec: float = 3.0,
+        kill_timeout_sec: float = 1.0,
+        reason: str = "operator console shutdown",
+    ) -> Dict[str, Any]:
+        """Terminate all active local launcher children and return a summary.
+
+        This is intentionally limited to child processes registered by this
+        console.  It does not send telescope STOP/ABORT commands.  The caller
+        should use the separate safety/operator actions for telescope state.
+        """
+
+        started_at = _now()
+        summary: Dict[str, Any] = {
+            "started_at": started_at,
+            "started_at_iso": _iso_timestamp(started_at),
+            "timeout_sec": float(timeout_sec),
+            "kill_timeout_sec": float(kill_timeout_sec),
+            "terminated": [],
+            "killed": [],
+            "remaining": [],
+            "finalized": [],
+            "ok": True,
+            "message": "no active local launcher subprocesses",
+        }
+
+        active_before = self.active()
+        if not active_before:
+            summary["finished_at"] = _now()
+            summary["finished_at_iso"] = _iso_timestamp(summary["finished_at"])
+            summary["counts"] = self.counts()
+            return summary
+
+        terminated = self.request_stop(reason=reason, kill=False)
+        summary["terminated"] = [r.to_dict() for r in terminated]
+
+        deadline = _now() + max(0.0, float(timeout_sec))
+        while _now() < deadline:
+            finalized = self.refresh()
+            if finalized:
+                summary["finalized"].extend(r.to_dict() for r in finalized)
+            if not self.active():
+                break
+            time.sleep(0.05)
+
+        remaining = self.active()
+        if remaining:
+            killed = self.request_stop(
+                reason=f"{reason}; escalated after graceful timeout",
+                kill=True,
+            )
+            summary["killed"] = [r.to_dict() for r in killed]
+            kill_deadline = _now() + max(0.0, float(kill_timeout_sec))
+            while _now() < kill_deadline:
+                finalized = self.refresh()
+                if finalized:
+                    summary["finalized"].extend(r.to_dict() for r in finalized)
+                if not self.active():
+                    break
+                time.sleep(0.05)
+
+        remaining = self.active()
+        summary["remaining"] = [r.to_dict() for r in remaining]
+        summary["counts"] = self.counts()
+        finished_at = _now()
+        summary["finished_at"] = finished_at
+        summary["finished_at_iso"] = _iso_timestamp(finished_at)
+        summary["ok"] = not bool(remaining)
+        if remaining:
+            summary["message"] = (
+                f"{len(remaining)} local launcher subprocess(es) remain active after shutdown cleanup"
+            )
+        else:
+            summary["message"] = "all local launcher subprocesses were cleaned up"
+        return summary
+
+    @staticmethod
+    def _pid_exists(pid: int) -> bool:
+        try:
+            os.kill(int(pid), 0)
+            return True
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            return True
+        except Exception:
+            return False
+
+
+def make_launcher_log_paths(log_dir: Path, action: str) -> Tuple[Path, Path]:
+    """Create deterministic stdout/stderr log paths for a launcher start."""
+
+    directory = Path(log_dir)
+    directory.mkdir(parents=True, exist_ok=True)
+    stamp = time.strftime("%Y%m%d_%H%M%S", time.localtime())
+    token = uuid.uuid4().hex[:8]
+    stem = f"{stamp}_{_safe_name(action)}_{token}"
+    return directory / f"{stem}.stdout.log", directory / f"{stem}.stderr.log"

--- a/necst/web/process_manager.py
+++ b/necst/web/process_manager.py
@@ -62,6 +62,17 @@ class ManagedProcessRecord:
     stop_reason: str = ""
     _popen: Optional[subprocess.Popen[Any]] = field(default=None, repr=False, compare=False)
 
+    def is_active(self) -> bool:
+        """Return True while the local launcher is still considered active.
+
+        Older console code and status adaptation paths use this method instead
+        of inspecting ``status`` directly.  Keeping it on the record object makes
+        status generation robust even when a process record has not just been
+        converted through ``to_dict()``.
+        """
+
+        return self.status not in {"exited", "lost"}
+
     def refresh(self) -> bool:
         """Poll the subprocess and return True if it finalized now."""
 
@@ -135,7 +146,7 @@ class ManagedProcessRecord:
             "finished_at": self.finished_at,
             "returncode": self.returncode,
             "status": self.status,
-            "active": self.status not in {"exited", "lost"},
+            "active": self.is_active(),
             "final_logged": bool(self.final_logged),
             "stop_requested_at": self.stop_requested_at,
             "stop_reason": self.stop_reason,

--- a/necst/web/process_manager.py
+++ b/necst/web/process_manager.py
@@ -1,121 +1,153 @@
-"""Subprocess lifecycle helpers for the NECST Operator Console.
+"""Local launcher process tracking for the NECST operator console.
 
-The operator console starts observation and calibration launchers as child
-processes so HTTP requests return immediately.  This module keeps the small
-piece of lifecycle state needed by the console:
-
-* reject accidental duplicate launcher starts;
-* remember PID, command, cwd, and stdout/stderr log paths;
-* reap child processes without blocking;
-* expose a JSON-serialisable status snapshot.
-
-It intentionally does not send telescope commands.  ABORT/STOP remain normal
-operator actions handled elsewhere.
+This module only manages local subprocesses started by the console.  It does
+not send telescope, recorder, or spectrometer commands.
 """
 
 from __future__ import annotations
 
 import os
 import signal
+import subprocess
+import threading
 import time
-import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
-
-
-_RUNNING_STATES = {"running", "terminating", "killing"}
-_FINAL_STATES = {"exited", "lost", "unknown"}
 
 
 def _now() -> float:
     return time.time()
 
 
-def _iso_timestamp(ts: Optional[float] = None) -> str:
-    value = _now() if ts is None else float(ts)
-    return time.strftime("%Y-%m-%dT%H:%M:%S%z", time.localtime(value))
+def _safe_stem(text: Any) -> str:
+    stem = "".join(ch if ch.isalnum() or ch in "._-" else "_" for ch in str(text or "launcher"))
+    stem = stem.strip("._-") or "launcher"
+    return stem[:80]
 
 
-def _safe_name(text: str) -> str:
-    out = []
-    for ch in str(text or "process"):
-        if ch.isalnum() or ch in {"-", "_"}:
-            out.append(ch)
-        else:
-            out.append("_")
-    name = "".join(out).strip("_")
-    return name or "process"
+def make_launcher_log_paths(log_dir: Path, stem: Any) -> Tuple[Path, Path]:
+    """Return unique stdout/stderr log paths under *log_dir*."""
+
+    log_dir = Path(log_dir).expanduser()
+    log_dir.mkdir(parents=True, exist_ok=True)
+    base = f"{time.strftime('%Y%m%dT%H%M%SZ', time.gmtime())}_{_safe_stem(stem)}_{os.getpid()}"
+    stdout = log_dir / f"{base}.stdout.log"
+    stderr = log_dir / f"{base}.stderr.log"
+    idx = 2
+    while stdout.exists() or stderr.exists():
+        stdout = log_dir / f"{base}_{idx}.stdout.log"
+        stderr = log_dir / f"{base}_{idx}.stderr.log"
+        idx += 1
+    return stdout, stderr
 
 
 @dataclass
 class ManagedProcessRecord:
-    """One launcher process started by the operator console."""
+    """A locally launched child process tracked by the operator console."""
 
     pid: int
-    action: str
     category: str
-    command: List[str]
-    cwd: str
-    started_at: float = field(default_factory=_now)
+    label: str
+    action: str = ""
+    command: List[str] = field(default_factory=list)
     stdout_path: Optional[str] = None
     stderr_path: Optional[str] = None
-    label: str = "launcher"
-    status: str = "running"
+    started_at: float = field(default_factory=_now)
+    finished_at: Optional[float] = None
     returncode: Optional[int] = None
-    ended_at: Optional[float] = None
+    status: str = "running"
     final_logged: bool = False
-    termination_requested_at: Optional[float] = None
-    termination_signal: Optional[str] = None
-    termination_reason: Optional[str] = None
-    data: Dict[str, Any] = field(default_factory=dict)
-    popen: Any = None
+    stop_requested_at: Optional[float] = None
+    stop_reason: str = ""
+    _popen: Optional[subprocess.Popen[Any]] = field(default=None, repr=False, compare=False)
 
-    def is_active(self) -> bool:
-        return self.status in _RUNNING_STATES
+    def refresh(self) -> bool:
+        """Poll the subprocess and return True if it finalized now."""
+
+        if self.status in {"exited", "lost"}:
+            return False
+        popen = self._popen
+        if popen is None:
+            # If the console lost the handle, keep the record visible but mark it
+            # as lost only once.  We cannot safely infer a return code.
+            self.status = "lost"
+            self.finished_at = self.finished_at or _now()
+            return True
+        rc = popen.poll()
+        if rc is None:
+            self.status = "stopping" if self.stop_requested_at is not None else "running"
+            return False
+        self.returncode = int(rc)
+        self.status = "exited"
+        self.finished_at = self.finished_at or _now()
+        return True
+
+    def request_stop(self, *, kill: bool = False, reason: str = "") -> None:
+        self.refresh()
+        if self.status in {"exited", "lost"}:
+            return
+        popen = self._popen
+        if popen is None:
+            self.status = "lost"
+            self.finished_at = self.finished_at or _now()
+            return
+        self.stop_requested_at = self.stop_requested_at or _now()
+        self.stop_reason = str(reason or self.stop_reason or "operator request")
+        try:
+            if kill:
+                popen.kill()
+            else:
+                popen.terminate()
+            self.status = "stopping"
+        except ProcessLookupError:
+            self.refresh()
+        except Exception:
+            # Preserve the record; a later refresh/status call may still reap it.
+            self.status = "stopping"
+
+    def wait(self, timeout: float) -> bool:
+        popen = self._popen
+        if popen is None:
+            self.refresh()
+            return True
+        try:
+            rc = popen.wait(timeout=max(0.0, float(timeout)))
+            self.returncode = int(rc)
+            self.status = "exited"
+            self.finished_at = self.finished_at or _now()
+            return True
+        except subprocess.TimeoutExpired:
+            self.refresh()
+            return False
 
     def to_dict(self) -> Dict[str, Any]:
-        duration = None
-        end = self.ended_at if self.ended_at is not None else _now()
-        try:
-            duration = max(0.0, float(end) - float(self.started_at))
-        except Exception:
-            duration = None
+        self.refresh()
         return {
             "pid": self.pid,
-            "action": self.action,
             "category": self.category,
             "label": self.label,
-            "status": self.status,
-            "returncode": self.returncode,
+            "action": self.action,
             "command": list(self.command),
-            "cwd": self.cwd,
             "stdout_path": self.stdout_path,
             "stderr_path": self.stderr_path,
             "started_at": self.started_at,
-            "started_at_iso": _iso_timestamp(self.started_at),
-            "ended_at": self.ended_at,
-            "ended_at_iso": _iso_timestamp(self.ended_at) if self.ended_at is not None else None,
-            "duration_sec": duration,
-            "final_logged": self.final_logged,
-            "termination_requested_at": self.termination_requested_at,
-            "termination_requested_at_iso": (
-                _iso_timestamp(self.termination_requested_at)
-                if self.termination_requested_at is not None
-                else None
-            ),
-            "termination_signal": self.termination_signal,
-            "termination_reason": self.termination_reason,
-            "can_terminate": self.is_active(),
-            "data": dict(self.data),
+            "finished_at": self.finished_at,
+            "returncode": self.returncode,
+            "status": self.status,
+            "active": self.status not in {"exited", "lost"},
+            "final_logged": bool(self.final_logged),
+            "stop_requested_at": self.stop_requested_at,
+            "stop_reason": self.stop_reason,
         }
 
 
 class ProcessRegistry:
-    """Track child launchers started by the console process."""
+    """Thread-safe registry of console-owned launcher subprocesses."""
 
     def __init__(self) -> None:
-        self._records: Dict[int, ManagedProcessRecord] = {}
+        self._records: List[ManagedProcessRecord] = []
+        self._lock = threading.RLock()
 
     def register_from_action_result(
         self,
@@ -123,123 +155,70 @@ class ProcessRegistry:
         action: str,
         category: str,
         result_data: Mapping[str, Any],
-        label: Optional[str] = None,
+        label: str,
     ) -> Optional[ManagedProcessRecord]:
-        """Register a launcher if an action result contains a child PID."""
-
-        pid_value = result_data.get("pid")
-        if pid_value is None:
+        popen = result_data.get("_popen") if isinstance(result_data, Mapping) else None
+        if popen is None or not hasattr(popen, "pid"):
             return None
-        try:
-            pid = int(pid_value)
-        except Exception as exc:
-            raise ValueError(f"invalid launcher pid in action result: {pid_value!r}") from exc
-        command = [str(x) for x in result_data.get("command", [])]
-        cwd = str(result_data.get("cwd") or "")
-        data = dict(result_data)
-        popen = data.pop("_popen", None)
+        command = result_data.get("command") if isinstance(result_data, Mapping) else None
+        if command is None and hasattr(popen, "args"):
+            command = popen.args
+        if isinstance(command, (str, bytes)):
+            command_list = [str(command)]
+        else:
+            try:
+                command_list = [str(x) for x in (command or [])]
+            except Exception:
+                command_list = []
         record = ManagedProcessRecord(
-            pid=pid,
-            action=str(action),
-            category=str(category),
-            label=str(label or action),
-            command=command,
-            cwd=cwd,
-            stdout_path=(
-                str(result_data.get("stdout_path"))
-                if result_data.get("stdout_path") is not None
-                else None
-            ),
-            stderr_path=(
-                str(result_data.get("stderr_path"))
-                if result_data.get("stderr_path") is not None
-                else None
-            ),
-            data=data,
-            popen=popen,
+            pid=int(popen.pid),
+            category=str(category or "launcher"),
+            label=str(label or action or category or "launcher"),
+            action=str(action or ""),
+            command=command_list,
+            stdout_path=str(result_data.get("stdout_path") or "") or None,
+            stderr_path=str(result_data.get("stderr_path") or "") or None,
+            _popen=popen,
         )
-        self._records[pid] = record
+        with self._lock:
+            self._records.append(record)
         return record
 
     def refresh(self) -> List[ManagedProcessRecord]:
-        """Non-blockingly reap children and return records newly finalized."""
-
         finalized: List[ManagedProcessRecord] = []
-        for record in list(self._records.values()):
-            if not record.is_active():
-                continue
-            if record.popen is not None:
-                returncode = record.popen.poll()
-                if returncode is None:
-                    continue
-                record.ended_at = _now()
-                record.status = "exited"
-                record.returncode = int(returncode)
-                finalized.append(record)
-                continue
-            try:
-                waited_pid, status = os.waitpid(record.pid, os.WNOHANG)
-            except ChildProcessError:
-                if not self._pid_exists(record.pid):
-                    record.status = "lost"
-                    record.ended_at = _now()
+        with self._lock:
+            for record in self._records:
+                if record.refresh():
                     finalized.append(record)
-                continue
-            except OSError:
-                if not self._pid_exists(record.pid):
-                    record.status = "lost"
-                    record.ended_at = _now()
-                    finalized.append(record)
-                continue
-            if waited_pid == 0:
-                continue
-            record.ended_at = _now()
-            record.status = "exited"
-            if os.WIFEXITED(status):
-                record.returncode = os.WEXITSTATUS(status)
-            elif os.WIFSIGNALED(status):
-                record.returncode = -os.WTERMSIG(status)
-            else:
-                record.returncode = None
-            finalized.append(record)
         return finalized
-
-    def active(self, *, category: Optional[str] = None) -> List[ManagedProcessRecord]:
-        self.refresh()
-        records = [r for r in self._records.values() if r.is_active()]
-        if category is not None:
-            records = [r for r in records if r.category == category]
-        return sorted(records, key=lambda r: r.started_at)
 
     def all_records(self, *, refresh: bool = True) -> List[ManagedProcessRecord]:
         if refresh:
             self.refresh()
-        return sorted(self._records.values(), key=lambda r: r.started_at, reverse=True)
+        with self._lock:
+            return list(self._records)
 
-    def counts(self) -> Dict[str, int]:
+    def active(self, *, category: Optional[str] = None) -> List[ManagedProcessRecord]:
         self.refresh()
-        out = {
-            "total": 0,
-            "running": 0,
-            "terminating": 0,
-            "killing": 0,
-            "active": 0,
-            "exited": 0,
-            "failed": 0,
-            "lost": 0,
-        }
-        for record in self._records.values():
-            out["total"] += 1
-            if record.status in _RUNNING_STATES:
-                out["active"] += 1
-                out[record.status] = out.get(record.status, 0) + 1
-            elif record.status == "exited":
-                out["exited"] += 1
-                if record.returncode not in (0, None):
-                    out["failed"] += 1
-            elif record.status == "lost":
-                out["lost"] += 1
-        return out
+        with self._lock:
+            out = []
+            for record in self._records:
+                if record.status in {"exited", "lost"}:
+                    continue
+                if category is not None and record.category != category:
+                    continue
+                out.append(record)
+            return out
+
+    def counts(self) -> Dict[str, Any]:
+        self.refresh()
+        with self._lock:
+            total = len(self._records)
+            active = sum(1 for r in self._records if r.status not in {"exited", "lost"})
+            by_category: Dict[str, int] = {}
+            for record in self._records:
+                by_category[record.category] = by_category.get(record.category, 0) + 1
+            return {"total": total, "active": active, "finished": total - active, "by_category": by_category}
 
     def request_stop(
         self,
@@ -247,151 +226,47 @@ class ProcessRegistry:
         pid: Optional[int] = None,
         category: Optional[str] = None,
         kill: bool = False,
-        reason: str = "operator requested launcher termination",
+        reason: str = "",
     ) -> List[ManagedProcessRecord]:
-        """Request termination of active launcher children.
-
-        This only acts on local child processes that were started and registered
-        by the operator console.  It does not send telescope STOP or ABORT
-        commands; those remain separate safety/operator actions.
-        """
-
-        self.refresh()
-        if pid is not None:
-            try:
-                pid_int = int(pid)
-            except Exception as exc:
-                raise ValueError(f"invalid launcher pid: {pid!r}") from exc
-            records = [self._records[pid_int]] if pid_int in self._records else []
-        else:
-            records = self.active(category=category)
-        records = [r for r in records if r.is_active()]
-        sig = signal.SIGKILL if kill else signal.SIGTERM
-        sig_name = "SIGKILL" if kill else "SIGTERM"
-        next_state = "killing" if kill else "terminating"
-        now = _now()
-        for record in records:
-            if record.status == "killing":
-                continue
-            try:
-                if record.popen is not None:
-                    if kill:
-                        record.popen.kill()
-                    else:
-                        record.popen.terminate()
-                else:
-                    os.kill(int(record.pid), sig)
-            except ProcessLookupError:
-                record.status = "lost"
-                record.ended_at = _now()
-                continue
-            except Exception as exc:
-                record.termination_reason = f"{reason}; failed to send {sig_name}: {exc}"
-                continue
-            record.status = next_state
-            record.termination_requested_at = now
-            record.termination_signal = sig_name
-            record.termination_reason = reason
-        return records
-
+        with self._lock:
+            targets = []
+            for record in self.active(category=category):
+                if pid is not None and int(record.pid) != int(pid):
+                    continue
+                targets.append(record)
+            for record in targets:
+                record.request_stop(kill=bool(kill), reason=reason)
+            return list(targets)
 
     def graceful_shutdown(
         self,
         *,
         timeout_sec: float = 3.0,
         kill_timeout_sec: float = 1.0,
-        reason: str = "operator console shutdown",
+        reason: str = "console shutdown",
     ) -> Dict[str, Any]:
-        """Terminate all active local launcher children and return a summary.
-
-        This is intentionally limited to child processes registered by this
-        console.  It does not send telescope STOP/ABORT commands.  The caller
-        should use the separate safety/operator actions for telescope state.
-        """
-
-        started_at = _now()
-        summary: Dict[str, Any] = {
-            "started_at": started_at,
-            "started_at_iso": _iso_timestamp(started_at),
-            "timeout_sec": float(timeout_sec),
-            "kill_timeout_sec": float(kill_timeout_sec),
-            "terminated": [],
-            "killed": [],
-            "remaining": [],
-            "finalized": [],
-            "ok": True,
-            "message": "no active local launcher subprocesses",
-        }
-
-        active_before = self.active()
-        if not active_before:
-            summary["finished_at"] = _now()
-            summary["finished_at_iso"] = _iso_timestamp(summary["finished_at"])
-            summary["counts"] = self.counts()
-            return summary
-
-        terminated = self.request_stop(reason=reason, kill=False)
-        summary["terminated"] = [r.to_dict() for r in terminated]
-
+        targets = self.active()
+        for record in targets:
+            record.request_stop(kill=False, reason=reason)
         deadline = _now() + max(0.0, float(timeout_sec))
-        while _now() < deadline:
-            finalized = self.refresh()
-            if finalized:
-                summary["finalized"].extend(r.to_dict() for r in finalized)
-            if not self.active():
-                break
+        while _now() < deadline and any(r.status not in {"exited", "lost"} for r in targets):
+            self.refresh()
             time.sleep(0.05)
-
-        remaining = self.active()
-        if remaining:
-            killed = self.request_stop(
-                reason=f"{reason}; escalated after graceful timeout",
-                kill=True,
-            )
-            summary["killed"] = [r.to_dict() for r in killed]
+        still_active = [r for r in targets if r.status not in {"exited", "lost"}]
+        for record in still_active:
+            record.request_stop(kill=True, reason=reason + " (kill after timeout)")
+        if still_active:
             kill_deadline = _now() + max(0.0, float(kill_timeout_sec))
-            while _now() < kill_deadline:
-                finalized = self.refresh()
-                if finalized:
-                    summary["finalized"].extend(r.to_dict() for r in finalized)
-                if not self.active():
-                    break
+            while _now() < kill_deadline and any(r.status not in {"exited", "lost"} for r in still_active):
+                self.refresh()
                 time.sleep(0.05)
-
-        remaining = self.active()
-        summary["remaining"] = [r.to_dict() for r in remaining]
-        summary["counts"] = self.counts()
-        finished_at = _now()
-        summary["finished_at"] = finished_at
-        summary["finished_at_iso"] = _iso_timestamp(finished_at)
-        summary["ok"] = not bool(remaining)
-        if remaining:
-            summary["message"] = (
-                f"{len(remaining)} local launcher subprocess(es) remain active after shutdown cleanup"
-            )
-        else:
-            summary["message"] = "all local launcher subprocesses were cleaned up"
-        return summary
-
-    @staticmethod
-    def _pid_exists(pid: int) -> bool:
-        try:
-            os.kill(int(pid), 0)
-            return True
-        except ProcessLookupError:
-            return False
-        except PermissionError:
-            return True
-        except Exception:
-            return False
-
-
-def make_launcher_log_paths(log_dir: Path, action: str) -> Tuple[Path, Path]:
-    """Create deterministic stdout/stderr log paths for a launcher start."""
-
-    directory = Path(log_dir)
-    directory.mkdir(parents=True, exist_ok=True)
-    stamp = time.strftime("%Y%m%d_%H%M%S", time.localtime())
-    token = uuid.uuid4().hex[:8]
-    stem = f"{stamp}_{_safe_name(action)}_{token}"
-    return directory / f"{stem}.stdout.log", directory / f"{stem}.stderr.log"
+        self.refresh()
+        remaining = [r.to_dict() for r in self.active()]
+        stopped = [r.to_dict() for r in targets]
+        return {
+            "ok": not bool(remaining),
+            "message": "launcher shutdown cleanup finished" if not remaining else "some launchers remain active after cleanup",
+            "terminated": stopped,
+            "remaining": remaining,
+            "counts": self.counts(),
+        }

--- a/necst/web/process_manager.py
+++ b/necst/web/process_manager.py
@@ -7,13 +7,12 @@ not send telescope, recorder, or spectrometer commands.
 from __future__ import annotations
 
 import os
-import signal
 import subprocess
 import threading
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
+from typing import Any, Dict, List, Mapping, Optional, Tuple
 
 
 def _now() -> float:
@@ -21,7 +20,9 @@ def _now() -> float:
 
 
 def _safe_stem(text: Any) -> str:
-    stem = "".join(ch if ch.isalnum() or ch in "._-" else "_" for ch in str(text or "launcher"))
+    stem = "".join(
+        ch if ch.isalnum() or ch in "._-" else "_" for ch in str(text or "launcher")
+    )
     stem = stem.strip("._-") or "launcher"
     return stem[:80]
 
@@ -60,7 +61,9 @@ class ManagedProcessRecord:
     final_logged: bool = False
     stop_requested_at: Optional[float] = None
     stop_reason: str = ""
-    _popen: Optional[subprocess.Popen[Any]] = field(default=None, repr=False, compare=False)
+    _popen: Optional[subprocess.Popen[Any]] = field(
+        default=None, repr=False, compare=False
+    )
 
     def is_active(self) -> bool:
         """Return True while the local launcher is still considered active.
@@ -87,7 +90,9 @@ class ManagedProcessRecord:
             return True
         rc = popen.poll()
         if rc is None:
-            self.status = "stopping" if self.stop_requested_at is not None else "running"
+            self.status = (
+                "stopping" if self.stop_requested_at is not None else "running"
+            )
             return False
         self.returncode = int(rc)
         self.status = "exited"
@@ -171,7 +176,9 @@ class ProcessRegistry:
         popen = result_data.get("_popen") if isinstance(result_data, Mapping) else None
         if popen is None or not hasattr(popen, "pid"):
             return None
-        command = result_data.get("command") if isinstance(result_data, Mapping) else None
+        command = (
+            result_data.get("command") if isinstance(result_data, Mapping) else None
+        )
         if command is None and hasattr(popen, "args"):
             command = popen.args
         if isinstance(command, (str, bytes)):
@@ -229,7 +236,12 @@ class ProcessRegistry:
             by_category: Dict[str, int] = {}
             for record in self._records:
                 by_category[record.category] = by_category.get(record.category, 0) + 1
-            return {"total": total, "active": active, "finished": total - active, "by_category": by_category}
+            return {
+                "total": total,
+                "active": active,
+                "finished": total - active,
+                "by_category": by_category,
+            }
 
     def request_stop(
         self,
@@ -260,7 +272,9 @@ class ProcessRegistry:
         for record in targets:
             record.request_stop(kill=False, reason=reason)
         deadline = _now() + max(0.0, float(timeout_sec))
-        while _now() < deadline and any(r.status not in {"exited", "lost"} for r in targets):
+        while _now() < deadline and any(
+            r.status not in {"exited", "lost"} for r in targets
+        ):
             self.refresh()
             time.sleep(0.05)
         still_active = [r for r in targets if r.status not in {"exited", "lost"}]
@@ -268,7 +282,9 @@ class ProcessRegistry:
             record.request_stop(kill=True, reason=reason + " (kill after timeout)")
         if still_active:
             kill_deadline = _now() + max(0.0, float(kill_timeout_sec))
-            while _now() < kill_deadline and any(r.status not in {"exited", "lost"} for r in still_active):
+            while _now() < kill_deadline and any(
+                r.status not in {"exited", "lost"} for r in still_active
+            ):
                 self.refresh()
                 time.sleep(0.05)
         self.refresh()
@@ -276,7 +292,11 @@ class ProcessRegistry:
         stopped = [r.to_dict() for r in targets]
         return {
             "ok": not bool(remaining),
-            "message": "launcher shutdown cleanup finished" if not remaining else "some launchers remain active after cleanup",
+            "message": (
+                "launcher shutdown cleanup finished"
+                if not remaining
+                else "some launchers remain active after cleanup"
+            ),
             "terminated": stopped,
             "remaining": remaining,
             "counts": self.counts(),

--- a/necst/web/progress_manager.py
+++ b/necst/web/progress_manager.py
@@ -1,0 +1,324 @@
+"""Managed progress-monitor lifecycle helpers for the NECST Operator Console.
+
+The operator console may open a progress monitor in two different situations:
+
+* a progress.py web server is already running outside the console;
+* the console starts its own progress.py server for operator convenience.
+
+Only the second case is owned by this console process.  Therefore console
+shutdown must stop only the process that the console launched, and must leave an
+external progress monitor untouched.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from . import process_manager
+
+
+def _now() -> float:
+    return time.time()
+
+
+@dataclass
+class ProgressMonitorState:
+    """Small JSON-serialisable snapshot of progress-monitor ownership."""
+
+    url: str
+    running: bool = False
+    owned_by_console: bool = False
+    pid: Optional[int] = None
+    status: str = "unknown"
+    message: str = ""
+    health: Dict[str, Any] = field(default_factory=dict)
+    stdout_path: Optional[str] = None
+    stderr_path: Optional[str] = None
+    command: List[str] = field(default_factory=list)
+    started_at: Optional[float] = None
+    returncode: Optional[int] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "url": self.url,
+            "running": bool(self.running),
+            "owned_by_console": bool(self.owned_by_console),
+            "pid": self.pid,
+            "status": self.status,
+            "message": self.message,
+            "health": dict(self.health),
+            "stdout_path": self.stdout_path,
+            "stderr_path": self.stderr_path,
+            "command": list(self.command),
+            "started_at": self.started_at,
+            "returncode": self.returncode,
+        }
+
+
+class ProgressMonitorManager:
+    """Start, detect, and stop a progress.py web server when appropriate."""
+
+    def __init__(
+        self,
+        *,
+        progress_script: Path,
+        progress_root: Path,
+        host: str,
+        port: int,
+        url: Optional[str] = None,
+        log_dir: Optional[Path] = None,
+        refresh_ms: int = 500,
+        no_ros: bool = False,
+        quiet: bool = True,
+        python_executable: Optional[str] = None,
+    ) -> None:
+        self.progress_script = Path(progress_script)
+        self.progress_root = Path(progress_root)
+        self.host = str(host)
+        self.port = int(port)
+        self.url = str(url or f"http://{self.host}:{self.port}/")
+        self.log_dir = Path(log_dir) if log_dir is not None else None
+        self.refresh_ms = max(250, int(refresh_ms))
+        self.no_ros = bool(no_ros)
+        self.quiet = bool(quiet)
+        self.python_executable = str(python_executable or sys.executable)
+        self._popen: Optional[subprocess.Popen[Any]] = None
+        self._stdout_fh: Any = None
+        self._stderr_fh: Any = None
+        self._stdout_path: Optional[Path] = None
+        self._stderr_path: Optional[Path] = None
+        self._command: List[str] = []
+        self._started_at: Optional[float] = None
+        self._last_message: str = ""
+        self._last_health: Dict[str, Any] = {}
+        self._external_detected: bool = False
+
+    def _health_url(self) -> str:
+        return self.url.rstrip("/") + "/api/health"
+
+    def check_health(self, *, timeout_sec: float = 0.25) -> Tuple[bool, Dict[str, Any], str]:
+        """Return ``(ok, payload, message)`` from /api/health."""
+
+        try:
+            with urllib.request.urlopen(self._health_url(), timeout=float(timeout_sec)) as resp:
+                raw = resp.read(1024 * 256)
+            payload = json.loads(raw.decode("utf-8") or "{}")
+            if not isinstance(payload, dict):
+                payload = {"payload": payload}
+            ok = bool(payload.get("ok", True))
+            message = "progress monitor health OK" if ok else "progress monitor health returned not-ok"
+            self._last_health = payload
+            self._last_message = message
+            return ok, payload, message
+        except urllib.error.HTTPError as exc:
+            message = f"progress monitor health HTTP error: {exc.code}"
+            return False, {}, message
+        except Exception as exc:
+            message = f"progress monitor health unavailable: {exc}"
+            return False, {}, message
+
+    def _poll_owned_process(self) -> Optional[int]:
+        if self._popen is None:
+            return None
+        rc = self._popen.poll()
+        return None if rc is None else int(rc)
+
+    def _is_owned_running(self) -> bool:
+        return self._popen is not None and self._poll_owned_process() is None
+
+    def _make_command(self) -> List[str]:
+        command = [
+            self.python_executable,
+            str(self.progress_script),
+            "--serve",
+            "--root",
+            str(self.progress_root),
+            "--host",
+            self.host,
+            "--port",
+            str(self.port),
+            "--refresh-ms",
+            str(self.refresh_ms),
+        ]
+        if self.quiet:
+            command.append("--quiet")
+        if self.no_ros:
+            command.append("--no-ros")
+        return command
+
+    def launch(self) -> Tuple[bool, str, Dict[str, Any]]:
+        """Launch progress.py if no external or owned server is already healthy."""
+
+        if self._is_owned_running():
+            ok, health, _message = self.check_health(timeout_sec=0.5)
+            data = self.status().to_dict()
+            data["health"] = health
+            data["progress_url"] = self.url
+            message = "managed progress monitor is already running"
+            self._last_message = message
+            return True, message, data
+
+        ok, health, message = self.check_health(timeout_sec=0.35)
+        if ok:
+            data = self.status().to_dict()
+            data.update(
+                {
+                    "running": True,
+                    "owned_by_console": False,
+                    "status": "external",
+                    "health": health,
+                    "progress_url": self.url,
+                }
+            )
+            message = "external progress monitor is already running; it will not be stopped by this console"
+            self._last_message = message
+            self._external_detected = True
+            return True, message, data
+
+        if not self.progress_script.exists():
+            message = f"progress.py not found: {self.progress_script}"
+            self._last_message = message
+            return False, message, self.status().to_dict()
+
+        stdout_path = stderr_path = None
+        stdout_fh = stderr_fh = subprocess.DEVNULL
+        if self.log_dir is not None:
+            stdout_path, stderr_path = process_manager.make_launcher_log_paths(
+                Path(self.log_dir), "progress_monitor"
+            )
+            stdout_fh = stdout_path.open("ab")
+            stderr_fh = stderr_path.open("ab")
+        command = self._make_command()
+        try:
+            popen = subprocess.Popen(
+                command,
+                cwd=str(self.progress_script.resolve().parents[1]),
+                stdout=stdout_fh,
+                stderr=stderr_fh,
+                close_fds=True,
+            )
+        except Exception as exc:
+            for handle in (stdout_fh, stderr_fh):
+                try:
+                    if handle is not subprocess.DEVNULL:
+                        handle.close()
+                except Exception:
+                    pass
+            message = f"failed to start progress monitor: {exc}"
+            self._last_message = message
+            return False, message, self.status().to_dict()
+
+        self._popen = popen
+        self._stdout_fh = stdout_fh if stdout_fh is not subprocess.DEVNULL else None
+        self._stderr_fh = stderr_fh if stderr_fh is not subprocess.DEVNULL else None
+        self._stdout_path = stdout_path
+        self._stderr_path = stderr_path
+        self._command = command
+        self._started_at = _now()
+
+        # Give the HTTP server a short chance to bind and answer health.  If it
+        # is still starting but the process is alive, report success with a
+        # pending health status; the browser can refresh and try again.
+        last_message = "progress monitor launch requested"
+        for _ in range(20):
+            if popen.poll() is not None:
+                break
+            ok, health, health_message = self.check_health(timeout_sec=0.15)
+            if ok:
+                data = self.status().to_dict()
+                data["health"] = health
+                data["progress_url"] = self.url
+                message = "managed progress monitor started"
+                self._last_message = message
+                return True, message, data
+            last_message = health_message
+            time.sleep(0.05)
+
+        rc = popen.poll()
+        data = self.status().to_dict()
+        data["progress_url"] = self.url
+        if rc is None:
+            message = f"managed progress monitor started; health is pending ({last_message})"
+            self._last_message = message
+            return True, message, data
+        message = f"progress monitor exited during startup with return code {rc}"
+        self._last_message = message
+        return False, message, data
+
+    def stop_if_owned(self, *, timeout_sec: float = 2.0) -> Tuple[bool, str, Dict[str, Any]]:
+        """Stop only the progress monitor started by this console."""
+
+        popen = self._popen
+        if popen is None:
+            return True, "no console-owned progress monitor to stop", self.status().to_dict()
+        if popen.poll() is None:
+            try:
+                popen.terminate()
+                popen.wait(timeout=float(timeout_sec))
+            except subprocess.TimeoutExpired:
+                try:
+                    popen.kill()
+                    popen.wait(timeout=1.0)
+                except Exception:
+                    pass
+            except Exception:
+                pass
+        rc = popen.poll()
+        message = f"console-owned progress monitor stopped with return code {rc}"
+        self._last_message = message
+        data = self.status().to_dict()
+        self._popen = None
+        for attr in ("_stdout_fh", "_stderr_fh"):
+            handle = getattr(self, attr, None)
+            if handle is not None:
+                try:
+                    handle.close()
+                except Exception:
+                    pass
+                setattr(self, attr, None)
+        return True, message, data
+
+    def status(self, *, check_external: bool = False) -> ProgressMonitorState:
+        """Return current monitor state without sending telescope commands."""
+
+        rc = self._poll_owned_process()
+        owned_running = self._is_owned_running()
+        running = owned_running
+        status = "managed" if owned_running else "not_running"
+        health: Dict[str, Any] = dict(self._last_health)
+        message = self._last_message
+        if (check_external or self._external_detected) and not owned_running:
+            ok, health, message = self.check_health(timeout_sec=0.20)
+            running = ok
+            status = "external" if ok else "not_running"
+            self._external_detected = bool(ok)
+        elif owned_running:
+            ok, health, message = self.check_health(timeout_sec=0.20)
+            running = True
+            status = "managed" if ok else "managed_starting"
+        elif self._popen is not None and rc is not None:
+            running = False
+            status = "exited"
+            message = f"console-owned progress monitor exited with return code {rc}"
+        return ProgressMonitorState(
+            url=self.url,
+            running=bool(running),
+            owned_by_console=bool(owned_running),
+            pid=int(self._popen.pid) if self._popen is not None else None,
+            status=status,
+            message=message,
+            health=health,
+            stdout_path=str(self._stdout_path) if self._stdout_path is not None else None,
+            stderr_path=str(self._stderr_path) if self._stderr_path is not None else None,
+            command=list(self._command),
+            started_at=self._started_at,
+            returncode=rc,
+        )

--- a/necst/web/progress_manager.py
+++ b/necst/web/progress_manager.py
@@ -134,6 +134,32 @@ class ProgressMonitorManager:
     def _is_owned_running(self) -> bool:
         return self._popen is not None and self._poll_owned_process() is None
 
+    def _close_output_handles(self) -> None:
+        for attr in ("_stdout_fh", "_stderr_fh"):
+            handle = getattr(self, attr, None)
+            if handle is not None:
+                try:
+                    handle.close()
+                except Exception:
+                    pass
+                setattr(self, attr, None)
+
+    def _forget_finished_owned_process(self) -> Optional[int]:
+        """Drop local references to a console-owned process that already exited.
+
+        This keeps Retry launch from leaking log file handles or treating an old
+        exited process as the current managed progress server.  The last message
+        is intentionally left intact for UI diagnostics.
+        """
+        if self._popen is None:
+            return None
+        rc = self._popen.poll()
+        if rc is None:
+            return None
+        self._close_output_handles()
+        self._popen = None
+        return int(rc)
+
     def _make_command(self) -> List[str]:
         command = [
             self.python_executable,
@@ -156,6 +182,10 @@ class ProgressMonitorManager:
 
     def launch(self) -> Tuple[bool, str, Dict[str, Any]]:
         """Launch progress.py if no external or owned server is already healthy."""
+
+        old_rc = self._forget_finished_owned_process()
+        if old_rc is not None:
+            self._last_message = f"previous console-owned progress monitor had exited with return code {old_rc}; retrying launch"
 
         if self._is_owned_running():
             ok, health, _message = self.check_health(timeout_sec=0.5)
@@ -251,6 +281,8 @@ class ProgressMonitorManager:
             return True, message, data
         message = f"progress monitor exited during startup with return code {rc}"
         self._last_message = message
+        self._close_output_handles()
+        self._popen = None
         return False, message, data
 
     def stop_if_owned(self, *, timeout_sec: float = 2.0) -> Tuple[bool, str, Dict[str, Any]]:
@@ -276,14 +308,7 @@ class ProgressMonitorManager:
         self._last_message = message
         data = self.status().to_dict()
         self._popen = None
-        for attr in ("_stdout_fh", "_stderr_fh"):
-            handle = getattr(self, attr, None)
-            if handle is not None:
-                try:
-                    handle.close()
-                except Exception:
-                    pass
-                setattr(self, attr, None)
+        self._close_output_handles()
         return True, message, data
 
     def status(self, *, check_external: bool = False) -> ProgressMonitorState:

--- a/necst/web/progress_manager.py
+++ b/necst/web/progress_manager.py
@@ -104,17 +104,25 @@ class ProgressMonitorManager:
     def _health_url(self) -> str:
         return self.url.rstrip("/") + "/api/health"
 
-    def check_health(self, *, timeout_sec: float = 0.25) -> Tuple[bool, Dict[str, Any], str]:
+    def check_health(
+        self, *, timeout_sec: float = 0.25
+    ) -> Tuple[bool, Dict[str, Any], str]:
         """Return ``(ok, payload, message)`` from /api/health."""
 
         try:
-            with urllib.request.urlopen(self._health_url(), timeout=float(timeout_sec)) as resp:
+            with urllib.request.urlopen(
+                self._health_url(), timeout=float(timeout_sec)
+            ) as resp:
                 raw = resp.read(1024 * 256)
             payload = json.loads(raw.decode("utf-8") or "{}")
             if not isinstance(payload, dict):
                 payload = {"payload": payload}
             ok = bool(payload.get("ok", True))
-            message = "progress monitor health OK" if ok else "progress monitor health returned not-ok"
+            message = (
+                "progress monitor health OK"
+                if ok
+                else "progress monitor health returned not-ok"
+            )
             self._last_health = payload
             self._last_message = message
             return ok, payload, message
@@ -276,7 +284,9 @@ class ProgressMonitorManager:
         data = self.status().to_dict()
         data["progress_url"] = self.url
         if rc is None:
-            message = f"managed progress monitor started; health is pending ({last_message})"
+            message = (
+                f"managed progress monitor started; health is pending ({last_message})"
+            )
             self._last_message = message
             return True, message, data
         message = f"progress monitor exited during startup with return code {rc}"
@@ -285,12 +295,18 @@ class ProgressMonitorManager:
         self._popen = None
         return False, message, data
 
-    def stop_if_owned(self, *, timeout_sec: float = 2.0) -> Tuple[bool, str, Dict[str, Any]]:
+    def stop_if_owned(
+        self, *, timeout_sec: float = 2.0
+    ) -> Tuple[bool, str, Dict[str, Any]]:
         """Stop only the progress monitor started by this console."""
 
         popen = self._popen
         if popen is None:
-            return True, "no console-owned progress monitor to stop", self.status().to_dict()
+            return (
+                True,
+                "no console-owned progress monitor to stop",
+                self.status().to_dict(),
+            )
         if popen.poll() is None:
             try:
                 popen.terminate()
@@ -341,8 +357,12 @@ class ProgressMonitorManager:
             status=status,
             message=message,
             health=health,
-            stdout_path=str(self._stdout_path) if self._stdout_path is not None else None,
-            stderr_path=str(self._stderr_path) if self._stderr_path is not None else None,
+            stdout_path=(
+                str(self._stdout_path) if self._stdout_path is not None else None
+            ),
+            stderr_path=(
+                str(self._stderr_path) if self._stderr_path is not None else None
+            ),
             command=list(self._command),
             started_at=self._started_at,
             returncode=rc,

--- a/necst/web/self_check.py
+++ b/necst/web/self_check.py
@@ -194,6 +194,7 @@ def run_console_self_check(
     progress_monitor: Any,
     events_limit: int = 12,
     include_progress_health: bool = True,
+    live_telemetry_snapshot: Optional[Mapping[str, Any]] = None,
 ) -> JsonDict:
     """Return a JSON-serialisable read-only console self-check result."""
 
@@ -256,6 +257,41 @@ def run_console_self_check(
     checks.append(_capability_check(capabilities))
     checks.append(_chopper_check(chopper_config, capabilities))
 
+    live_snapshot = live_telemetry_snapshot if isinstance(live_telemetry_snapshot, Mapping) else {}
+    live_requested = bool(live_snapshot.get("requested"))
+    live_available = bool(live_snapshot.get("available"))
+    live_error = live_snapshot.get("error")
+    if live_requested and live_available:
+        checks.append(
+            _check_item(
+                "live_telemetry",
+                True,
+                f"console ROS live telemetry available ({live_snapshot.get('spin_mode') or 'unknown spin mode'})",
+                severity="info",
+                data=live_snapshot,
+            )
+        )
+    elif live_requested:
+        checks.append(
+            _check_item(
+                "live_telemetry",
+                action_mode != "live",
+                f"console ROS live telemetry unavailable: {live_error or 'unknown reason'}",
+                severity="error" if action_mode == "live" else "warning",
+                data=live_snapshot,
+            )
+        )
+    else:
+        checks.append(
+            _check_item(
+                "live_telemetry",
+                True,
+                "console ROS live telemetry disabled by --no-ros",
+                severity="warning" if action_mode == "live" else "info",
+                data=live_snapshot,
+            )
+        )
+
     progress_root = Path(progress_root)
     checks.append(
         _check_item(
@@ -315,6 +351,7 @@ def run_console_self_check(
         status_state = status_model.build_progress_status_state(
             progress_root,
             events_limit=int(events_limit),
+            live_payload=live_snapshot if live_available else None,
         )
         op = status_state.get("operator_status", {})
         checks.append(

--- a/necst/web/self_check.py
+++ b/necst/web/self_check.py
@@ -1,0 +1,362 @@
+"""Operator-console self-check helpers.
+
+The console needs a cheap, read-only preflight before observers trust it for
+live operation.  This module checks the console's own wiring and configuration;
+it does not send telescope commands, does not start launchers, and does not
+start or stop the progress monitor.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional
+
+from . import status_model
+
+JsonDict = Dict[str, Any]
+
+_REQUIRED_MOUNT_LIMITS = ("az_min", "az_max", "el_min", "el_max")
+_EXPECTED_CAPABILITIES = (
+    "mount_move",
+    "target_tracking",
+    "observation_start",
+    "rsky",
+    "skydip",
+    "chopper_status",
+    "chopper_move",
+    "chopper_maintenance",
+)
+
+
+def _now_iso() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%S%z", time.localtime())
+
+
+def _check_item(
+    name: str,
+    ok: bool,
+    message: str,
+    *,
+    severity: str = "error",
+    data: Optional[Mapping[str, Any]] = None,
+) -> JsonDict:
+    return {
+        "name": str(name),
+        "ok": bool(ok),
+        "severity": str(severity),
+        "message": str(message),
+        "data": dict(data or {}),
+    }
+
+
+def _is_writable_dir(path: Path) -> bool:
+    """Return whether *path* is an existing writable directory.
+
+    This intentionally avoids creating files so /api/self-check remains a
+    read-only diagnostic endpoint.
+    """
+
+    try:
+        return path.is_dir() and os.access(str(path), os.W_OK | os.X_OK)
+    except Exception:
+        return False
+
+
+def _mount_limit_check(mount_limits: Mapping[str, Any]) -> JsonDict:
+    missing = [key for key in _REQUIRED_MOUNT_LIMITS if key not in mount_limits]
+    if missing:
+        return _check_item(
+            "mount_limits",
+            False,
+            "site TOML mount limits are incomplete",
+            data={"missing": missing, "mount_limits": dict(mount_limits)},
+        )
+    try:
+        az_min = float(mount_limits["az_min"])
+        az_max = float(mount_limits["az_max"])
+        el_min = float(mount_limits["el_min"])
+        el_max = float(mount_limits["el_max"])
+    except Exception as exc:
+        return _check_item(
+            "mount_limits",
+            False,
+            f"site TOML mount limits are not numeric: {exc}",
+            data={"mount_limits": dict(mount_limits)},
+        )
+    if az_min >= az_max or el_min >= el_max:
+        return _check_item(
+            "mount_limits",
+            False,
+            "site TOML mount min/max order is invalid",
+            data={"mount_limits": dict(mount_limits)},
+        )
+    return _check_item(
+        "mount_limits",
+        True,
+        f"mount limits OK: Az {az_min:g}..{az_max:g} deg, El {el_min:g}..{el_max:g} deg",
+        severity="info",
+        data={"mount_limits": dict(mount_limits)},
+    )
+
+
+def _capability_check(capabilities: Mapping[str, Any]) -> JsonDict:
+    missing = [key for key in _EXPECTED_CAPABILITIES if key not in capabilities]
+    non_bool = [key for key, value in capabilities.items() if not isinstance(value, bool)]
+    if missing or non_bool:
+        return _check_item(
+            "site_capabilities",
+            False,
+            "site capabilities are incomplete or non-boolean",
+            data={"missing": missing, "non_bool": non_bool, "capabilities": dict(capabilities)},
+        )
+    disabled = sorted(key for key, value in capabilities.items() if not value)
+    message = "site capabilities OK"
+    severity = "info"
+    if disabled:
+        message += "; disabled: " + ", ".join(disabled)
+        severity = "warning"
+    return _check_item(
+        "site_capabilities",
+        True,
+        message,
+        severity=severity,
+        data={"disabled": disabled, "capabilities": dict(capabilities)},
+    )
+
+
+def _chopper_check(chopper: Mapping[str, Any], capabilities: Mapping[str, Any]) -> JsonDict:
+    if not bool(capabilities.get("chopper_move", False)):
+        return _check_item(
+            "chopper_config",
+            True,
+            "chopper move is disabled by site capability",
+            severity="info",
+            data={"chopper": dict(chopper)},
+        )
+    missing = [
+        key
+        for key in ("insert_position", "remove_position")
+        if chopper.get(key) in (None, "")
+    ]
+    if missing:
+        return _check_item(
+            "chopper_config",
+            False,
+            "chopper move is enabled but IN/OUT positions are missing",
+            data={"missing": missing, "chopper": dict(chopper)},
+        )
+    return _check_item(
+        "chopper_config",
+        True,
+        f"chopper endpoints OK: IN={chopper.get('insert_position')}, OUT={chopper.get('remove_position')}",
+        severity="info",
+        data={"chopper": dict(chopper)},
+    )
+
+
+def _log_path_check(path_value: Any, *, name: str, expect_file: bool = False) -> JsonDict:
+    if path_value in (None, ""):
+        return _check_item(name, False, f"{name} is not configured")
+    path = Path(str(path_value))
+    directory = path.parent if expect_file else path
+    ok = _is_writable_dir(directory)
+    if not ok:
+        return _check_item(
+            name,
+            False,
+            f"{directory} is not an existing writable directory",
+            data={"path": str(path), "directory": str(directory)},
+        )
+    return _check_item(
+        name,
+        True,
+        f"{directory} is writable",
+        severity="info",
+        data={"path": str(path), "directory": str(directory)},
+    )
+
+
+def run_console_self_check(
+    *,
+    telescope: str,
+    action_mode: str,
+    live_actions_enabled: bool,
+    progress_root: Path,
+    site_summary: Any,
+    mount_limits: Mapping[str, Any],
+    capabilities: Mapping[str, Any],
+    chopper_config: Mapping[str, Any],
+    operator_log_path: Optional[Path],
+    launcher_log_dir: Optional[Path],
+    process_registry: Any,
+    progress_monitor: Any,
+    events_limit: int = 12,
+    include_progress_health: bool = True,
+) -> JsonDict:
+    """Return a JSON-serialisable read-only console self-check result."""
+
+    checks: List[JsonDict] = []
+    checks.append(
+        _check_item(
+            "action_mode",
+            action_mode in {"live", "dry-run"},
+            f"action_mode={action_mode}",
+            severity="info" if action_mode in {"live", "dry-run"} else "error",
+        )
+    )
+    if action_mode == "live" and not live_actions_enabled:
+        checks.append(
+            _check_item(
+                "live_write_guard",
+                True,
+                "live write actions are guarded by --guard-live-actions; STOP/ABORT remain available",
+                severity="warning",
+                data={
+                    "live_actions_enabled": False,
+                    "guard_option": "--guard-live-actions",
+                },
+            )
+        )
+    elif action_mode == "live" and live_actions_enabled:
+        checks.append(
+            _check_item(
+                "live_write_guard",
+                True,
+                "live write actions are enabled by default in live mode",
+                severity="info",
+                data={"live_actions_enabled": True},
+            )
+        )
+    else:
+        checks.append(
+            _check_item(
+                "live_write_guard",
+                True,
+                "dry-run mode: no live command is sent",
+                severity="info",
+                data={"live_actions_enabled": False},
+            )
+        )
+
+    site_dict = site_summary.to_dict() if hasattr(site_summary, "to_dict") else {}
+    site_source = site_dict.get("source") or "unknown"
+    site_warnings = list(site_dict.get("warnings") or [])
+    checks.append(
+        _check_item(
+            "site_config",
+            not bool(site_warnings) and site_source != "unresolved",
+            f"site config source={site_source}, observatory={site_dict.get('observatory') or 'unknown'}",
+            severity="warning" if site_warnings else "info",
+            data={"site": site_dict, "warnings": site_warnings},
+        )
+    )
+    checks.append(_mount_limit_check(mount_limits))
+    checks.append(_capability_check(capabilities))
+    checks.append(_chopper_check(chopper_config, capabilities))
+
+    progress_root = Path(progress_root)
+    checks.append(
+        _check_item(
+            "progress_root",
+            progress_root.exists() and progress_root.is_dir(),
+            f"progress root {'exists' if progress_root.exists() else 'does not exist'}: {progress_root}",
+            severity="info" if progress_root.exists() and progress_root.is_dir() else "warning",
+            data={"path": str(progress_root)},
+        )
+    )
+    checks.append(_log_path_check(operator_log_path, name="operator_log", expect_file=True))
+    checks.append(_log_path_check(launcher_log_dir, name="launcher_log_dir", expect_file=False))
+
+    try:
+        counts = process_registry.counts()
+        active_count = int(counts.get("active", 0))
+        checks.append(
+            _check_item(
+                "launcher_registry",
+                True,
+                f"launcher registry OK; active={active_count}, total={counts.get('total', 0)}",
+                severity="warning" if active_count else "info",
+                data={"process_counts": counts},
+            )
+        )
+    except Exception as exc:
+        checks.append(_check_item("launcher_registry", False, f"launcher registry failed: {exc}"))
+
+    progress_data: JsonDict = {"url": None, "running": False, "owned_by_console": False}
+    if progress_monitor is None:
+        checks.append(
+            _check_item(
+                "progress_monitor",
+                True,
+                "progress monitor manager is not configured",
+                severity="warning",
+                data=progress_data,
+            )
+        )
+    else:
+        try:
+            status = progress_monitor.status(check_external=bool(include_progress_health))
+            progress_data = status.to_dict()
+            checks.append(
+                _check_item(
+                    "progress_monitor",
+                    True,
+                    str(progress_data.get("message") or progress_data.get("status") or "progress monitor status OK"),
+                    severity="info" if progress_data.get("running") else "warning",
+                    data=progress_data,
+                )
+            )
+        except Exception as exc:
+            checks.append(_check_item("progress_monitor", False, f"progress monitor status failed: {exc}"))
+
+    try:
+        status_state = status_model.build_progress_status_state(
+            progress_root,
+            events_limit=int(events_limit),
+        )
+        op = status_state.get("operator_status", {})
+        checks.append(
+            _check_item(
+                "status_model",
+                isinstance(op, Mapping),
+                "status_model.build_progress_status_state returned operator_status"
+                if isinstance(op, Mapping)
+                else "status_model did not return operator_status mapping",
+                severity="info" if isinstance(op, Mapping) else "error",
+                data={"operator_status_schema": op.get("schema") if isinstance(op, Mapping) else None},
+            )
+        )
+    except Exception as exc:
+        checks.append(_check_item("status_model", False, f"status model failed: {exc}"))
+
+    error_count = sum(
+        1 for item in checks if not item.get("ok") and item.get("severity") == "error"
+    )
+    warning_count = sum(
+        1
+        for item in checks
+        if item.get("severity") == "warning" or (not item.get("ok") and item.get("severity") != "error")
+    )
+    ok = error_count == 0
+    status = "ok" if ok and warning_count == 0 else ("warning" if ok else "error")
+    summary = {
+        "ok": ok,
+        "status": status,
+        "error_count": error_count,
+        "warning_count": warning_count,
+        "check_count": len(checks),
+        "telescope": str(telescope),
+        "action_mode": str(action_mode),
+        "live_actions_enabled": bool(live_actions_enabled),
+        "site_source": site_source,
+        "observatory": site_dict.get("observatory"),
+        "checked_at_iso": _now_iso(),
+    }
+    return {
+        "ok": ok,
+        "status": status,
+        "summary": summary,
+        "checks": checks,
+    }

--- a/necst/web/self_check.py
+++ b/necst/web/self_check.py
@@ -262,13 +262,18 @@ def run_console_self_check(
     live_available = bool(live_snapshot.get("available"))
     live_error = live_snapshot.get("error")
     if live_requested and live_available:
+        has_position = bool(live_snapshot.get("has_position"))
+        sample_counts = live_snapshot.get("sample_counts") if isinstance(live_snapshot.get("sample_counts"), Mapping) else {}
         checks.append(
             _check_item(
                 "live_telemetry",
-                True,
-                f"console ROS live telemetry available ({live_snapshot.get('spin_mode') or 'unknown spin mode'})",
-                severity="info",
-                data=live_snapshot,
+                has_position or action_mode != "live",
+                (
+                    f"console ROS live telemetry available ({live_snapshot.get('spin_mode') or 'unknown spin mode'}); "
+                    + ("encoder/pointing position sample received" if has_position else "waiting for encoder/pointing position sample")
+                ),
+                severity="info" if has_position else ("error" if action_mode == "live" else "warning"),
+                data={**dict(live_snapshot), "sample_counts": dict(sample_counts)},
             )
         )
     elif live_requested:

--- a/necst/web/self_check.py
+++ b/necst/web/self_check.py
@@ -103,13 +103,19 @@ def _mount_limit_check(mount_limits: Mapping[str, Any]) -> JsonDict:
 
 def _capability_check(capabilities: Mapping[str, Any]) -> JsonDict:
     missing = [key for key in _EXPECTED_CAPABILITIES if key not in capabilities]
-    non_bool = [key for key, value in capabilities.items() if not isinstance(value, bool)]
+    non_bool = [
+        key for key, value in capabilities.items() if not isinstance(value, bool)
+    ]
     if missing or non_bool:
         return _check_item(
             "site_capabilities",
             False,
             "site capabilities are incomplete or non-boolean",
-            data={"missing": missing, "non_bool": non_bool, "capabilities": dict(capabilities)},
+            data={
+                "missing": missing,
+                "non_bool": non_bool,
+                "capabilities": dict(capabilities),
+            },
         )
     disabled = sorted(key for key, value in capabilities.items() if not value)
     message = "site capabilities OK"
@@ -126,7 +132,9 @@ def _capability_check(capabilities: Mapping[str, Any]) -> JsonDict:
     )
 
 
-def _chopper_check(chopper: Mapping[str, Any], capabilities: Mapping[str, Any]) -> JsonDict:
+def _chopper_check(
+    chopper: Mapping[str, Any], capabilities: Mapping[str, Any]
+) -> JsonDict:
     if not bool(capabilities.get("chopper_move", False)):
         return _check_item(
             "chopper_config",
@@ -156,7 +164,9 @@ def _chopper_check(chopper: Mapping[str, Any], capabilities: Mapping[str, Any]) 
     )
 
 
-def _log_path_check(path_value: Any, *, name: str, expect_file: bool = False) -> JsonDict:
+def _log_path_check(
+    path_value: Any, *, name: str, expect_file: bool = False
+) -> JsonDict:
     if path_value in (None, ""):
         return _check_item(name, False, f"{name} is not configured")
     path = Path(str(path_value))
@@ -257,22 +267,36 @@ def run_console_self_check(
     checks.append(_capability_check(capabilities))
     checks.append(_chopper_check(chopper_config, capabilities))
 
-    live_snapshot = live_telemetry_snapshot if isinstance(live_telemetry_snapshot, Mapping) else {}
+    live_snapshot = (
+        live_telemetry_snapshot if isinstance(live_telemetry_snapshot, Mapping) else {}
+    )
     live_requested = bool(live_snapshot.get("requested"))
     live_available = bool(live_snapshot.get("available"))
     live_error = live_snapshot.get("error")
     if live_requested and live_available:
         has_position = bool(live_snapshot.get("has_position"))
-        sample_counts = live_snapshot.get("sample_counts") if isinstance(live_snapshot.get("sample_counts"), Mapping) else {}
+        sample_counts = (
+            live_snapshot.get("sample_counts")
+            if isinstance(live_snapshot.get("sample_counts"), Mapping)
+            else {}
+        )
         checks.append(
             _check_item(
                 "live_telemetry",
                 has_position or action_mode != "live",
                 (
                     f"console ROS live telemetry available ({live_snapshot.get('spin_mode') or 'unknown spin mode'}); "
-                    + ("encoder/pointing position sample received" if has_position else "waiting for encoder/pointing position sample")
+                    + (
+                        "encoder/pointing position sample received"
+                        if has_position
+                        else "waiting for encoder/pointing position sample"
+                    )
                 ),
-                severity="info" if has_position else ("error" if action_mode == "live" else "warning"),
+                severity=(
+                    "info"
+                    if has_position
+                    else ("error" if action_mode == "live" else "warning")
+                ),
                 data={**dict(live_snapshot), "sample_counts": dict(sample_counts)},
             )
         )
@@ -303,12 +327,20 @@ def run_console_self_check(
             "progress_root",
             progress_root.exists() and progress_root.is_dir(),
             f"progress root {'exists' if progress_root.exists() else 'does not exist'}: {progress_root}",
-            severity="info" if progress_root.exists() and progress_root.is_dir() else "warning",
+            severity=(
+                "info"
+                if progress_root.exists() and progress_root.is_dir()
+                else "warning"
+            ),
             data={"path": str(progress_root)},
         )
     )
-    checks.append(_log_path_check(operator_log_path, name="operator_log", expect_file=True))
-    checks.append(_log_path_check(launcher_log_dir, name="launcher_log_dir", expect_file=False))
+    checks.append(
+        _log_path_check(operator_log_path, name="operator_log", expect_file=True)
+    )
+    checks.append(
+        _log_path_check(launcher_log_dir, name="launcher_log_dir", expect_file=False)
+    )
 
     try:
         counts = process_registry.counts()
@@ -323,7 +355,9 @@ def run_console_self_check(
             )
         )
     except Exception as exc:
-        checks.append(_check_item("launcher_registry", False, f"launcher registry failed: {exc}"))
+        checks.append(
+            _check_item("launcher_registry", False, f"launcher registry failed: {exc}")
+        )
 
     progress_data: JsonDict = {"url": None, "running": False, "owned_by_console": False}
     if progress_monitor is None:
@@ -338,19 +372,29 @@ def run_console_self_check(
         )
     else:
         try:
-            status = progress_monitor.status(check_external=bool(include_progress_health))
+            status = progress_monitor.status(
+                check_external=bool(include_progress_health)
+            )
             progress_data = status.to_dict()
             checks.append(
                 _check_item(
                     "progress_monitor",
                     True,
-                    str(progress_data.get("message") or progress_data.get("status") or "progress monitor status OK"),
+                    str(
+                        progress_data.get("message")
+                        or progress_data.get("status")
+                        or "progress monitor status OK"
+                    ),
                     severity="info" if progress_data.get("running") else "warning",
                     data=progress_data,
                 )
             )
         except Exception as exc:
-            checks.append(_check_item("progress_monitor", False, f"progress monitor status failed: {exc}"))
+            checks.append(
+                _check_item(
+                    "progress_monitor", False, f"progress monitor status failed: {exc}"
+                )
+            )
 
     try:
         status_state = status_model.build_progress_status_state(
@@ -363,11 +407,17 @@ def run_console_self_check(
             _check_item(
                 "status_model",
                 isinstance(op, Mapping),
-                "status_model.build_progress_status_state returned operator_status"
-                if isinstance(op, Mapping)
-                else "status_model did not return operator_status mapping",
+                (
+                    "status_model.build_progress_status_state returned operator_status"
+                    if isinstance(op, Mapping)
+                    else "status_model did not return operator_status mapping"
+                ),
                 severity="info" if isinstance(op, Mapping) else "error",
-                data={"operator_status_schema": op.get("schema") if isinstance(op, Mapping) else None},
+                data={
+                    "operator_status_schema": (
+                        op.get("schema") if isinstance(op, Mapping) else None
+                    )
+                },
             )
         )
     except Exception as exc:
@@ -379,7 +429,8 @@ def run_console_self_check(
     warning_count = sum(
         1
         for item in checks
-        if item.get("severity") == "warning" or (not item.get("ok") and item.get("severity") != "error")
+        if item.get("severity") == "warning"
+        or (not item.get("ok") and item.get("severity") != "error")
     )
     ok = error_count == 0
     status = "ok" if ok and warning_count == 0 else ("warning" if ok else "error")

--- a/necst/web/site_config.py
+++ b/necst/web/site_config.py
@@ -1,523 +1,160 @@
-"""Site-configuration summary for the NECST Operator Console.
-
-The Operator Console must not hard-code drive limits or chopper endpoints.  This
-module resolves the active configuration into a small, dependency-light summary
-that browser status and server-side validation can both use.
-
-Resolution order
-----------------
-1. Explicit TOML path passed by ``bin/console.py --site-config``.
-2. Active ``necst.config`` / neclib configuration, when importable.
-3. CLI fallback values for mount limits only.
-
-No telescope command is sent from this module.
-"""
+"""Site configuration summary for the NECST operator console."""
 
 from __future__ import annotations
 
-import math
 import os
 import re
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, Mapping, Optional, Tuple
+from typing import Any, Dict, List, Mapping, Optional
 
-try:  # Python 3.11+
-    import tomllib  # type: ignore[attr-defined]
-except Exception:  # pragma: no cover - old Python fallback if tomli is installed
-    tomllib = None  # type: ignore[assignment]
-
-
-JsonDict = Dict[str, Any]
+try:
+    import tomllib  # Python 3.11+
+except Exception:  # pragma: no cover
+    tomllib = None  # type: ignore
 
 
-@dataclass(frozen=True)
+_DEFAULT_CAPABILITIES: Dict[str, bool] = {
+    "mount_move": True,
+    "target_tracking": True,
+    "observation_start": True,
+    "rsky": True,
+    "skydip": True,
+    "chopper_status": True,
+    "chopper_move": True,
+    "chopper_maintenance": True,
+}
+
+
+@dataclass
 class SiteConfigSummary:
-    """Small, serializable view of active site/operator settings."""
-
-    source: str
+    source: str = "defaults"
     source_path: Optional[str] = None
     observatory: Optional[str] = None
     mount_limits: Dict[str, float] = field(default_factory=dict)
-    mount_warning_limits: Dict[str, float] = field(default_factory=dict)
-    mount_drive_range: Dict[str, float] = field(default_factory=dict)
+    capabilities: Dict[str, bool] = field(default_factory=lambda: dict(_DEFAULT_CAPABILITIES))
     chopper: Dict[str, Any] = field(default_factory=dict)
-    capabilities: Dict[str, bool] = field(default_factory=dict)
-    warnings: list[str] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
 
-    def to_dict(self) -> JsonDict:
+    def to_dict(self) -> Dict[str, Any]:
         return {
             "source": self.source,
             "source_path": self.source_path,
             "observatory": self.observatory,
             "mount_limits": dict(self.mount_limits),
-            "mount_warning_limits": dict(self.mount_warning_limits),
-            "mount_drive_range": dict(self.mount_drive_range),
-            "chopper": dict(self.chopper),
             "capabilities": dict(self.capabilities),
+            "chopper": dict(self.chopper),
             "warnings": list(self.warnings),
         }
 
 
-def _finite_float(value: Any) -> Optional[float]:
-    try:
-        number = float(value)
-    except Exception:
+def _parse_deg(value: Any) -> Optional[float]:
+    if value in (None, ""):
         return None
-    return number if math.isfinite(number) else None
-
-
-def _as_mapping(value: Any) -> Mapping[str, Any]:
-    return value if isinstance(value, Mapping) else {}
-
-
-_QUANTITY_RE = re.compile(
-    r"^\s*([+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?)\s*([A-Za-z/_*\-0-9]*)\s*$"
-)
-
-
-def _quantity_to_deg(value: Any) -> Optional[float]:
-    """Convert a config quantity-like object to degrees.
-
-    Numeric values are interpreted as degrees because neclib has already parsed
-    the site TOML or because the console CLI fallback explicitly uses degrees.
-    String values are accepted only for common angular units.
-    """
-
-    if value is None:
-        return None
-    try:
-        return float(value.to_value("deg"))  # astropy Quantity
-    except Exception:
-        pass
-    try:
-        raw = getattr(value, "value")
-        unit = str(getattr(value, "unit", "deg") or "deg").lower()
-        number = float(raw)
-        if unit in {"deg", "degree", "degrees"}:
-            return number
-        if unit in {"arcmin", "arcminute", "arcminutes"}:
-            return number / 60.0
-        if unit in {"arcsec", "arcsecond", "arcseconds"}:
-            return number / 3600.0
-        if unit in {"rad", "radian", "radians"}:
-            return math.degrees(number)
-    except Exception:
-        pass
     if isinstance(value, (int, float)):
-        number = _finite_float(value)
-        return number
-    if isinstance(value, str):
-        m = _QUANTITY_RE.match(value)
-        if not m:
-            return None
-        number = _finite_float(m.group(1))
-        if number is None:
-            return None
-        unit = (m.group(2) or "deg").lower().replace(" ", "")
-        if unit in {"", "deg", "degree", "degrees"}:
-            return number
-        if unit in {"arcmin", "arcminute", "arcminutes"}:
-            return number / 60.0
-        if unit in {"arcsec", "arcsecond", "arcseconds"}:
-            return number / 3600.0
-        if unit in {"rad", "radian", "radians"}:
-            return math.degrees(number)
-    return None
-
-
-def _range_to_pair(obj: Any) -> Optional[Tuple[float, float]]:
-    """Return ``(min_deg, max_deg)`` from neclib ValueRange or TOML list."""
-
-    if obj is None:
+        return float(value)
+    text = str(value).strip()
+    match = re.search(r"[-+]?\d+(?:\.\d*)?(?:[eE][-+]?\d+)?", text)
+    if not match:
         return None
-    try:
-        values = list(obj.map(lambda x: x.to_value("deg")))
-    except Exception:
-        try:
-            values = list(obj)
-        except Exception:
-            return None
-    if len(values) < 2:
-        return None
-    lo = _quantity_to_deg(values[0])
-    hi = _quantity_to_deg(values[1])
-    if lo is None or hi is None:
-        return None
-    if not (math.isfinite(lo) and math.isfinite(hi)):
-        return None
-    return float(lo), float(hi)
+    return float(match.group(0))
 
 
-def _dict_from_range_pair(pair: Optional[Tuple[float, float]], prefix: str) -> Dict[str, float]:
-    if pair is None:
-        return {}
-    return {f"{prefix}_min": float(pair[0]), f"{prefix}_max": float(pair[1])}
-
-
-def _mount_dict(
-    az_obj: Any,
-    el_obj: Any,
-    *,
-    az_prefix: str = "az",
-    el_prefix: str = "el",
-) -> Dict[str, float]:
-    out: Dict[str, float] = {}
-    out.update(_dict_from_range_pair(_range_to_pair(az_obj), az_prefix))
-    out.update(_dict_from_range_pair(_range_to_pair(el_obj), el_prefix))
-    return out
-
-
-def _normalize_observatory(value: Any) -> Optional[str]:
-    text = str(value or "").strip()
-    return text or None
-
-
-def _maintenance_supported(observatory: Optional[str]) -> bool:
-    """Return whether chopper maintenance services should be exposed.
-
-    The current confirmed maintenance path is for the OMU 1.85 m system.  For
-    NANTEN2/NANTEN2SA these service buttons must not send commands from the GUI.
-    Unknown sites are kept conservative and treated as unsupported.
-    """
-
-    key = (observatory or "").replace("-", "").replace("_", "").upper()
-    return key in {"OMU1P85M", "OMU185M", "ALAB"}
-
-
-def _capabilities_from_summary(
-    *,
-    observatory: Optional[str],
-    mount_limits: Mapping[str, Any],
-    chopper: Mapping[str, Any],
-) -> Dict[str, bool]:
-    has_mount_limits = all(k in mount_limits for k in ("az_min", "az_max", "el_min", "el_max"))
-    has_chopper_positions = chopper.get("insert_position") is not None and chopper.get("remove_position") is not None
-    return {
-        "mount_move": bool(has_mount_limits),
-        "antenna_stop": True,
-        "abort_observation": True,
-        "observation_start": True,
-        "rsky": True,
-        "skydip": True,
-        "target_tracking": True,
-        "chopper": bool(has_chopper_positions),
-        "chopper_move": bool(has_chopper_positions),
-        "chopper_status": bool(has_chopper_positions),
-        "chopper_maintenance": bool(has_chopper_positions and _maintenance_supported(observatory)),
-    }
-
-
-def _summary_from_necst_config(config: Any) -> SiteConfigSummary:
-    observatory = _normalize_observatory(getattr(config, "observatory", None))
-    mount_limits = _mount_dict(
-        getattr(config, "antenna_drive_critical_limit_az", None),
-        getattr(config, "antenna_drive_critical_limit_el", None),
-    )
-    warning_limits = _mount_dict(
-        getattr(config, "antenna_drive_warning_limit_az", None),
-        getattr(config, "antenna_drive_warning_limit_el", None),
-    )
-    drive_range = _mount_dict(
-        getattr(config, "antenna_drive_range_az", None),
-        getattr(config, "antenna_drive_range_el", None),
-    )
-
-    chopper_position = _as_mapping(getattr(config, "chopper_motor_position", None))
-    insert_position = _finite_float(chopper_position.get("insert"))
-    remove_position = _finite_float(chopper_position.get("remove"))
-    chopper = {
-        "available": insert_position is not None and remove_position is not None,
-        "insert_position": int(insert_position) if insert_position is not None else None,
-        "remove_position": int(remove_position) if remove_position is not None else None,
-        "maintenance_supported": bool(_maintenance_supported(observatory)),
-    }
-    capabilities = _capabilities_from_summary(
-        observatory=observatory,
-        mount_limits=mount_limits,
-        chopper=chopper,
-    )
-    warnings: list[str] = []
-    if not mount_limits:
-        warnings.append("antenna drive critical limits are unavailable from necst.config")
-    if not chopper["available"]:
-        warnings.append("chopper motor insert/remove positions are unavailable from necst.config")
-    return SiteConfigSummary(
-        source="necst.config",
-        source_path=None,
-        observatory=observatory,
-        mount_limits=mount_limits,
-        mount_warning_limits=warning_limits,
-        mount_drive_range=drive_range,
-        chopper=chopper,
-        capabilities=capabilities,
-        warnings=warnings,
-    )
-
-
-def _read_toml(path: Path) -> Mapping[str, Any]:
+def _read_toml(path: Path) -> Dict[str, Any]:
     if tomllib is None:
-        raise RuntimeError("tomllib/tomli is unavailable; cannot read site TOML")
+        raise RuntimeError("tomllib is unavailable")
     with path.open("rb") as fh:
-        data = tomllib.load(fh)  # type: ignore[union-attr]
-    return data if isinstance(data, Mapping) else {}
+        payload = tomllib.load(fh)
+    return payload if isinstance(payload, dict) else {}
 
 
-def _strip_inline_comment(line: str) -> str:
-    in_single = False
-    in_double = False
-    out: list[str] = []
-    prev = ""
-    for ch in line:
-        if ch == "'" and not in_double:
-            in_single = not in_single
-        elif ch == '"' and not in_single and prev != "\\":
-            in_double = not in_double
-        if ch == "#" and not in_single and not in_double:
-            break
-        out.append(ch)
-        prev = ch
-    return "".join(out).strip()
-
-
-def _parse_toml_array_value(value: str) -> list[str]:
-    m = re.search(r"\[(.*)\]", value)
-    if not m:
-        return []
-    body = m.group(1)
-    items: list[str] = []
-    token: list[str] = []
-    in_single = False
-    in_double = False
-    prev = ""
-    for ch in body:
-        if ch == "'" and not in_double:
-            in_single = not in_single
-            continue
-        if ch == '"' and not in_single and prev != "\\":
-            in_double = not in_double
-            continue
-        if ch == "," and not in_single and not in_double:
-            item = "".join(token).strip()
-            if item:
-                items.append(item)
-            token = []
-        else:
-            token.append(ch)
-        prev = ch
-    item = "".join(token).strip()
-    if item:
-        items.append(item)
-    return items
-
-
-def _parse_inline_position(value: str) -> Dict[str, Any]:
-    out: Dict[str, Any] = {}
-    for key in ("insert", "remove"):
-        m = re.search(rf"\b{key}\s*=\s*([+-]?(?:\d+(?:\.\d*)?|\.\d+))", value)
-        if m:
-            out[key] = float(m.group(1))
-    return out
-
-
-def _summary_from_lenient_toml(path: Path, *, parse_error: Exception) -> SiteConfigSummary:
-    """Extract console-critical fields even if unrelated TOML sections fail.
-
-    Some development/default configuration files may contain duplicate sections
-    outside the fields needed by the console.  For operator safety we still read
-    only the top-level observatory, antenna drive limits, and chopper endpoints;
-    if these cannot be extracted, the corresponding capability stays disabled.
-    """
-
-    section = ""
-    observatory: Optional[str] = None
-    antenna: Dict[str, Any] = {}
-    chopper_position: Dict[str, Any] = {}
-    for raw_line in path.read_text(encoding="utf-8").splitlines():
-        line = _strip_inline_comment(raw_line)
-        if not line:
-            continue
-        if line.startswith("[") and line.endswith("]"):
-            section = line.strip("[]").strip()
-            continue
-        if "=" not in line:
-            continue
-        key, value = line.split("=", 1)
-        key = key.strip().strip('"').strip("'")
-        value = value.strip()
-        if section == "" and key == "observatory":
-            observatory = _normalize_observatory(value.strip().strip('"').strip("'"))
-        elif section == "antenna" and key in {
-            "drive_critical_limit_az",
-            "drive_critical_limit_el",
-            "drive_warning_limit_az",
-            "drive_warning_limit_el",
-            "drive_range_az",
-            "drive_range_el",
-        }:
-            antenna[key] = _parse_toml_array_value(value)
-        elif section == "chopper_motor" and key == "position":
-            chopper_position.update(_parse_inline_position(value))
-
-    mount_limits = _mount_dict(
-        antenna.get("drive_critical_limit_az"),
-        antenna.get("drive_critical_limit_el"),
-    )
-    warning_limits = _mount_dict(
-        antenna.get("drive_warning_limit_az"),
-        antenna.get("drive_warning_limit_el"),
-    )
-    drive_range = _mount_dict(
-        antenna.get("drive_range_az"),
-        antenna.get("drive_range_el"),
-    )
-    insert_position = _finite_float(chopper_position.get("insert"))
-    remove_position = _finite_float(chopper_position.get("remove"))
-    chopper = {
-        "available": insert_position is not None and remove_position is not None,
-        "insert_position": int(insert_position) if insert_position is not None else None,
-        "remove_position": int(remove_position) if remove_position is not None else None,
-        "maintenance_supported": bool(_maintenance_supported(observatory)),
-    }
-    capabilities = _capabilities_from_summary(
-        observatory=observatory,
-        mount_limits=mount_limits,
-        chopper=chopper,
-    )
-    warnings = [
-        "standard TOML parser failed; used lenient field scan for console-critical site settings: "
-        f"{parse_error}"
-    ]
-    if not mount_limits:
-        warnings.append(f"antenna drive critical limits are unavailable in {path}")
-    if not chopper["available"]:
-        warnings.append(f"chopper motor insert/remove positions are unavailable in {path}")
-    return SiteConfigSummary(
-        source="toml-lenient",
-        source_path=str(path),
-        observatory=observatory,
-        mount_limits=mount_limits,
-        mount_warning_limits=warning_limits,
-        mount_drive_range=drive_range,
-        chopper=chopper,
-        capabilities=capabilities,
-        warnings=warnings,
-    )
-
-
-def _summary_from_toml(path: Path) -> SiteConfigSummary:
+def _candidate_config_paths(site_config_path: Optional[os.PathLike[str] | str]) -> List[Path]:
+    raw: List[str] = []
+    if site_config_path not in (None, ""):
+        raw.append(str(site_config_path))
+    for env_name in ("NECST_SITE_CONFIG", "NECST_CONFIG", "NECLIB_CONFIG", "NECST_CONFIG_PATH"):
+        value = str(os.environ.get(env_name, "")).strip()
+        if value:
+            raw.append(value)
+    telescope = str(os.environ.get("TELESCOPE", os.environ.get("NECST_TELESCOPE", ""))).strip().lower()
+    default_dirs: List[Path] = []
+    source_tree_defaults = Path(__file__).resolve().parents[3] / "neclib-main" / "neclib" / "defaults"
+    default_dirs.append(source_tree_defaults)
     try:
-        raw = _read_toml(path)
-    except Exception as exc:
-        return _summary_from_lenient_toml(path, parse_error=exc)
-    observatory = _normalize_observatory(raw.get("observatory"))
-    antenna = _as_mapping(raw.get("antenna"))
-    chopper_motor = _as_mapping(raw.get("chopper_motor"))
-    position = _as_mapping(chopper_motor.get("position"))
+        import neclib  # type: ignore
 
-    mount_limits = _mount_dict(
-        antenna.get("drive_critical_limit_az"),
-        antenna.get("drive_critical_limit_el"),
-    )
-    warning_limits = _mount_dict(
-        antenna.get("drive_warning_limit_az"),
-        antenna.get("drive_warning_limit_el"),
-    )
-    drive_range = _mount_dict(
-        antenna.get("drive_range_az"),
-        antenna.get("drive_range_el"),
-    )
-    insert_position = _finite_float(position.get("insert"))
-    remove_position = _finite_float(position.get("remove"))
-    chopper = {
-        "available": insert_position is not None and remove_position is not None,
-        "insert_position": int(insert_position) if insert_position is not None else None,
-        "remove_position": int(remove_position) if remove_position is not None else None,
-        "maintenance_supported": bool(_maintenance_supported(observatory)),
-    }
-    capabilities = _capabilities_from_summary(
-        observatory=observatory,
-        mount_limits=mount_limits,
-        chopper=chopper,
-    )
-    warnings: list[str] = []
-    if not mount_limits:
-        warnings.append(f"antenna drive critical limits are unavailable in {path}")
-    if not chopper["available"]:
-        warnings.append(f"chopper motor insert/remove positions are unavailable in {path}")
-    return SiteConfigSummary(
-        source="toml",
-        source_path=str(path),
-        observatory=observatory,
-        mount_limits=mount_limits,
-        mount_warning_limits=warning_limits,
-        mount_drive_range=drive_range,
-        chopper=chopper,
-        capabilities=capabilities,
-        warnings=warnings,
-    )
-
-
-def _try_active_necst_config() -> Optional[SiteConfigSummary]:
-    try:
-        from necst import config as necst_config  # type: ignore
+        default_dirs.append(Path(neclib.__file__).resolve().parent / "defaults")
     except Exception:
-        return None
-    try:
-        return _summary_from_necst_config(necst_config)
-    except Exception as exc:
-        return SiteConfigSummary(
-            source="necst.config",
-            warnings=[f"failed to summarize necst.config: {exc}"],
-            capabilities=_capabilities_from_summary(
-                observatory=None,
-                mount_limits={},
-                chopper={},
-            ),
-        )
+        pass
+    # In source-tree fallback mode, source_tree_defaults works.  In an installed
+    # ROS/colcon environment, the importable neclib defaults path is preferred if
+    # available.  Duplicates are removed below.
+    for defaults_dir in default_dirs:
+        if telescope:
+            if "nanten2" in telescope:
+                raw.append(str(defaults_dir / "NANTEN2_config.toml"))
+            elif "1p85" in telescope or "1.85" in telescope or "omu" in telescope:
+                raw.append(str(defaults_dir / "OMU1p85m_config.toml"))
+        raw.append(str(defaults_dir / "config.toml"))
+    paths: List[Path] = []
+    seen = set()
+    for item in raw:
+        try:
+            path = Path(item).expanduser()
+        except Exception:
+            continue
+        key = str(path)
+        if key not in seen:
+            seen.add(key)
+            paths.append(path)
+    return paths
 
 
-def _apply_mount_fallbacks(
-    summary: SiteConfigSummary,
-    *,
-    az_min: Optional[float] = None,
-    az_max: Optional[float] = None,
-    el_min: Optional[float] = None,
-    el_max: Optional[float] = None,
-) -> SiteConfigSummary:
-    mount_limits = dict(summary.mount_limits)
-    fallback = {
-        "az_min": az_min,
-        "az_max": az_max,
-        "el_min": el_min,
-        "el_max": el_max,
+def _limits_from_config(config: Mapping[str, Any]) -> Dict[str, float]:
+    antenna = config.get("antenna") if isinstance(config.get("antenna"), Mapping) else {}
+    limits: Dict[str, float] = {}
+    az_range = antenna.get("drive_range_az") if isinstance(antenna, Mapping) else None
+    el_range = antenna.get("drive_range_el") if isinstance(antenna, Mapping) else None
+    if isinstance(az_range, (list, tuple)) and len(az_range) >= 2:
+        az_min = _parse_deg(az_range[0])
+        az_max = _parse_deg(az_range[1])
+        if az_min is not None and az_max is not None:
+            limits["az_min"] = az_min
+            limits["az_max"] = az_max
+    if isinstance(el_range, (list, tuple)) and len(el_range) >= 2:
+        el_min = _parse_deg(el_range[0])
+        el_max = _parse_deg(el_range[1])
+        if el_min is not None and el_max is not None:
+            limits["el_min"] = el_min
+            limits["el_max"] = el_max
+    return limits
+
+
+def _chopper_from_config(config: Mapping[str, Any]) -> Dict[str, Any]:
+    motor = config.get("chopper_motor") if isinstance(config.get("chopper_motor"), Mapping) else {}
+    pos = motor.get("position") if isinstance(motor, Mapping) and isinstance(motor.get("position"), Mapping) else {}
+    insert = pos.get("insert") if isinstance(pos, Mapping) else None
+    remove = pos.get("remove") if isinstance(pos, Mapping) else None
+    available = bool(motor) and insert not in (None, "") and remove not in (None, "")
+    return {
+        "available": available,
+        "insert_position": insert,
+        "remove_position": remove,
+        "maintenance_supported": available,
     }
-    used: list[str] = []
-    for key, value in fallback.items():
-        if key not in mount_limits and value is not None:
-            number = _finite_float(value)
-            if number is not None:
-                mount_limits[key] = float(number)
-                used.append(key)
-    capabilities = _capabilities_from_summary(
-        observatory=summary.observatory,
-        mount_limits=mount_limits,
-        chopper=summary.chopper,
-    )
-    warnings = list(summary.warnings)
-    if used:
-        warnings.append("using CLI fallback mount limit(s): " + ", ".join(sorted(used)))
-    return SiteConfigSummary(
-        source=summary.source,
-        source_path=summary.source_path,
-        observatory=summary.observatory,
-        mount_limits=mount_limits,
-        mount_warning_limits=dict(summary.mount_warning_limits),
-        mount_drive_range=dict(summary.mount_drive_range),
-        chopper=dict(summary.chopper),
-        capabilities=capabilities,
-        warnings=warnings,
-    )
+
+
+def _capabilities_from_config(config: Mapping[str, Any], chopper: Mapping[str, Any]) -> Dict[str, bool]:
+    caps = dict(_DEFAULT_CAPABILITIES)
+    custom = config.get("operator_console") if isinstance(config.get("operator_console"), Mapping) else {}
+    custom_caps = custom.get("capabilities") if isinstance(custom.get("capabilities"), Mapping) else {}
+    for key, value in custom_caps.items():
+        caps[str(key)] = bool(value)
+    if not bool(chopper.get("available")):
+        caps["chopper_move"] = False
+        caps["chopper_maintenance"] = False
+    return caps
 
 
 def resolve_site_config(
@@ -528,48 +165,39 @@ def resolve_site_config(
     el_min: Optional[float] = None,
     el_max: Optional[float] = None,
 ) -> SiteConfigSummary:
-    """Resolve active site configuration for the Operator Console."""
-
-    warnings: list[str] = []
-    if site_config_path:
-        path = Path(site_config_path).expanduser()
+    warnings: List[str] = []
+    config: Dict[str, Any] = {}
+    source = "unresolved"
+    source_path: Optional[str] = None
+    for path in _candidate_config_paths(site_config_path):
+        if not path.exists():
+            continue
         try:
-            summary = _summary_from_toml(path)
+            config = _read_toml(path)
+            source = "site_config_path" if site_config_path not in (None, "") and Path(site_config_path).expanduser() == path else "default_config"
+            source_path = str(path)
+            break
         except Exception as exc:
-            summary = SiteConfigSummary(
-                source="toml",
-                source_path=str(path),
-                warnings=[f"failed to read site config TOML {path}: {exc}"],
-                capabilities=_capabilities_from_summary(
-                    observatory=None,
-                    mount_limits={},
-                    chopper={},
-                ),
-            )
-        return _apply_mount_fallbacks(
-            summary,
-            az_min=az_min,
-            az_max=az_max,
-            el_min=el_min,
-            el_max=el_max,
-        )
-
-    active = _try_active_necst_config()
-    if active is None:
-        warnings.append("necst.config is unavailable; site TOML was not explicitly provided")
-        active = SiteConfigSummary(
-            source="fallback",
-            warnings=warnings,
-            capabilities=_capabilities_from_summary(
-                observatory=None,
-                mount_limits={},
-                chopper={},
-            ),
-        )
-    return _apply_mount_fallbacks(
-        active,
-        az_min=az_min,
-        az_max=az_max,
-        el_min=el_min,
-        el_max=el_max,
+            warnings.append(f"failed to read site config {path}: {exc}")
+    if not config:
+        warnings.append("no site TOML config found; using conservative console defaults")
+    limits = _limits_from_config(config)
+    overrides = {"az_min": az_min, "az_max": az_max, "el_min": el_min, "el_max": el_max}
+    for key, value in overrides.items():
+        if value is not None:
+            try:
+                limits[key] = float(value)
+            except Exception:
+                warnings.append(f"invalid CLI mount limit {key}={value!r}")
+    chopper = _chopper_from_config(config)
+    caps = _capabilities_from_config(config, chopper)
+    observatory = config.get("observatory") if isinstance(config, Mapping) else None
+    return SiteConfigSummary(
+        source=source,
+        source_path=source_path,
+        observatory=str(observatory) if observatory not in (None, "") else None,
+        mount_limits=limits,
+        capabilities=caps,
+        chopper=chopper,
+        warnings=warnings,
     )

--- a/necst/web/site_config.py
+++ b/necst/web/site_config.py
@@ -1,0 +1,575 @@
+"""Site-configuration summary for the NECST Operator Console.
+
+The Operator Console must not hard-code drive limits or chopper endpoints.  This
+module resolves the active configuration into a small, dependency-light summary
+that browser status and server-side validation can both use.
+
+Resolution order
+----------------
+1. Explicit TOML path passed by ``bin/console.py --site-config``.
+2. Active ``necst.config`` / neclib configuration, when importable.
+3. CLI fallback values for mount limits only.
+
+No telescope command is sent from this module.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Mapping, Optional, Tuple
+
+try:  # Python 3.11+
+    import tomllib  # type: ignore[attr-defined]
+except Exception:  # pragma: no cover - old Python fallback if tomli is installed
+    tomllib = None  # type: ignore[assignment]
+
+
+JsonDict = Dict[str, Any]
+
+
+@dataclass(frozen=True)
+class SiteConfigSummary:
+    """Small, serializable view of active site/operator settings."""
+
+    source: str
+    source_path: Optional[str] = None
+    observatory: Optional[str] = None
+    mount_limits: Dict[str, float] = field(default_factory=dict)
+    mount_warning_limits: Dict[str, float] = field(default_factory=dict)
+    mount_drive_range: Dict[str, float] = field(default_factory=dict)
+    chopper: Dict[str, Any] = field(default_factory=dict)
+    capabilities: Dict[str, bool] = field(default_factory=dict)
+    warnings: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> JsonDict:
+        return {
+            "source": self.source,
+            "source_path": self.source_path,
+            "observatory": self.observatory,
+            "mount_limits": dict(self.mount_limits),
+            "mount_warning_limits": dict(self.mount_warning_limits),
+            "mount_drive_range": dict(self.mount_drive_range),
+            "chopper": dict(self.chopper),
+            "capabilities": dict(self.capabilities),
+            "warnings": list(self.warnings),
+        }
+
+
+def _finite_float(value: Any) -> Optional[float]:
+    try:
+        number = float(value)
+    except Exception:
+        return None
+    return number if math.isfinite(number) else None
+
+
+def _as_mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+_QUANTITY_RE = re.compile(
+    r"^\s*([+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?)\s*([A-Za-z/_*\-0-9]*)\s*$"
+)
+
+
+def _quantity_to_deg(value: Any) -> Optional[float]:
+    """Convert a config quantity-like object to degrees.
+
+    Numeric values are interpreted as degrees because neclib has already parsed
+    the site TOML or because the console CLI fallback explicitly uses degrees.
+    String values are accepted only for common angular units.
+    """
+
+    if value is None:
+        return None
+    try:
+        return float(value.to_value("deg"))  # astropy Quantity
+    except Exception:
+        pass
+    try:
+        raw = getattr(value, "value")
+        unit = str(getattr(value, "unit", "deg") or "deg").lower()
+        number = float(raw)
+        if unit in {"deg", "degree", "degrees"}:
+            return number
+        if unit in {"arcmin", "arcminute", "arcminutes"}:
+            return number / 60.0
+        if unit in {"arcsec", "arcsecond", "arcseconds"}:
+            return number / 3600.0
+        if unit in {"rad", "radian", "radians"}:
+            return math.degrees(number)
+    except Exception:
+        pass
+    if isinstance(value, (int, float)):
+        number = _finite_float(value)
+        return number
+    if isinstance(value, str):
+        m = _QUANTITY_RE.match(value)
+        if not m:
+            return None
+        number = _finite_float(m.group(1))
+        if number is None:
+            return None
+        unit = (m.group(2) or "deg").lower().replace(" ", "")
+        if unit in {"", "deg", "degree", "degrees"}:
+            return number
+        if unit in {"arcmin", "arcminute", "arcminutes"}:
+            return number / 60.0
+        if unit in {"arcsec", "arcsecond", "arcseconds"}:
+            return number / 3600.0
+        if unit in {"rad", "radian", "radians"}:
+            return math.degrees(number)
+    return None
+
+
+def _range_to_pair(obj: Any) -> Optional[Tuple[float, float]]:
+    """Return ``(min_deg, max_deg)`` from neclib ValueRange or TOML list."""
+
+    if obj is None:
+        return None
+    try:
+        values = list(obj.map(lambda x: x.to_value("deg")))
+    except Exception:
+        try:
+            values = list(obj)
+        except Exception:
+            return None
+    if len(values) < 2:
+        return None
+    lo = _quantity_to_deg(values[0])
+    hi = _quantity_to_deg(values[1])
+    if lo is None or hi is None:
+        return None
+    if not (math.isfinite(lo) and math.isfinite(hi)):
+        return None
+    return float(lo), float(hi)
+
+
+def _dict_from_range_pair(pair: Optional[Tuple[float, float]], prefix: str) -> Dict[str, float]:
+    if pair is None:
+        return {}
+    return {f"{prefix}_min": float(pair[0]), f"{prefix}_max": float(pair[1])}
+
+
+def _mount_dict(
+    az_obj: Any,
+    el_obj: Any,
+    *,
+    az_prefix: str = "az",
+    el_prefix: str = "el",
+) -> Dict[str, float]:
+    out: Dict[str, float] = {}
+    out.update(_dict_from_range_pair(_range_to_pair(az_obj), az_prefix))
+    out.update(_dict_from_range_pair(_range_to_pair(el_obj), el_prefix))
+    return out
+
+
+def _normalize_observatory(value: Any) -> Optional[str]:
+    text = str(value or "").strip()
+    return text or None
+
+
+def _maintenance_supported(observatory: Optional[str]) -> bool:
+    """Return whether chopper maintenance services should be exposed.
+
+    The current confirmed maintenance path is for the OMU 1.85 m system.  For
+    NANTEN2/NANTEN2SA these service buttons must not send commands from the GUI.
+    Unknown sites are kept conservative and treated as unsupported.
+    """
+
+    key = (observatory or "").replace("-", "").replace("_", "").upper()
+    return key in {"OMU1P85M", "OMU185M", "ALAB"}
+
+
+def _capabilities_from_summary(
+    *,
+    observatory: Optional[str],
+    mount_limits: Mapping[str, Any],
+    chopper: Mapping[str, Any],
+) -> Dict[str, bool]:
+    has_mount_limits = all(k in mount_limits for k in ("az_min", "az_max", "el_min", "el_max"))
+    has_chopper_positions = chopper.get("insert_position") is not None and chopper.get("remove_position") is not None
+    return {
+        "mount_move": bool(has_mount_limits),
+        "antenna_stop": True,
+        "abort_observation": True,
+        "observation_start": True,
+        "rsky": True,
+        "skydip": True,
+        "target_tracking": True,
+        "chopper": bool(has_chopper_positions),
+        "chopper_move": bool(has_chopper_positions),
+        "chopper_status": bool(has_chopper_positions),
+        "chopper_maintenance": bool(has_chopper_positions and _maintenance_supported(observatory)),
+    }
+
+
+def _summary_from_necst_config(config: Any) -> SiteConfigSummary:
+    observatory = _normalize_observatory(getattr(config, "observatory", None))
+    mount_limits = _mount_dict(
+        getattr(config, "antenna_drive_critical_limit_az", None),
+        getattr(config, "antenna_drive_critical_limit_el", None),
+    )
+    warning_limits = _mount_dict(
+        getattr(config, "antenna_drive_warning_limit_az", None),
+        getattr(config, "antenna_drive_warning_limit_el", None),
+    )
+    drive_range = _mount_dict(
+        getattr(config, "antenna_drive_range_az", None),
+        getattr(config, "antenna_drive_range_el", None),
+    )
+
+    chopper_position = _as_mapping(getattr(config, "chopper_motor_position", None))
+    insert_position = _finite_float(chopper_position.get("insert"))
+    remove_position = _finite_float(chopper_position.get("remove"))
+    chopper = {
+        "available": insert_position is not None and remove_position is not None,
+        "insert_position": int(insert_position) if insert_position is not None else None,
+        "remove_position": int(remove_position) if remove_position is not None else None,
+        "maintenance_supported": bool(_maintenance_supported(observatory)),
+    }
+    capabilities = _capabilities_from_summary(
+        observatory=observatory,
+        mount_limits=mount_limits,
+        chopper=chopper,
+    )
+    warnings: list[str] = []
+    if not mount_limits:
+        warnings.append("antenna drive critical limits are unavailable from necst.config")
+    if not chopper["available"]:
+        warnings.append("chopper motor insert/remove positions are unavailable from necst.config")
+    return SiteConfigSummary(
+        source="necst.config",
+        source_path=None,
+        observatory=observatory,
+        mount_limits=mount_limits,
+        mount_warning_limits=warning_limits,
+        mount_drive_range=drive_range,
+        chopper=chopper,
+        capabilities=capabilities,
+        warnings=warnings,
+    )
+
+
+def _read_toml(path: Path) -> Mapping[str, Any]:
+    if tomllib is None:
+        raise RuntimeError("tomllib/tomli is unavailable; cannot read site TOML")
+    with path.open("rb") as fh:
+        data = tomllib.load(fh)  # type: ignore[union-attr]
+    return data if isinstance(data, Mapping) else {}
+
+
+def _strip_inline_comment(line: str) -> str:
+    in_single = False
+    in_double = False
+    out: list[str] = []
+    prev = ""
+    for ch in line:
+        if ch == "'" and not in_double:
+            in_single = not in_single
+        elif ch == '"' and not in_single and prev != "\\":
+            in_double = not in_double
+        if ch == "#" and not in_single and not in_double:
+            break
+        out.append(ch)
+        prev = ch
+    return "".join(out).strip()
+
+
+def _parse_toml_array_value(value: str) -> list[str]:
+    m = re.search(r"\[(.*)\]", value)
+    if not m:
+        return []
+    body = m.group(1)
+    items: list[str] = []
+    token: list[str] = []
+    in_single = False
+    in_double = False
+    prev = ""
+    for ch in body:
+        if ch == "'" and not in_double:
+            in_single = not in_single
+            continue
+        if ch == '"' and not in_single and prev != "\\":
+            in_double = not in_double
+            continue
+        if ch == "," and not in_single and not in_double:
+            item = "".join(token).strip()
+            if item:
+                items.append(item)
+            token = []
+        else:
+            token.append(ch)
+        prev = ch
+    item = "".join(token).strip()
+    if item:
+        items.append(item)
+    return items
+
+
+def _parse_inline_position(value: str) -> Dict[str, Any]:
+    out: Dict[str, Any] = {}
+    for key in ("insert", "remove"):
+        m = re.search(rf"\b{key}\s*=\s*([+-]?(?:\d+(?:\.\d*)?|\.\d+))", value)
+        if m:
+            out[key] = float(m.group(1))
+    return out
+
+
+def _summary_from_lenient_toml(path: Path, *, parse_error: Exception) -> SiteConfigSummary:
+    """Extract console-critical fields even if unrelated TOML sections fail.
+
+    Some development/default configuration files may contain duplicate sections
+    outside the fields needed by the console.  For operator safety we still read
+    only the top-level observatory, antenna drive limits, and chopper endpoints;
+    if these cannot be extracted, the corresponding capability stays disabled.
+    """
+
+    section = ""
+    observatory: Optional[str] = None
+    antenna: Dict[str, Any] = {}
+    chopper_position: Dict[str, Any] = {}
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = _strip_inline_comment(raw_line)
+        if not line:
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            section = line.strip("[]").strip()
+            continue
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip().strip('"').strip("'")
+        value = value.strip()
+        if section == "" and key == "observatory":
+            observatory = _normalize_observatory(value.strip().strip('"').strip("'"))
+        elif section == "antenna" and key in {
+            "drive_critical_limit_az",
+            "drive_critical_limit_el",
+            "drive_warning_limit_az",
+            "drive_warning_limit_el",
+            "drive_range_az",
+            "drive_range_el",
+        }:
+            antenna[key] = _parse_toml_array_value(value)
+        elif section == "chopper_motor" and key == "position":
+            chopper_position.update(_parse_inline_position(value))
+
+    mount_limits = _mount_dict(
+        antenna.get("drive_critical_limit_az"),
+        antenna.get("drive_critical_limit_el"),
+    )
+    warning_limits = _mount_dict(
+        antenna.get("drive_warning_limit_az"),
+        antenna.get("drive_warning_limit_el"),
+    )
+    drive_range = _mount_dict(
+        antenna.get("drive_range_az"),
+        antenna.get("drive_range_el"),
+    )
+    insert_position = _finite_float(chopper_position.get("insert"))
+    remove_position = _finite_float(chopper_position.get("remove"))
+    chopper = {
+        "available": insert_position is not None and remove_position is not None,
+        "insert_position": int(insert_position) if insert_position is not None else None,
+        "remove_position": int(remove_position) if remove_position is not None else None,
+        "maintenance_supported": bool(_maintenance_supported(observatory)),
+    }
+    capabilities = _capabilities_from_summary(
+        observatory=observatory,
+        mount_limits=mount_limits,
+        chopper=chopper,
+    )
+    warnings = [
+        "standard TOML parser failed; used lenient field scan for console-critical site settings: "
+        f"{parse_error}"
+    ]
+    if not mount_limits:
+        warnings.append(f"antenna drive critical limits are unavailable in {path}")
+    if not chopper["available"]:
+        warnings.append(f"chopper motor insert/remove positions are unavailable in {path}")
+    return SiteConfigSummary(
+        source="toml-lenient",
+        source_path=str(path),
+        observatory=observatory,
+        mount_limits=mount_limits,
+        mount_warning_limits=warning_limits,
+        mount_drive_range=drive_range,
+        chopper=chopper,
+        capabilities=capabilities,
+        warnings=warnings,
+    )
+
+
+def _summary_from_toml(path: Path) -> SiteConfigSummary:
+    try:
+        raw = _read_toml(path)
+    except Exception as exc:
+        return _summary_from_lenient_toml(path, parse_error=exc)
+    observatory = _normalize_observatory(raw.get("observatory"))
+    antenna = _as_mapping(raw.get("antenna"))
+    chopper_motor = _as_mapping(raw.get("chopper_motor"))
+    position = _as_mapping(chopper_motor.get("position"))
+
+    mount_limits = _mount_dict(
+        antenna.get("drive_critical_limit_az"),
+        antenna.get("drive_critical_limit_el"),
+    )
+    warning_limits = _mount_dict(
+        antenna.get("drive_warning_limit_az"),
+        antenna.get("drive_warning_limit_el"),
+    )
+    drive_range = _mount_dict(
+        antenna.get("drive_range_az"),
+        antenna.get("drive_range_el"),
+    )
+    insert_position = _finite_float(position.get("insert"))
+    remove_position = _finite_float(position.get("remove"))
+    chopper = {
+        "available": insert_position is not None and remove_position is not None,
+        "insert_position": int(insert_position) if insert_position is not None else None,
+        "remove_position": int(remove_position) if remove_position is not None else None,
+        "maintenance_supported": bool(_maintenance_supported(observatory)),
+    }
+    capabilities = _capabilities_from_summary(
+        observatory=observatory,
+        mount_limits=mount_limits,
+        chopper=chopper,
+    )
+    warnings: list[str] = []
+    if not mount_limits:
+        warnings.append(f"antenna drive critical limits are unavailable in {path}")
+    if not chopper["available"]:
+        warnings.append(f"chopper motor insert/remove positions are unavailable in {path}")
+    return SiteConfigSummary(
+        source="toml",
+        source_path=str(path),
+        observatory=observatory,
+        mount_limits=mount_limits,
+        mount_warning_limits=warning_limits,
+        mount_drive_range=drive_range,
+        chopper=chopper,
+        capabilities=capabilities,
+        warnings=warnings,
+    )
+
+
+def _try_active_necst_config() -> Optional[SiteConfigSummary]:
+    try:
+        from necst import config as necst_config  # type: ignore
+    except Exception:
+        return None
+    try:
+        return _summary_from_necst_config(necst_config)
+    except Exception as exc:
+        return SiteConfigSummary(
+            source="necst.config",
+            warnings=[f"failed to summarize necst.config: {exc}"],
+            capabilities=_capabilities_from_summary(
+                observatory=None,
+                mount_limits={},
+                chopper={},
+            ),
+        )
+
+
+def _apply_mount_fallbacks(
+    summary: SiteConfigSummary,
+    *,
+    az_min: Optional[float] = None,
+    az_max: Optional[float] = None,
+    el_min: Optional[float] = None,
+    el_max: Optional[float] = None,
+) -> SiteConfigSummary:
+    mount_limits = dict(summary.mount_limits)
+    fallback = {
+        "az_min": az_min,
+        "az_max": az_max,
+        "el_min": el_min,
+        "el_max": el_max,
+    }
+    used: list[str] = []
+    for key, value in fallback.items():
+        if key not in mount_limits and value is not None:
+            number = _finite_float(value)
+            if number is not None:
+                mount_limits[key] = float(number)
+                used.append(key)
+    capabilities = _capabilities_from_summary(
+        observatory=summary.observatory,
+        mount_limits=mount_limits,
+        chopper=summary.chopper,
+    )
+    warnings = list(summary.warnings)
+    if used:
+        warnings.append("using CLI fallback mount limit(s): " + ", ".join(sorted(used)))
+    return SiteConfigSummary(
+        source=summary.source,
+        source_path=summary.source_path,
+        observatory=summary.observatory,
+        mount_limits=mount_limits,
+        mount_warning_limits=dict(summary.mount_warning_limits),
+        mount_drive_range=dict(summary.mount_drive_range),
+        chopper=dict(summary.chopper),
+        capabilities=capabilities,
+        warnings=warnings,
+    )
+
+
+def resolve_site_config(
+    *,
+    site_config_path: Optional[os.PathLike[str] | str] = None,
+    az_min: Optional[float] = None,
+    az_max: Optional[float] = None,
+    el_min: Optional[float] = None,
+    el_max: Optional[float] = None,
+) -> SiteConfigSummary:
+    """Resolve active site configuration for the Operator Console."""
+
+    warnings: list[str] = []
+    if site_config_path:
+        path = Path(site_config_path).expanduser()
+        try:
+            summary = _summary_from_toml(path)
+        except Exception as exc:
+            summary = SiteConfigSummary(
+                source="toml",
+                source_path=str(path),
+                warnings=[f"failed to read site config TOML {path}: {exc}"],
+                capabilities=_capabilities_from_summary(
+                    observatory=None,
+                    mount_limits={},
+                    chopper={},
+                ),
+            )
+        return _apply_mount_fallbacks(
+            summary,
+            az_min=az_min,
+            az_max=az_max,
+            el_min=el_min,
+            el_max=el_max,
+        )
+
+    active = _try_active_necst_config()
+    if active is None:
+        warnings.append("necst.config is unavailable; site TOML was not explicitly provided")
+        active = SiteConfigSummary(
+            source="fallback",
+            warnings=warnings,
+            capabilities=_capabilities_from_summary(
+                observatory=None,
+                mount_limits={},
+                chopper={},
+            ),
+        )
+    return _apply_mount_fallbacks(
+        active,
+        az_min=az_min,
+        az_max=az_max,
+        el_min=el_min,
+        el_max=el_max,
+    )

--- a/necst/web/site_config.py
+++ b/necst/web/site_config.py
@@ -37,6 +37,7 @@ class SiteConfigSummary:
     mount_limits: Dict[str, float] = field(default_factory=dict)
     capabilities: Dict[str, bool] = field(default_factory=lambda: dict(_DEFAULT_CAPABILITIES))
     chopper: Dict[str, Any] = field(default_factory=dict)
+    observation_log: Dict[str, Any] = field(default_factory=dict)
     health: node_health.NodeHealthConfig = field(default_factory=node_health.NodeHealthConfig)
     warnings: List[str] = field(default_factory=list)
 
@@ -48,6 +49,7 @@ class SiteConfigSummary:
             "mount_limits": dict(self.mount_limits),
             "capabilities": dict(self.capabilities),
             "chopper": dict(self.chopper),
+            "observation_log": dict(self.observation_log),
             "health": self.health.to_dict(),
             "warnings": list(self.warnings),
         }
@@ -73,15 +75,44 @@ def _read_toml(path: Path) -> Dict[str, Any]:
     return payload if isinstance(payload, dict) else {}
 
 
+def _telescope_config_filename() -> str:
+    telescope = str(os.environ.get("TELESCOPE", os.environ.get("NECST_TELESCOPE", ""))).strip()
+    return f"{telescope}_config.toml" if telescope else "config.toml"
+
+
 def _candidate_config_paths(site_config_path: Optional[os.PathLike[str] | str]) -> List[Path]:
     raw: List[str] = []
     if site_config_path not in (None, ""):
         raw.append(str(site_config_path))
+
+    # Explicit overrides first.  These are console-specific escape hatches and
+    # keep working even if neclib is not importable in a reduced smoke-test env.
     for env_name in ("NECST_SITE_CONFIG", "NECST_CONFIG", "NECLIB_CONFIG", "NECST_CONFIG_PATH"):
         value = str(os.environ.get(env_name, "")).strip()
         if value:
             raw.append(value)
-    telescope = str(os.environ.get("TELESCOPE", os.environ.get("NECST_TELESCOPE", ""))).strip().lower()
+
+    # Match neclib's normal configuration lookup before falling back to bundled
+    # defaults.  The actual telescope site TOML is usually
+    #   $NECST_ROOT/${TELESCOPE}_config.toml
+    # or
+    #   ~/.necst/${TELESCOPE}_config.toml
+    # so omitting these paths makes console-only additions such as
+    # [console.health] invisible on the real telescope.
+    config_file_name = _telescope_config_filename()
+    necst_root = str(os.environ.get("NECST_ROOT", "")).strip()
+    if necst_root:
+        raw.append(str(Path(necst_root).expanduser() / config_file_name))
+    raw.append(str(Path.home() / ".necst" / config_file_name))
+
+    try:
+        from neclib.core.configuration import find_config  # type: ignore
+
+        raw.append(str(find_config()))
+    except Exception:
+        pass
+
+    telescope_key = str(os.environ.get("TELESCOPE", os.environ.get("NECST_TELESCOPE", ""))).strip().lower()
     default_dirs: List[Path] = []
     source_tree_defaults = Path(__file__).resolve().parents[3] / "neclib-main" / "neclib" / "defaults"
     default_dirs.append(source_tree_defaults)
@@ -95,10 +126,11 @@ def _candidate_config_paths(site_config_path: Optional[os.PathLike[str] | str]) 
     # ROS/colcon environment, the importable neclib defaults path is preferred if
     # available.  Duplicates are removed below.
     for defaults_dir in default_dirs:
-        if telescope:
-            if "nanten2" in telescope:
+        if telescope_key:
+            raw.append(str(defaults_dir / config_file_name))
+            if "nanten2" in telescope_key:
                 raw.append(str(defaults_dir / "NANTEN2_config.toml"))
-            elif "1p85" in telescope or "1.85" in telescope or "omu" in telescope:
+            elif "1p85" in telescope_key or "1.85" in telescope_key or "omu" in telescope_key:
                 raw.append(str(defaults_dir / "OMU1p85m_config.toml"))
         raw.append(str(defaults_dir / "config.toml"))
     paths: List[Path] = []
@@ -161,6 +193,64 @@ def _capabilities_from_config(config: Mapping[str, Any], chopper: Mapping[str, A
     return caps
 
 
+
+
+def _observation_log_from_config(config: Mapping[str, Any]) -> Dict[str, Any]:
+    """Return console observation-log settings from site TOML.
+
+    Supported forms are intentionally small and console-local.  ``directory`` is
+    the preferred key because the observation CSV must be written by the
+    operator-console process, not necessarily by the recorder/spectrometer PC.
+    """
+    console = config.get("console") if isinstance(config.get("console"), Mapping) else {}
+    raw = {}
+    if isinstance(console, Mapping):
+        for key in ("observation_log", "obslog"):
+            value = console.get(key)
+            if isinstance(value, Mapping):
+                raw = dict(value)
+                break
+    out: Dict[str, Any] = {}
+    warnings: List[str] = []
+
+    for key in ("directory", "dir", "log_dir", "path"):
+        value = raw.get(key)
+        if value not in (None, ""):
+            out["directory"] = str(value).strip()
+            break
+
+    for key in ("prefix", "filename_prefix"):
+        value = raw.get(key)
+        if value not in (None, ""):
+            out["prefix"] = str(value).strip()
+            break
+
+    for key in ("user", "observer", "operator"):
+        value = raw.get(key)
+        if value not in (None, ""):
+            out["user"] = str(value).strip()
+            break
+
+    record_roots: List[str] = []
+    for key in ("record_root", "record_roots"):
+        value = raw.get(key)
+        if value in (None, ""):
+            continue
+        if isinstance(value, (list, tuple)):
+            record_roots.extend(str(item).strip() for item in value if str(item or "").strip())
+        else:
+            record_roots.append(str(value).strip())
+    if record_roots:
+        out["record_roots"] = record_roots
+        warnings.append(
+            "console.observation_log.record_root is only a fallback candidate for <record_root>/obslogs; "
+            "prefer console.observation_log.directory when the recorder root is on another PC or is not mounted"
+        )
+
+    if warnings:
+        out["warnings"] = warnings
+    return out
+
 def resolve_site_config(
     *,
     site_config_path: Optional[os.PathLike[str] | str] = None,
@@ -195,6 +285,7 @@ def resolve_site_config(
                 warnings.append(f"invalid CLI mount limit {key}={value!r}")
     chopper = _chopper_from_config(config)
     caps = _capabilities_from_config(config, chopper)
+    obslog = _observation_log_from_config(config)
     health = node_health.config_from_mapping(config)
     observatory = config.get("observatory") if isinstance(config, Mapping) else None
     return SiteConfigSummary(
@@ -204,6 +295,7 @@ def resolve_site_config(
         mount_limits=limits,
         capabilities=caps,
         chopper=chopper,
+        observation_log=obslog,
         health=health,
-        warnings=warnings + list(health.warnings),
+        warnings=warnings + list(obslog.get("warnings", [])) + list(health.warnings),
     )

--- a/necst/web/site_config.py
+++ b/necst/web/site_config.py
@@ -9,6 +9,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional
 
+from . import node_health
+
 try:
     import tomllib  # Python 3.11+
 except Exception:  # pragma: no cover
@@ -35,6 +37,7 @@ class SiteConfigSummary:
     mount_limits: Dict[str, float] = field(default_factory=dict)
     capabilities: Dict[str, bool] = field(default_factory=lambda: dict(_DEFAULT_CAPABILITIES))
     chopper: Dict[str, Any] = field(default_factory=dict)
+    health: node_health.NodeHealthConfig = field(default_factory=node_health.NodeHealthConfig)
     warnings: List[str] = field(default_factory=list)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -45,6 +48,7 @@ class SiteConfigSummary:
             "mount_limits": dict(self.mount_limits),
             "capabilities": dict(self.capabilities),
             "chopper": dict(self.chopper),
+            "health": self.health.to_dict(),
             "warnings": list(self.warnings),
         }
 
@@ -191,6 +195,7 @@ def resolve_site_config(
                 warnings.append(f"invalid CLI mount limit {key}={value!r}")
     chopper = _chopper_from_config(config)
     caps = _capabilities_from_config(config, chopper)
+    health = node_health.config_from_mapping(config)
     observatory = config.get("observatory") if isinstance(config, Mapping) else None
     return SiteConfigSummary(
         source=source,
@@ -199,5 +204,6 @@ def resolve_site_config(
         mount_limits=limits,
         capabilities=caps,
         chopper=chopper,
-        warnings=warnings,
+        health=health,
+        warnings=warnings + list(health.warnings),
     )

--- a/necst/web/site_config.py
+++ b/necst/web/site_config.py
@@ -35,10 +35,14 @@ class SiteConfigSummary:
     source_path: Optional[str] = None
     observatory: Optional[str] = None
     mount_limits: Dict[str, float] = field(default_factory=dict)
-    capabilities: Dict[str, bool] = field(default_factory=lambda: dict(_DEFAULT_CAPABILITIES))
+    capabilities: Dict[str, bool] = field(
+        default_factory=lambda: dict(_DEFAULT_CAPABILITIES)
+    )
     chopper: Dict[str, Any] = field(default_factory=dict)
     observation_log: Dict[str, Any] = field(default_factory=dict)
-    health: node_health.NodeHealthConfig = field(default_factory=node_health.NodeHealthConfig)
+    health: node_health.NodeHealthConfig = field(
+        default_factory=node_health.NodeHealthConfig
+    )
     warnings: List[str] = field(default_factory=list)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -76,18 +80,27 @@ def _read_toml(path: Path) -> Dict[str, Any]:
 
 
 def _telescope_config_filename() -> str:
-    telescope = str(os.environ.get("TELESCOPE", os.environ.get("NECST_TELESCOPE", ""))).strip()
+    telescope = str(
+        os.environ.get("TELESCOPE", os.environ.get("NECST_TELESCOPE", ""))
+    ).strip()
     return f"{telescope}_config.toml" if telescope else "config.toml"
 
 
-def _candidate_config_paths(site_config_path: Optional[os.PathLike[str] | str]) -> List[Path]:
+def _candidate_config_paths(
+    site_config_path: Optional[os.PathLike[str] | str],
+) -> List[Path]:
     raw: List[str] = []
     if site_config_path not in (None, ""):
         raw.append(str(site_config_path))
 
     # Explicit overrides first.  These are console-specific escape hatches and
     # keep working even if neclib is not importable in a reduced smoke-test env.
-    for env_name in ("NECST_SITE_CONFIG", "NECST_CONFIG", "NECLIB_CONFIG", "NECST_CONFIG_PATH"):
+    for env_name in (
+        "NECST_SITE_CONFIG",
+        "NECST_CONFIG",
+        "NECLIB_CONFIG",
+        "NECST_CONFIG_PATH",
+    ):
         value = str(os.environ.get(env_name, "")).strip()
         if value:
             raw.append(value)
@@ -112,9 +125,15 @@ def _candidate_config_paths(site_config_path: Optional[os.PathLike[str] | str]) 
     except Exception:
         pass
 
-    telescope_key = str(os.environ.get("TELESCOPE", os.environ.get("NECST_TELESCOPE", ""))).strip().lower()
+    telescope_key = (
+        str(os.environ.get("TELESCOPE", os.environ.get("NECST_TELESCOPE", "")))
+        .strip()
+        .lower()
+    )
     default_dirs: List[Path] = []
-    source_tree_defaults = Path(__file__).resolve().parents[3] / "neclib-main" / "neclib" / "defaults"
+    source_tree_defaults = (
+        Path(__file__).resolve().parents[3] / "neclib-main" / "neclib" / "defaults"
+    )
     default_dirs.append(source_tree_defaults)
     try:
         import neclib  # type: ignore
@@ -130,7 +149,11 @@ def _candidate_config_paths(site_config_path: Optional[os.PathLike[str] | str]) 
             raw.append(str(defaults_dir / config_file_name))
             if "nanten2" in telescope_key:
                 raw.append(str(defaults_dir / "NANTEN2_config.toml"))
-            elif "1p85" in telescope_key or "1.85" in telescope_key or "omu" in telescope_key:
+            elif (
+                "1p85" in telescope_key
+                or "1.85" in telescope_key
+                or "omu" in telescope_key
+            ):
                 raw.append(str(defaults_dir / "OMU1p85m_config.toml"))
         raw.append(str(defaults_dir / "config.toml"))
     paths: List[Path] = []
@@ -148,7 +171,9 @@ def _candidate_config_paths(site_config_path: Optional[os.PathLike[str] | str]) 
 
 
 def _limits_from_config(config: Mapping[str, Any]) -> Dict[str, float]:
-    antenna = config.get("antenna") if isinstance(config.get("antenna"), Mapping) else {}
+    antenna = (
+        config.get("antenna") if isinstance(config.get("antenna"), Mapping) else {}
+    )
     limits: Dict[str, float] = {}
     az_range = antenna.get("drive_range_az") if isinstance(antenna, Mapping) else None
     el_range = antenna.get("drive_range_el") if isinstance(antenna, Mapping) else None
@@ -168,8 +193,16 @@ def _limits_from_config(config: Mapping[str, Any]) -> Dict[str, float]:
 
 
 def _chopper_from_config(config: Mapping[str, Any]) -> Dict[str, Any]:
-    motor = config.get("chopper_motor") if isinstance(config.get("chopper_motor"), Mapping) else {}
-    pos = motor.get("position") if isinstance(motor, Mapping) and isinstance(motor.get("position"), Mapping) else {}
+    motor = (
+        config.get("chopper_motor")
+        if isinstance(config.get("chopper_motor"), Mapping)
+        else {}
+    )
+    pos = (
+        motor.get("position")
+        if isinstance(motor, Mapping) and isinstance(motor.get("position"), Mapping)
+        else {}
+    )
     insert = pos.get("insert") if isinstance(pos, Mapping) else None
     remove = pos.get("remove") if isinstance(pos, Mapping) else None
     available = bool(motor) and insert not in (None, "") and remove not in (None, "")
@@ -181,18 +214,26 @@ def _chopper_from_config(config: Mapping[str, Any]) -> Dict[str, Any]:
     }
 
 
-def _capabilities_from_config(config: Mapping[str, Any], chopper: Mapping[str, Any]) -> Dict[str, bool]:
+def _capabilities_from_config(
+    config: Mapping[str, Any], chopper: Mapping[str, Any]
+) -> Dict[str, bool]:
     caps = dict(_DEFAULT_CAPABILITIES)
-    custom = config.get("operator_console") if isinstance(config.get("operator_console"), Mapping) else {}
-    custom_caps = custom.get("capabilities") if isinstance(custom.get("capabilities"), Mapping) else {}
+    custom = (
+        config.get("operator_console")
+        if isinstance(config.get("operator_console"), Mapping)
+        else {}
+    )
+    custom_caps = (
+        custom.get("capabilities")
+        if isinstance(custom.get("capabilities"), Mapping)
+        else {}
+    )
     for key, value in custom_caps.items():
         caps[str(key)] = bool(value)
     if not bool(chopper.get("available")):
         caps["chopper_move"] = False
         caps["chopper_maintenance"] = False
     return caps
-
-
 
 
 def _observation_log_from_config(config: Mapping[str, Any]) -> Dict[str, Any]:
@@ -202,7 +243,9 @@ def _observation_log_from_config(config: Mapping[str, Any]) -> Dict[str, Any]:
     the preferred key because the observation CSV must be written by the
     operator-console process, not necessarily by the recorder/spectrometer PC.
     """
-    console = config.get("console") if isinstance(config.get("console"), Mapping) else {}
+    console = (
+        config.get("console") if isinstance(config.get("console"), Mapping) else {}
+    )
     raw = {}
     if isinstance(console, Mapping):
         for key in ("observation_log", "obslog"):
@@ -237,7 +280,9 @@ def _observation_log_from_config(config: Mapping[str, Any]) -> Dict[str, Any]:
         if value in (None, ""):
             continue
         if isinstance(value, (list, tuple)):
-            record_roots.extend(str(item).strip() for item in value if str(item or "").strip())
+            record_roots.extend(
+                str(item).strip() for item in value if str(item or "").strip()
+            )
         else:
             record_roots.append(str(value).strip())
     if record_roots:
@@ -250,6 +295,7 @@ def _observation_log_from_config(config: Mapping[str, Any]) -> Dict[str, Any]:
     if warnings:
         out["warnings"] = warnings
     return out
+
 
 def resolve_site_config(
     *,
@@ -268,13 +314,20 @@ def resolve_site_config(
             continue
         try:
             config = _read_toml(path)
-            source = "site_config_path" if site_config_path not in (None, "") and Path(site_config_path).expanduser() == path else "default_config"
+            source = (
+                "site_config_path"
+                if site_config_path not in (None, "")
+                and Path(site_config_path).expanduser() == path
+                else "default_config"
+            )
             source_path = str(path)
             break
         except Exception as exc:
             warnings.append(f"failed to read site config {path}: {exc}")
     if not config:
-        warnings.append("no site TOML config found; using conservative console defaults")
+        warnings.append(
+            "no site TOML config found; using conservative console defaults"
+        )
     limits = _limits_from_config(config)
     overrides = {"az_min": az_min, "az_max": az_max, "el_min": el_min, "el_max": el_max}
     for key, value in overrides.items():

--- a/necst/web/site_config.py
+++ b/necst/web/site_config.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import os
 import re
-import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional

--- a/necst/web/status_model.py
+++ b/necst/web/status_model.py
@@ -477,16 +477,20 @@ def merge_live_telemetry(
         # its newest sample is not necessarily the command at the encoder time.
         # NECST's antenna_tracking topic already performs the correct comparison.
         antenna_update.setdefault("tracking_status_available", False)
-    if antenna_update:
-        antenna_section = out.setdefault("antenna", {})
-        if not command_valid:
-            _clear_command_fields(antenna_section)
-            _clear_command_fields(antenna_update)
+    # Command Az/El is a truth value, not a planned/progress value.
+    # If live telemetry is present but no fresh command topic was actually
+    # received, remove any command fields that may already exist in an older
+    # progress snapshot before merging live data.
+    antenna_section = out.setdefault("antenna", {})
+    if not command_valid:
+        _clear_command_fields(antenna_section)
+        _clear_command_fields(antenna_update)
+    if antenna_update or isinstance(antenna_section, dict):
         antenna_update["command_valid"] = bool(command_valid)
         antenna_update["command_source"] = command_source
         if command_topic_age is not None:
             antenna_update["command_topic_age_sec"] = command_topic_age
-        out.setdefault("antenna", {}).update(antenna_update)
+        antenna_section.update(antenna_update)
     weather_payload = (
         live_payload.get("weather")
         if isinstance(live_payload.get("weather"), dict)
@@ -912,7 +916,7 @@ def build_operator_status(
         if active_task in (None, ""):
             active_task = "observation" if lifecycle_state not in {"idle", "unknown"} else "idle"
 
-    command_fields_valid = antenna.get("command_valid") is not False
+    command_fields_valid = antenna.get("command_valid") is True
     command_lon = (
         _finite_float(_first_present(antenna, "command_lon_deg", "cmd_az_deg", "az_cmd_deg"))
         if command_fields_valid

--- a/necst/web/status_model.py
+++ b/necst/web/status_model.py
@@ -840,6 +840,16 @@ def _live_truth_scrub_stale_motion(
         and not encoder_moving
         and (hold_stage_active or lifecycle_final_or_idle)
     )
+    # If STOP has cleared /ctrl/antenna/altaz, there is no fresh command left to
+    # compare with the encoder.  In that case a final/idle lifecycle plus no
+    # encoder motion is enough to treat stale SKY/tracking/hold status as idle.
+    # Otherwise the operator can get trapped in MOUNT MOVING after pressing STOP
+    # simply because a low-level section_status kept reporting SKY.
+    mount_final_idle_without_command = bool(
+        lifecycle_final_or_idle
+        and not command_valid
+        and not encoder_moving
+    )
 
     # command_valid keeps Tracking diagnostics meaningful, but by itself it is
     # not physical movement.  Prefer explicit motion topics; use the encoder
@@ -850,6 +860,7 @@ def _live_truth_scrub_stale_motion(
     live_motion_active = bool(
         (section_active or queue_active or control_active or encoder_moving)
         and not mount_hold_at_target
+        and not mount_final_idle_without_command
     )
     if section_active:
         motion_source = "section_status"
@@ -875,7 +886,7 @@ def _live_truth_scrub_stale_motion(
     activity["mount_target_reached"] = bool(mount_target_reached)
     activity["mount_target_reached_tol_deg"] = MOUNT_TARGET_REACHED_TOL_DEG
 
-    if mount_hold_at_target:
+    if mount_hold_at_target or mount_final_idle_without_command:
         for key in (
             "motion_stage",
             "drive_kind",
@@ -896,7 +907,9 @@ def _live_truth_scrub_stale_motion(
         ):
             activity.pop(key, None)
         activity["live_motion_active"] = False
-        activity["live_motion_source"] = "mount_target_reached"
+        activity["live_motion_source"] = (
+            "mount_target_reached" if mount_hold_at_target else "final_idle_no_encoder_motion"
+        )
         activity["active_task"] = "idle"
         activity["phase"] = "IDLE"
         activity["motion_stage"] = "idle"
@@ -904,7 +917,8 @@ def _live_truth_scrub_stale_motion(
         activity["control_section_active"] = False
         activity["control_section_fresh"] = bool(section_fresh or control_fresh)
         activity["control_section_age_sec"] = _topic_age_sec(live_payload, "section_status", section)
-        activity["mount_hold_at_target"] = True
+        activity["mount_hold_at_target"] = bool(mount_hold_at_target)
+        activity["mount_final_idle_without_command"] = bool(mount_final_idle_without_command)
         return
 
     if section_active:

--- a/necst/web/status_model.py
+++ b/necst/web/status_model.py
@@ -1,0 +1,799 @@
+"""Shared read-only status model for NECST operator/progress UIs.
+
+This module intentionally contains no telescope command path.  It reads the
+progress sidecar files and optional live telemetry snapshots, then returns a
+canonical dictionary that can be consumed by both the diagnostic progress
+monitor and the future operator console.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import math
+import os
+import re
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional
+
+
+def safe_name(value: Any) -> str:
+    original = str(value or "unknown")
+    sanitized = re.sub(r"[^A-Za-z0-9_.-]+", "_", original)
+    sanitized = re.sub(r"_+", "_", sanitized).strip("_") or "record"
+    if sanitized != original:
+        digest = hashlib.sha1(
+            original.encode("utf-8", errors="surrogatepass")
+        ).hexdigest()[:8]
+        sanitized = f"{sanitized}_{digest}"
+    return sanitized
+
+
+def progress_root(value: Optional[str] = None) -> Path:
+    return Path(
+        value or os.environ.get("NECST_PROGRESS_ROOT", "/tmp/necst_progress")
+    ).expanduser()
+
+
+def live_status_max_age_sec() -> float:
+    """Maximum age for live ROS status before it is treated as stale."""
+    try:
+        return max(
+            0.2, float(os.environ.get("NECST_PROGRESS_LIVE_STATUS_MAX_AGE_SEC", "2.0"))
+        )
+    except Exception:
+        return 2.0
+
+
+def strip_record_file_header(text: str) -> str:
+    """Remove leading NECST FileWriter comment headers if present."""
+    lines = text.splitlines()
+    start = 0
+    while start < len(lines) and (
+        not lines[start].strip() or lines[start].lstrip().startswith("#")
+    ):
+        start += 1
+    return "\n".join(lines[start:])
+
+
+def read_json(path: Optional[Path]) -> Optional[Dict[str, Any]]:
+    if path is None:
+        return None
+    try:
+        return json.loads(strip_record_file_header(path.read_text(encoding="utf-8")))
+    except FileNotFoundError:
+        return None
+    except json.JSONDecodeError as exc:
+        return {"_error": f"invalid JSON in {path}: {exc}"}
+    except Exception as exc:
+        return {"_error": f"failed to read {path}: {exc}"}
+
+
+def read_jsonl(path: Optional[Path], limit: Optional[int] = None) -> List[Dict[str, Any]]:
+    if path is None:
+        return []
+    try:
+        raw_lines = path.read_text(encoding="utf-8").splitlines()
+    except Exception:
+        return []
+    entries: List[Dict[str, Any]] = []
+    for line in raw_lines:
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        try:
+            payload = json.loads(line)
+        except Exception:
+            continue
+        if isinstance(payload, dict):
+            entries.append(payload)
+    if limit is not None and limit >= 0:
+        return entries[-limit:]
+    return entries
+
+
+def current_snapshot_path(root: Path) -> Path:
+    return root / "current_observation_progress.json"
+
+
+def current_record_name(root: Path) -> Optional[str]:
+    try:
+        text = (
+            (root / "current_observation_record.txt")
+            .read_text(encoding="utf-8")
+            .strip()
+        )
+        return text or None
+    except Exception:
+        return None
+
+
+def latest_events_path(
+    root: Path, snapshot: Optional[Mapping[str, Any]] = None
+) -> Optional[Path]:
+    record = None
+    if snapshot:
+        record = (snapshot.get("observation") or {}).get("record_name")
+    record = record or current_record_name(root)
+    if record:
+        safe = safe_name(record)
+        path = root / safe / "observation_events.jsonl"
+        if path.exists():
+            return path
+    candidates = sorted(
+        root.glob("*/observation_events.jsonl"),
+        key=lambda p: p.stat().st_mtime if p.exists() else 0,
+        reverse=True,
+    )
+    return candidates[0] if candidates else None
+
+
+def latest_plan_path(
+    root: Path, snapshot: Optional[Mapping[str, Any]] = None
+) -> Optional[Path]:
+    record = None
+    if snapshot:
+        record = (snapshot.get("observation") or {}).get("record_name")
+    record = record or current_record_name(root)
+    if record:
+        safe = safe_name(record)
+        path = root / safe / "observation_plan.json"
+        if path.exists():
+            return path
+    candidates = sorted(
+        root.glob("*/observation_plan.json"),
+        key=lambda p: p.stat().st_mtime if p.exists() else 0,
+        reverse=True,
+    )
+    return candidates[0] if candidates else None
+
+
+def read_recent_events(path: Optional[Path], limit: int) -> List[Dict[str, Any]]:
+    if limit <= 0:
+        return []
+    return read_jsonl(path, limit=limit)
+
+
+def read_all_events(path: Optional[Path]) -> List[Dict[str, Any]]:
+    return read_jsonl(path, limit=None)
+
+
+def _finite_float(value: Any) -> Optional[float]:
+    try:
+        out = float(value)
+    except Exception:
+        return None
+    return out if math.isfinite(out) else None
+
+
+def _as_mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+FINAL_LIFECYCLE_STATES = {"finished", "error", "aborted"}
+
+
+def apply_dynamic_remaining(
+    snapshot: Optional[Dict[str, Any]], *, now_unix: Optional[float] = None
+) -> Optional[Dict[str, Any]]:
+    """Return a display/API snapshot with ETA counted down from completion time."""
+    if not isinstance(snapshot, dict):
+        return snapshot
+    timing = snapshot.get("time")
+    lifecycle = snapshot.get("lifecycle") if isinstance(snapshot.get("lifecycle"), dict) else {}
+    if not isinstance(timing, dict):
+        return snapshot
+    state = str(lifecycle.get("state") or "").lower()
+    if state in FINAL_LIFECYCLE_STATES:
+        if timing.get("estimated_remaining_sec") is not None:
+            timing["estimated_remaining_sec"] = 0.0
+        return snapshot
+    completion = _finite_float(timing.get("estimated_completion_unix"))
+    if completion is not None:
+        timing["estimated_remaining_sec"] = max(
+            0.0, completion - float(now_unix if now_unix is not None else time.time())
+        )
+    return snapshot
+
+def _live_payload_has_position(live_payload: Mapping[str, Any]) -> bool:
+    """Return True when live ROS telemetry has enough antenna data to display.
+
+    Observation progress files may legitimately be absent while the telescope is
+    idle.  In that case the dashboard should still show current encoder Az/El
+    when ROS is running, but it must not fabricate an observation merely because
+    unrelated topics such as weather or queue status are available.
+    """
+    if not isinstance(live_payload, Mapping):
+        return False
+    pointing = (
+        live_payload.get("pointing_status")
+        if isinstance(live_payload.get("pointing_status"), Mapping)
+        else {}
+    )
+    encoder = (
+        live_payload.get("encoder")
+        if isinstance(live_payload.get("encoder"), Mapping)
+        else {}
+    )
+
+    # An idle snapshot must represent the actual telescope position.  A live
+    # command-only sample may be stale or merely the last target, so it must not
+    # fabricate an "idle antenna position" when no encoder/pointing encoder value
+    # is available.
+    for payload, keys in (
+        (pointing, ("enc_az_deg", "enc_el_deg")),
+        (encoder, ("encoder_lon_deg", "encoder_lat_deg")),
+    ):
+        if any(_finite_float(payload.get(key)) is not None for key in keys):
+            return True
+    return False
+
+
+def make_idle_live_snapshot(
+    live_payload: Mapping[str, Any], *, now_unix: Optional[float] = None
+) -> Dict[str, Any]:
+    """Build a minimal display-only snapshot for idle live telemetry.
+
+    This snapshot is used only by progress.py.  It is not written back to
+    ``current_observation_progress.json`` and therefore does not affect the
+    observation runtime.
+    """
+    now = float(now_unix if now_unix is not None else time.time())
+    return {
+        "observation": {
+            "type": "idle",
+            "record_name": "-",
+            "obs_file": "-",
+            "target": "-",
+        },
+        "lifecycle": {
+            "state": "idle",
+            "status": "idle",
+        },
+        "plan": {
+            "label": "no active observation",
+            "mode": "-",
+            "role": "idle",
+            "total": 0,
+        },
+        "activity": {
+            "phase": "IDLE",
+            "drive_kind": "idle",
+            "motion_stage": "idle",
+            "data_state": "no active observation",
+        },
+        "geometry": {
+            "kind": "idle",
+            "frame": "altaz",
+            "unit": "deg",
+        },
+        "data": {
+            "expected_metadata_position": "-",
+            "expected_metadata_id": "-",
+        },
+        "time": {
+            "updated_at_unix": now,
+            "elapsed_sec": None,
+            "estimated_remaining_sec": None,
+            "remaining_method": "idle/live-telemetry",
+            "remaining_confidence": "n/a",
+        },
+        "display": {
+            "idle_live_telemetry": True,
+            "idle_message": "No active observation; showing live antenna telemetry.",
+        },
+    }
+
+
+def merge_live_telemetry(
+    snapshot: Optional[Dict[str, Any]], live: Optional[Mapping[str, Any]]
+) -> Optional[Dict[str, Any]]:
+    """Return a display-only snapshot augmented with live ROS telemetry.
+
+    The progress JSON files remain the source of truth while an observation is
+    active.  Live ROS values are merged only in the CLI/web process so the
+    observation runtime stays free of high-frequency subscriptions.
+
+    If no progress snapshot exists but live antenna position telemetry is
+    available, return a minimal ``idle`` snapshot so observers can still see
+    current encoder Az/El before starting an observation.  This idle snapshot is
+    display-only and is never written to disk.
+    """
+    if not live:
+        return snapshot
+    live_payload = dict(live)
+    if not isinstance(snapshot, dict):
+        if not _live_payload_has_position(live_payload):
+            return snapshot
+        snapshot = make_idle_live_snapshot(live_payload)
+    out = copy.deepcopy(snapshot)
+    out["live"] = live_payload
+
+    antenna_update: Dict[str, Any] = {}
+    cmd = (
+        live_payload.get("command")
+        if isinstance(live_payload.get("command"), dict)
+        else {}
+    )
+    enc = (
+        live_payload.get("encoder")
+        if isinstance(live_payload.get("encoder"), dict)
+        else {}
+    )
+    pointing = (
+        live_payload.get("pointing_status")
+        if isinstance(live_payload.get("pointing_status"), dict)
+        else {}
+    )
+    az_unwrap = (
+        live_payload.get("az_unwrap_status")
+        if isinstance(live_payload.get("az_unwrap_status"), dict)
+        else {}
+    )
+    if pointing:
+        antenna_update["pointing_status_available"] = True
+        antenna_update["pointing_status_valid"] = bool(pointing.get("valid", False))
+        if pointing.get("cmd_az_deg") is not None:
+            antenna_update["command_lon_deg"] = pointing.get("cmd_az_deg")
+            antenna_update["command_lat_deg"] = pointing.get("cmd_el_deg")
+            antenna_update["command_frame"] = "altaz"
+            antenna_update["command_unit"] = "deg"
+            antenna_update["command_time_unix"] = pointing.get("command_time_unix")
+        if pointing.get("enc_az_deg") is not None:
+            antenna_update["encoder_lon_deg"] = pointing.get("enc_az_deg")
+            antenna_update["encoder_lat_deg"] = pointing.get("enc_el_deg")
+            antenna_update["encoder_frame"] = "altaz"
+            antenna_update["encoder_unit"] = "deg"
+            antenna_update["encoder_time_unix"] = pointing.get("encoder_time_unix")
+        antenna_update["tracking_status_available"] = True
+        antenna_update["tracking_ok"] = bool(pointing.get("tracking_ok", False))
+        antenna_update["tracking_error_deg"] = pointing.get("tracking_error_deg")
+        antenna_update["tracking_status_time_unix"] = pointing.get("publish_time_unix")
+        antenna_update["tracking_status_age_sec"] = (
+            max(0.0, time.time() - pointing.get("publish_time_unix", time.time()))
+            if pointing.get("publish_time_unix") is not None
+            else None
+        )
+        antenna_update["tracking_threshold_deg"] = pointing.get(
+            "tracking_threshold_deg"
+        )
+        antenna_update["command_stale"] = bool(pointing.get("command_stale", False))
+        antenna_update["encoder_stale"] = bool(pointing.get("encoder_stale", False))
+        antenna_update["command_age_sec"] = pointing.get("cmd_age_sec")
+        antenna_update["encoder_age_sec"] = pointing.get("enc_age_sec")
+        antenna_update["delta_az_deg"] = pointing.get("delta_az_deg")
+        antenna_update["delta_el_deg"] = pointing.get("delta_el_deg")
+        antenna_update["delta_az_cos_el_deg"] = pointing.get("delta_az_cos_el_deg")
+        antenna_update["pointing_basis"] = pointing.get("basis")
+    else:
+        if cmd:
+            antenna_update.update(cmd)
+        if enc:
+            antenna_update.update(enc)
+    if az_unwrap and az_unwrap.get("enabled"):
+        antenna_update["az_unwrap"] = dict(az_unwrap)
+        antenna_update["az_unwrap_enabled"] = True
+        antenna_update["az_unwrap_valid"] = bool(az_unwrap.get("valid", False))
+        antenna_update["az_unwrap_branch"] = az_unwrap.get("branch")
+        antenna_update["az_unwrap_raw_az_deg"] = az_unwrap.get("raw_az_deg")
+        antenna_update["az_unwrap_state"] = az_unwrap.get("state")
+        antenna_update["az_unwrap_reason"] = az_unwrap.get("reason")
+    tracking = (
+        live_payload.get("tracking")
+        if isinstance(live_payload.get("tracking"), dict)
+        else {}
+    )
+    if tracking:
+        terr = _finite_float(tracking.get("error_deg"))
+        tstat = _finite_float(tracking.get("time_unix"))
+        antenna_update["tracking_status_available"] = True
+        antenna_update["tracking_ok"] = bool(tracking.get("ok", False))
+        if terr is not None:
+            antenna_update["tracking_error_deg"] = terr
+        if tstat is not None:
+            antenna_update["tracking_status_time_unix"] = tstat
+            antenna_update["tracking_status_age_sec"] = max(0.0, time.time() - tstat)
+    else:
+        # Do not compute a tracking error from the latest command and latest
+        # encoder samples here.  altaz_cmd is a time-tagged command stream and
+        # its newest sample is not necessarily the command at the encoder time.
+        # NECST's antenna_tracking topic already performs the correct comparison.
+        antenna_update.setdefault("tracking_status_available", False)
+    if antenna_update:
+        out.setdefault("antenna", {}).update(antenna_update)
+    weather_payload = (
+        live_payload.get("weather")
+        if isinstance(live_payload.get("weather"), dict)
+        else {}
+    )
+    if weather_payload:
+        out.setdefault("weather", {}).update(weather_payload)
+    queue_payload = (
+        live_payload.get("queue_status")
+        if isinstance(live_payload.get("queue_status"), dict)
+        else {}
+    )
+    if queue_payload:
+        out.setdefault("antenna_command_queue", {}).update(queue_payload)
+    spec_payload = (
+        live_payload.get("spectrometer_status")
+        if isinstance(live_payload.get("spectrometer_status"), dict)
+        else {}
+    )
+    if spec_payload:
+        out.setdefault("spectrometer", {}).update(spec_payload)
+    chopper_payload = (
+        live_payload.get("chopper_status")
+        if isinstance(live_payload.get("chopper_status"), dict)
+        else {}
+    )
+    if chopper_payload:
+        out.setdefault("chopper", {}).update(chopper_payload)
+
+    lifecycle = out.get("lifecycle") if isinstance(out.get("lifecycle"), dict) else {}
+    final_state = str(lifecycle.get("state") or "").lower() in {
+        "finished",
+        "error",
+        "aborted",
+    }
+    section_status = (
+        live_payload.get("section_status")
+        if isinstance(live_payload.get("section_status"), dict)
+        else {}
+    )
+    ctrl = (
+        live_payload.get("control")
+        if isinstance(live_payload.get("control"), dict)
+        else {}
+    )
+    if section_status and not final_state:
+        activity = out.setdefault("activity", {})
+        geometry = out.setdefault("geometry", {})
+        data = out.setdefault("data", {})
+        # Preserve the observation-progress line index before live antenna
+        # section status may overwrite geometry.current_line_index0.  The
+        # former answers "which planned OTF item is being processed", while
+        # the latter answers "which antenna scan-line section is active now".
+        # Mixing them makes Plan View jump to the next line during OFF,
+        # standby, or accelerate intervals.
+        progress_line_index = geometry.get("current_line_index0")
+        if isinstance(progress_line_index, int) and progress_line_index >= 0:
+            geometry.setdefault("progress_line_index0", progress_line_index)
+        section_kind = section_status.get("section_kind")
+        section_label = section_status.get("section_label")
+        line_index = section_status.get("line_index")
+        if section_kind not in (None, ""):
+            activity["motion_stage"] = section_kind
+            activity["control_section_kind"] = section_kind
+        if section_label not in (None, ""):
+            activity["control_section_label"] = section_label
+            geometry["current_line_label"] = section_label
+        if section_status.get("control_id") not in (None, ""):
+            activity["control_id"] = section_status.get("control_id")
+        activity["control_tight"] = bool(section_status.get("tight", False))
+        activity["control_section_uid"] = section_status.get("section_uid")
+        activity["control_section_plan_index"] = section_status.get(
+            "section_plan_index"
+        )
+        activity["control_section_sequence_index"] = section_status.get(
+            "section_sequence_index"
+        )
+        activity["control_section_line_index"] = line_index
+        activity["control_status_basis"] = section_status.get("status_basis")
+        activity["control_section_active"] = bool(section_status.get("active", False))
+        activity["control_section_science_line"] = bool(
+            section_status.get("science_line", False)
+        )
+        activity["control_section_interrupt_ok"] = bool(
+            section_status.get("interrupt_ok", False)
+        )
+        activity["control_section_start_unix"] = section_status.get(
+            "section_start_unix"
+        )
+        activity["control_section_stop_unix"] = section_status.get("section_stop_unix")
+        activity["control_section_duration_sec"] = section_status.get(
+            "section_duration_sec"
+        )
+        activity["control_section_command_time_unix"] = section_status.get(
+            "command_time_unix"
+        )
+        activity["control_section_query_time_unix"] = section_status.get(
+            "query_time_unix"
+        )
+        activity["control_section_publish_time_unix"] = section_status.get(
+            "publish_time_unix"
+        )
+        pub_time = section_status.get("publish_time_unix")
+        try:
+            section_age = max(0.0, time.time() - float(pub_time))
+        except Exception:
+            section_age = None
+        activity["control_section_age_sec"] = section_age
+        activity["control_section_fresh"] = bool(
+            section_age is not None and section_age <= live_status_max_age_sec()
+        )
+        if section_status.get("fraction_valid"):
+            activity["control_section_fraction"] = section_status.get(
+                "nominal_fraction"
+            )
+        if isinstance(line_index, int) and line_index >= 0:
+            geometry["current_line_index0"] = line_index
+            if data.get("latest_control_line_index") is None:
+                data["latest_control_line_index"] = line_index
+        if section_status.get("geometry_valid"):
+            geometry["live_section_geometry"] = {
+                "frame": section_status.get("section_frame"),
+                "unit": section_status.get("section_unit"),
+                "start": [
+                    section_status.get("section_start_lon_deg"),
+                    section_status.get("section_start_lat_deg"),
+                ],
+                "stop": [
+                    section_status.get("section_stop_lon_deg"),
+                    section_status.get("section_stop_lat_deg"),
+                ],
+                "speed_deg_per_sec": section_status.get("section_speed_deg_per_sec"),
+            }
+    elif ctrl and not final_state:
+        activity = out.setdefault("activity", {})
+        geometry = out.setdefault("geometry", {})
+        section_kind = ctrl.get("section_kind")
+        section_label = ctrl.get("section_label")
+        ctrl_id = ctrl.get("id")
+        line_index = ctrl.get("line_index")
+        if section_kind not in (None, ""):
+            activity["motion_stage"] = section_kind
+            activity["control_section_kind"] = section_kind
+        if section_label not in (None, ""):
+            activity["control_section_label"] = section_label
+            geometry["current_line_label"] = section_label
+        if ctrl_id not in (None, ""):
+            activity["control_id"] = ctrl_id
+        if ctrl.get("tight") is not None:
+            activity["control_tight"] = bool(ctrl.get("tight"))
+        activity["control_section_line_index"] = line_index
+        if isinstance(line_index, int) and line_index >= 0:
+            geometry["current_line_index0"] = line_index
+            data = out.setdefault("data", {})
+            # Do not overwrite expected_metadata_line_index for non-scan-block
+            # integrations; only fill a display helper when no explicit value is
+            # present.
+            if data.get("latest_control_line_index") is None:
+                data["latest_control_line_index"] = line_index
+    return apply_dynamic_remaining(out)
+
+
+
+
+def _first_present(mapping: Mapping[str, Any], *keys: str) -> Any:
+    for key in keys:
+        value = mapping.get(key)
+        if value not in (None, ""):
+            return value
+    return None
+
+
+def _age_sec(timestamp_unix: Any, *, now_unix: float) -> Optional[float]:
+    ts = _finite_float(timestamp_unix)
+    if ts is None:
+        return None
+    return max(0.0, now_unix - ts)
+
+
+def _progress_percent(snapshot: Mapping[str, Any]) -> Optional[float]:
+    plan = _as_mapping(snapshot.get("plan"))
+    for key in ("percent", "completion_percent", "progress_percent"):
+        value = _finite_float(plan.get(key))
+        if value is not None:
+            return max(0.0, min(100.0, value))
+    total = _finite_float(plan.get("total"))
+    completed = _finite_float(
+        _first_present(plan, "completed", "done", "finished", "current_index")
+    )
+    if total is not None and total > 0 and completed is not None:
+        return max(0.0, min(100.0, 100.0 * completed / total))
+    return None
+
+
+def build_operator_status(
+    snapshot: Optional[Mapping[str, Any]],
+    *,
+    plan: Optional[Mapping[str, Any]] = None,
+    events: Optional[List[Mapping[str, Any]]] = None,
+    paths: Optional[Mapping[str, Any]] = None,
+    server_time_unix: Optional[float] = None,
+) -> Dict[str, Any]:
+    """Build a compact, read-only status summary for operator-facing UIs.
+
+    The output is deliberately conservative: missing fields are represented as
+    ``None`` or ``unknown`` rather than guessed.  It must be safe to call while
+    the telescope is idle and while ROS/neclib are unavailable.
+    """
+    now = float(server_time_unix if server_time_unix is not None else time.time())
+    snap = snapshot if isinstance(snapshot, Mapping) else {}
+    obs = _as_mapping(snap.get("observation"))
+    lifecycle = _as_mapping(snap.get("lifecycle"))
+    activity = _as_mapping(snap.get("activity"))
+    snap_plan = _as_mapping(snap.get("plan"))
+    plan_payload = plan if isinstance(plan, Mapping) else {}
+    antenna = _as_mapping(snap.get("antenna"))
+    chopper = _as_mapping(snap.get("chopper"))
+    spectrometer = _as_mapping(snap.get("spectrometer"))
+    time_sync = _as_mapping(snap.get("time_sync"))
+    timing = _as_mapping(snap.get("time"))
+
+    lifecycle_state = str(
+        _first_present(lifecycle, "state", "status") or "unknown"
+    ).lower()
+    observation_type = _first_present(obs, "type", "mode")
+    observation_record = obs.get("record_name")
+    observation_target = obs.get("target")
+
+    active_task = _first_present(
+        activity,
+        "active_task",
+        "phase",
+        "drive_kind",
+        "motion_stage",
+    )
+    if active_task in (None, ""):
+        active_task = "observation" if lifecycle_state not in {"idle", "unknown"} else "idle"
+
+    command_lon = _finite_float(
+        _first_present(antenna, "command_lon_deg", "cmd_az_deg", "az_cmd_deg")
+    )
+    command_lat = _finite_float(
+        _first_present(antenna, "command_lat_deg", "cmd_el_deg", "el_cmd_deg")
+    )
+    encoder_lon = _finite_float(
+        _first_present(antenna, "encoder_lon_deg", "enc_az_deg", "az_deg")
+    )
+    encoder_lat = _finite_float(
+        _first_present(antenna, "encoder_lat_deg", "enc_el_deg", "el_deg")
+    )
+    tracking_error = _finite_float(antenna.get("tracking_error_deg"))
+    tracking_ok_raw = antenna.get("tracking_ok")
+    tracking_ok = bool(tracking_ok_raw) if tracking_ok_raw is not None else None
+
+    chopper_time = _first_present(
+        chopper, "publish_time_unix", "time_unix", "updated_at_unix"
+    )
+    chopper_position = _finite_float(
+        _first_present(chopper, "position", "position_count", "pos")
+    )
+    time_sync_status = str(
+        _first_present(time_sync, "status", "label") or "unknown"
+    ).lower()
+
+    warnings: List[str] = []
+    if antenna.get("command_stale"):
+        warnings.append("antenna command status is stale")
+    if antenna.get("encoder_stale"):
+        warnings.append("antenna encoder status is stale")
+    if time_sync_status in {"bad", "nosync", "warn"}:
+        warnings.append(f"time sync is {time_sync_status}")
+    if chopper.get("alarm") or str(chopper.get("state") or "").lower() == "alarm":
+        warnings.append("chopper alarm")
+
+    compact_plan_total = _first_present(snap_plan, "total", "n_total")
+    if compact_plan_total is None:
+        compact_plan_total = _first_present(plan_payload, "total", "n_total")
+
+    return {
+        "schema": "necst.operator_status.v1",
+        "server_time_unix": now,
+        "system": {
+            "state": lifecycle_state,
+            "lifecycle_status": lifecycle.get("status"),
+            "ok": lifecycle_state not in {"error", "failed"},
+        },
+        "observation": {
+            "type": observation_type,
+            "record_name": observation_record,
+            "obs_file": obs.get("obs_file"),
+            "target": observation_target,
+            "elapsed_sec": _finite_float(timing.get("elapsed_sec")),
+            "remaining_sec": _finite_float(timing.get("estimated_remaining_sec")),
+            "remaining_method": timing.get("remaining_method"),
+        },
+        "progress": {
+            "percent": _progress_percent(snap),
+            "total": compact_plan_total,
+            "current": _first_present(snap_plan, "current", "current_index", "current_id"),
+            "label": _first_present(snap_plan, "label", "mode", "role"),
+        },
+        "motion": {
+            "active_task": active_task,
+            "stage": _first_present(activity, "motion_stage", "phase"),
+            "tracking_ok": tracking_ok,
+            "tracking_error_deg": tracking_error,
+        },
+        "antenna": {
+            "command_az_deg": command_lon,
+            "command_el_deg": command_lat,
+            "current_az_deg": encoder_lon,
+            "current_el_deg": encoder_lat,
+            "command_frame": antenna.get("command_frame"),
+            "encoder_frame": antenna.get("encoder_frame"),
+            "tracking_status_age_sec": _finite_float(
+                antenna.get("tracking_status_age_sec")
+            ),
+            "az_unwrap": antenna.get("az_unwrap") if isinstance(antenna.get("az_unwrap"), Mapping) else None,
+        },
+        "chopper": {
+            "state": _first_present(chopper, "state", "position_state", "status") or "unknown",
+            "position": chopper_position,
+            "age_sec": _age_sec(chopper_time, now_unix=now),
+            "raw": dict(chopper) if chopper else {},
+        },
+        "spectrometer": {
+            "status": _first_present(spectrometer, "status", "state") or "unknown",
+            "irigb": _first_present(
+                spectrometer, "irigb", "irig_b", "time_source", "time_src"
+            ),
+            "raw": dict(spectrometer) if spectrometer else {},
+        },
+        "time_sync": dict(time_sync) if time_sync else {},
+        "paths": dict(paths) if isinstance(paths, Mapping) else {},
+        "event_count": len(events or []),
+        "warnings": warnings,
+    }
+
+
+def build_progress_status_state(
+    root: Path,
+    *,
+    events_limit: int = 12,
+    live_payload: Optional[Mapping[str, Any]] = None,
+    time_sync_payload: Optional[Mapping[str, Any]] = None,
+    server_time_unix: Optional[float] = None,
+) -> Dict[str, Any]:
+    """Read progress sidecars and return raw inputs plus compact status.
+
+    This is the shared read-only boundary between progress.py and the future
+    operator console.  It does not render HTML and it does not send commands.
+    """
+    now = float(server_time_unix if server_time_unix is not None else time.time())
+    snapshot_path = current_snapshot_path(root)
+    raw_snapshot = read_json(snapshot_path)
+    snapshot = merge_live_telemetry(
+        raw_snapshot if isinstance(raw_snapshot, dict) else None,
+        live_payload if isinstance(live_payload, Mapping) else None,
+    )
+    snapshot = apply_dynamic_remaining(snapshot, now_unix=now)
+
+    if isinstance(snapshot, dict) and isinstance(time_sync_payload, Mapping):
+        if time_sync_payload.get("enabled"):
+            snapshot.setdefault("time_sync", {}).update(dict(time_sync_payload))
+
+    raw_snapshot_for_paths = raw_snapshot if isinstance(raw_snapshot, Mapping) else None
+    events_path = latest_events_path(root, raw_snapshot_for_paths)
+    plan_path = latest_plan_path(root, raw_snapshot_for_paths)
+    plan = read_json(plan_path) if plan_path else None
+    all_events = read_all_events(events_path)
+    events = all_events[-events_limit:] if events_limit > 0 else []
+    paths = {
+        "snapshot": str(snapshot_path) if snapshot_path else None,
+        "events": str(events_path) if events_path else None,
+        "plan": str(plan_path) if plan_path else None,
+    }
+    compact_status = build_operator_status(
+        snapshot if isinstance(snapshot, Mapping) else None,
+        plan=plan if isinstance(plan, Mapping) else None,
+        events=events,
+        paths=paths,
+        server_time_unix=now,
+    )
+    return {
+        "ok": isinstance(snapshot, dict) and bool(snapshot) and not snapshot.get("_error"),
+        "root": str(root),
+        "paths": paths,
+        "raw_snapshot": raw_snapshot or {},
+        "snapshot": snapshot or {},
+        "events": events,
+        "status_events": all_events,
+        "plan": plan or {},
+        "server_time_unix": now,
+        "operator_status": compact_status,
+    }

--- a/necst/web/status_model.py
+++ b/necst/web/status_model.py
@@ -241,28 +241,19 @@ def _live_payload_has_position(live_payload: Mapping[str, Any]) -> bool:
     """
     if not isinstance(live_payload, Mapping):
         return False
-    pointing = (
-        live_payload.get("pointing_status")
-        if isinstance(live_payload.get("pointing_status"), Mapping)
-        else {}
-    )
     encoder = (
         live_payload.get("encoder")
         if isinstance(live_payload.get("encoder"), Mapping)
         else {}
     )
 
-    # An idle snapshot must represent the actual telescope position.  A live
-    # command-only sample may be stale or merely the last target, so it must not
-    # fabricate an "idle antenna position" when no encoder/pointing encoder value
-    # is available.
-    for payload, keys in (
-        (pointing, ("enc_az_deg", "enc_el_deg")),
-        (encoder, ("encoder_lon_deg", "encoder_lat_deg")),
-    ):
-        if any(_finite_float(payload.get(key)) is not None for key in keys):
-            return True
-    return False
+    # An idle snapshot must represent the actual telescope position.  Use only
+    # the real encoder topic here.  AntennaPointingStatus is a diagnostic topic
+    # and may be invalid or extrapolated when no command is active.
+    return (
+        _finite_float(encoder.get("encoder_lon_deg")) is not None
+        and _finite_float(encoder.get("encoder_lat_deg")) is not None
+    )
 
 
 def make_idle_live_snapshot(
@@ -356,21 +347,21 @@ def merge_live_telemetry(
         if isinstance(live_payload.get("encoder"), dict)
         else {}
     )
-    pointing = (
-        live_payload.get("pointing_status")
-        if isinstance(live_payload.get("pointing_status"), dict)
-        else {}
-    )
+    # AntennaPointingStatus is a diagnostic topic derived from altaz + encoder
+    # and may contain interpolated/extrapolated command values even after the
+    # real altaz command stream stops.  Do not use it for Current, Command,
+    # Tracking, or Moving state in operator-facing displays.
+    pointing: Dict[str, Any] = {}
     az_unwrap = (
         live_payload.get("az_unwrap_status")
         if isinstance(live_payload.get("az_unwrap_status"), dict)
         else {}
     )
     # Always start from direct encoder telemetry.  Command display is stricter:
-    # it must represent a real, fresh command status topic (or a valid
-    # pointing_status command), not an observation plan, old progress snapshot,
-    # or interpolated section.  Otherwise Command Az/El can keep moving after
-    # abort even when no command topic is being published.
+    # it must represent a real, fresh altaz command topic callback only, not an
+    # observation plan, old progress snapshot, AntennaPointingStatus, or
+    # interpolated section.  Otherwise Command Az/El can keep moving after abort
+    # even when no real command topic is being published.
     command_valid = False
     command_source = "none"
     live_ages = (
@@ -393,61 +384,8 @@ def merge_live_telemetry(
     if enc:
         antenna_update.update(enc)
 
-    if pointing:
-        antenna_update["pointing_status_available"] = True
-        pointing_valid = bool(pointing.get("valid", False))
-        antenna_update["pointing_status_valid"] = pointing_valid
-        cmd_az = _finite_float(pointing.get("cmd_az_deg"))
-        cmd_el = _finite_float(pointing.get("cmd_el_deg"))
-        enc_az = _finite_float(pointing.get("enc_az_deg"))
-        enc_el = _finite_float(pointing.get("enc_el_deg"))
-        pointing_cmd_age = _finite_float(pointing.get("cmd_age_sec"))
-        pointing_cmd_fresh = (
-            pointing_cmd_age is not None
-            and pointing_cmd_age <= live_status_max_age_sec()
-        )
-        pointing_command_stale = bool(pointing.get("command_stale", False))
-        if (
-            not command_valid
-            and pointing_valid
-            and not pointing_command_stale
-            and pointing_cmd_fresh
-            and cmd_az is not None
-            and cmd_el is not None
-        ):
-            antenna_update["command_lon_deg"] = cmd_az
-            antenna_update["command_lat_deg"] = cmd_el
-            antenna_update["command_frame"] = "altaz"
-            antenna_update["command_unit"] = "deg"
-            antenna_update["command_time_unix"] = pointing.get("command_time_unix")
-            command_valid = True
-            command_source = "pointing_status"
-        if enc_az is not None and enc_el is not None:
-            antenna_update["encoder_lon_deg"] = enc_az
-            antenna_update["encoder_lat_deg"] = enc_el
-            antenna_update["encoder_frame"] = "altaz"
-            antenna_update["encoder_unit"] = "deg"
-            antenna_update["encoder_time_unix"] = pointing.get("encoder_time_unix")
-        antenna_update["tracking_status_available"] = True
-        antenna_update["tracking_ok"] = bool(pointing.get("tracking_ok", False))
-        antenna_update["tracking_error_deg"] = pointing.get("tracking_error_deg")
-        antenna_update["tracking_status_time_unix"] = pointing.get("publish_time_unix")
-        antenna_update["tracking_status_age_sec"] = (
-            max(0.0, time.time() - pointing.get("publish_time_unix", time.time()))
-            if pointing.get("publish_time_unix") is not None
-            else None
-        )
-        antenna_update["tracking_threshold_deg"] = pointing.get(
-            "tracking_threshold_deg"
-        )
-        antenna_update["command_stale"] = bool(pointing.get("command_stale", False))
-        antenna_update["encoder_stale"] = bool(pointing.get("encoder_stale", False))
-        antenna_update["command_age_sec"] = pointing.get("cmd_age_sec")
-        antenna_update["encoder_age_sec"] = pointing.get("enc_age_sec")
-        antenna_update["delta_az_deg"] = pointing.get("delta_az_deg")
-        antenna_update["delta_el_deg"] = pointing.get("delta_el_deg")
-        antenna_update["delta_az_cos_el_deg"] = pointing.get("delta_az_cos_el_deg")
-        antenna_update["pointing_basis"] = pointing.get("basis")
+    # Intentionally ignore AntennaPointingStatus for normal display.
+    # Tracking error is taken only from topic.antenna_tracking below.
     if az_unwrap and az_unwrap.get("enabled"):
         antenna_update["az_unwrap"] = dict(az_unwrap)
         antenna_update["az_unwrap_enabled"] = True
@@ -461,7 +399,8 @@ def merge_live_telemetry(
         if isinstance(live_payload.get("tracking"), dict)
         else {}
     )
-    if tracking:
+    tracking_fresh = bool(tracking and _topic_received_fresh(live_payload, "tracking"))
+    if tracking_fresh:
         terr = _finite_float(tracking.get("error_deg"))
         tstat = _finite_float(tracking.get("time_unix"))
         antenna_update["tracking_status_available"] = True
@@ -470,7 +409,10 @@ def merge_live_telemetry(
             antenna_update["tracking_error_deg"] = terr
         if tstat is not None:
             antenna_update["tracking_status_time_unix"] = tstat
-            antenna_update["tracking_status_age_sec"] = max(0.0, time.time() - tstat)
+        antenna_update["tracking_status_age_sec"] = _topic_receipt_age_sec(
+            live_payload, "tracking"
+        )
+        antenna_update["tracking_status_source"] = "antenna_tracking"
     else:
         # Do not compute a tracking error from the latest command and latest
         # encoder samples here.  altaz_cmd is a time-tagged command stream and
@@ -774,13 +716,11 @@ def _live_truth_scrub_stale_motion(
         queue_depth = 0
     queue_active = bool(queue_fresh and (queue.get("active") or queue_depth > 0))
 
-    section_fresh = _topic_received_fresh(live_payload, "section_status")
-    section_active = bool(section_fresh and section.get("active"))
-
-    control_fresh = _topic_received_fresh(live_payload, "control")
-    control_active = bool(control_fresh and (control.get("controlled") or control.get("tight")))
-
-    live_motion_active = bool(command_valid or queue_active or section_active or control_active)
+    # Operator-facing Moving/Tracking must not be inferred from section/control
+    # diagnostic topics.  These can remain active or carry planned scan metadata
+    # after stop/abort.  Use the real altaz command stream and explicit command
+    # queue activity only.
+    live_motion_active = bool(command_valid or queue_active)
     activity = out.setdefault("activity", {})
     if not isinstance(activity, dict):
         return
@@ -788,8 +728,6 @@ def _live_truth_scrub_stale_motion(
     activity["live_motion_source"] = (
         "command" if command_valid else
         "queue_status" if queue_active else
-        "section_status" if section_active else
-        "control_status" if control_active else
         "none"
     )
 

--- a/necst/web/status_model.py
+++ b/necst/web/status_model.py
@@ -400,13 +400,13 @@ def merge_live_telemetry(
         else {}
     )
     tracking_fresh = bool(tracking and _topic_received_fresh(live_payload, "tracking"))
-    if tracking_fresh:
-        terr = _finite_float(tracking.get("error_deg"))
+    terr = _finite_float(tracking.get("error_deg")) if tracking else None
+    tracking_available = bool(command_valid and tracking_fresh and terr is not None)
+    if tracking_available:
         tstat = _finite_float(tracking.get("time_unix"))
         antenna_update["tracking_status_available"] = True
         antenna_update["tracking_ok"] = bool(tracking.get("ok", False))
-        if terr is not None:
-            antenna_update["tracking_error_deg"] = terr
+        antenna_update["tracking_error_deg"] = terr
         if tstat is not None:
             antenna_update["tracking_status_time_unix"] = tstat
         antenna_update["tracking_status_age_sec"] = _topic_receipt_age_sec(
@@ -417,8 +417,10 @@ def merge_live_telemetry(
         # Do not compute a tracking error from the latest command and latest
         # encoder samples here.  altaz_cmd is a time-tagged command stream and
         # its newest sample is not necessarily the command at the encoder time.
-        # NECST's antenna_tracking topic already performs the correct comparison.
-        antenna_update.setdefault("tracking_status_available", False)
+        # NECST's antenna_tracking topic already performs the correct comparison,
+        # but it is meaningful for the UI only while a fresh altaz command exists.
+        antenna_update["tracking_status_available"] = False
+        _clear_tracking_fields(antenna_update)
     # Command Az/El is a truth value, not a planned/progress value.
     # If live telemetry is present but no fresh command topic was actually
     # received, remove any command fields that may already exist in an older
@@ -427,6 +429,9 @@ def merge_live_telemetry(
     if not command_valid:
         _clear_command_fields(antenna_section)
         _clear_command_fields(antenna_update)
+    if not tracking_available:
+        _clear_tracking_fields(antenna_section)
+        _clear_tracking_fields(antenna_update)
     if antenna_update or isinstance(antenna_section, dict):
         antenna_update["command_valid"] = bool(command_valid)
         antenna_update["command_source"] = command_source
@@ -684,6 +689,17 @@ def _clear_command_fields(mapping: Dict[str, Any]) -> None:
         mapping.pop(key, None)
 
 
+def _clear_tracking_fields(mapping: Dict[str, Any]) -> None:
+    for key in (
+        "tracking_ok",
+        "tracking_error_deg",
+        "tracking_status_time_unix",
+        "tracking_status_age_sec",
+        "tracking_status_source",
+    ):
+        mapping.pop(key, None)
+
+
 def _live_truth_scrub_stale_motion(
     out: Dict[str, Any],
     live_payload: Mapping[str, Any],
@@ -692,9 +708,10 @@ def _live_truth_scrub_stale_motion(
 ) -> None:
     """Remove stale planned/sidecar motion fields when live ROS says idle.
 
-    The progress sidecar can legitimately lag after ``necst abort`` or a local
-    launcher failure.  In operator-facing displays, command and motion must be
-    shown only when backed by fresh live command / section / queue status.
+    Motion display is based on explicit fresh motion/status topics first
+    (section status, command queue, control status).  Encoder-delta motion is
+    only a fallback and uses a deadband, because the low-order encoder digits
+    can jitter while the antenna is physically stopped.
     """
     if not isinstance(out, dict) or not isinstance(live_payload, Mapping):
         return
@@ -702,12 +719,19 @@ def _live_truth_scrub_stale_motion(
     antenna = out.setdefault("antenna", {})
     if isinstance(antenna, dict) and not command_valid:
         _clear_command_fields(antenna)
+        _clear_tracking_fields(antenna)
         antenna["command_valid"] = False
+        antenna["tracking_status_available"] = False
         antenna.setdefault("command_source", "none")
 
     queue = live_payload.get("queue_status") if isinstance(live_payload.get("queue_status"), Mapping) else {}
     section = live_payload.get("section_status") if isinstance(live_payload.get("section_status"), Mapping) else {}
     control = live_payload.get("control") if isinstance(live_payload.get("control"), Mapping) else {}
+    encoder_motion = live_payload.get("encoder_motion") if isinstance(live_payload.get("encoder_motion"), Mapping) else {}
+
+    section_fresh = _topic_received_fresh(live_payload, "section_status")
+    section_active = bool(section_fresh and section.get("active"))
+    section_stage = str(section.get("section_kind") or section.get("section_label") or "").strip()
 
     queue_fresh = _topic_received_fresh(live_payload, "queue_status")
     try:
@@ -716,26 +740,73 @@ def _live_truth_scrub_stale_motion(
         queue_depth = 0
     queue_active = bool(queue_fresh and (queue.get("active") or queue_depth > 0))
 
-    # Operator-facing Moving/Tracking must not be inferred from section/control
-    # diagnostic topics.  These can remain active or carry planned scan metadata
-    # after stop/abort.  Use the real altaz command stream and explicit command
-    # queue activity only.
-    live_motion_active = bool(command_valid or queue_active)
+    control_fresh = _topic_received_fresh(live_payload, "control")
+    control_stage = str(control.get("section_kind") or control.get("section_label") or "").strip()
+    control_active = bool(
+        control_fresh
+        and (control.get("controlled") or control.get("tight") or control_stage)
+    )
+
+    encoder_motion_fresh = _topic_received_fresh(live_payload, "encoder")
+    encoder_moving = bool(encoder_motion_fresh and encoder_motion.get("moving"))
+
+    # command_valid keeps Tracking diagnostics meaningful, but by itself it is
+    # not physical movement.  Prefer explicit motion topics; use the encoder
+    # only as a deadbanded fallback for manual motion cases.
+    live_motion_active = bool(section_active or queue_active or control_active or encoder_moving)
+    if section_active:
+        motion_source = "section_status"
+    elif queue_active:
+        motion_source = "queue_status"
+    elif control_active:
+        motion_source = "control_status"
+    elif encoder_moving:
+        motion_source = "encoder_delta"
+    elif command_valid:
+        motion_source = "command"
+    else:
+        motion_source = "none"
+
     activity = out.setdefault("activity", {})
     if not isinstance(activity, dict):
         return
     activity["live_motion_active"] = live_motion_active
-    activity["live_motion_source"] = (
-        "command" if command_valid else
-        "queue_status" if queue_active else
-        "none"
-    )
+    activity["live_motion_source"] = motion_source
+    activity["encoder_motion_deadband_deg"] = encoder_motion.get("deadband_deg")
+    activity["encoder_motion_delta_az_deg"] = encoder_motion.get("delta_az_deg")
+    activity["encoder_motion_delta_el_deg"] = encoder_motion.get("delta_el_deg")
+
+    if section_active:
+        if section_stage:
+            activity["motion_stage"] = section_stage
+            activity["control_section_kind"] = section_stage
+        activity["control_section_active"] = True
+        activity["control_section_fresh"] = True
+        activity["control_section_age_sec"] = _topic_age_sec(live_payload, "section_status", section)
+        return
+
+    if queue_active:
+        if not activity.get("motion_stage") or str(activity.get("motion_stage")).lower() in {"idle", "none", "unknown"}:
+            activity["motion_stage"] = "moving"
+        return
+
+    if control_active:
+        if control_stage:
+            activity["motion_stage"] = control_stage
+            activity["control_section_kind"] = control_stage
+        elif not activity.get("motion_stage") or str(activity.get("motion_stage")).lower() in {"idle", "none", "unknown"}:
+            activity["motion_stage"] = "moving"
+        return
+
+    if encoder_moving:
+        activity["motion_stage"] = "moving"
+        return
+
+    # Fresh command without explicit movement can still support tracking error
+    # display, but it must not preserve or invent a Moving state.
 
     # If fresh live status does not support motion, old sidecar/planned values
     # such as ON/line/moving must not remain visible as current state.
-    if live_motion_active:
-        return
-
     for key in (
         "motion_stage",
         "drive_kind",
@@ -770,7 +841,6 @@ def _live_truth_scrub_stale_motion(
             "live_section_geometry",
         ):
             geometry.pop(key, None)
-
 def _first_present(mapping: Mapping[str, Any], *keys: str) -> Any:
     for key in keys:
         value = mapping.get(key)
@@ -871,8 +941,11 @@ def build_operator_status(
     encoder_lat = _finite_float(
         _first_present(antenna, "encoder_lat_deg", "enc_el_deg", "el_deg")
     )
-    tracking_error = _finite_float(antenna.get("tracking_error_deg"))
-    tracking_ok_raw = antenna.get("tracking_ok")
+    tracking_available = antenna.get("tracking_status_available") is True
+    tracking_error = (
+        _finite_float(antenna.get("tracking_error_deg")) if tracking_available else None
+    )
+    tracking_ok_raw = antenna.get("tracking_ok") if tracking_available else None
     tracking_ok = bool(tracking_ok_raw) if tracking_ok_raw is not None else None
 
     chopper_time = _first_present(

--- a/necst/web/status_model.py
+++ b/necst/web/status_model.py
@@ -824,11 +824,21 @@ def _live_truth_scrub_stale_motion(
         (section_active and section_stage_lower in MOUNT_HOLD_STAGE_NAMES)
         or (control_active and control_stage_lower in MOUNT_HOLD_STAGE_NAMES)
     )
+    lifecycle = out.get("lifecycle") if isinstance(out.get("lifecycle"), Mapping) else {}
+    lifecycle_state = str(_first_present(lifecycle, "state", "status") or "").strip().lower()
+    lifecycle_final_or_idle = lifecycle_state in {"", "idle", "finished", "aborted", "error", "failed"}
+
+    # A fixed Az/El mount-move can leave fresh low-level status such as
+    # section=SKY, stage=tracking, or queue/control active even after the mount
+    # has physically reached the requested coordinate.  In a final/idle
+    # observation lifecycle, command ~= encoder and no encoder motion is the
+    # authoritative truth for the operator UI: the mount is at target, not
+    # running.  During an active observation we keep ON/SKY activity visible.
     mount_hold_at_target = bool(
         command_valid
         and mount_target_reached
         and not encoder_moving
-        and hold_stage_active
+        and (hold_stage_active or lifecycle_final_or_idle)
     )
 
     # command_valid keeps Tracking diagnostics meaningful, but by itself it is
@@ -1123,6 +1133,14 @@ def build_operator_status(
             "stage": ("idle" if activity.get("live_motion_active") is False else _first_present(activity, "motion_stage", "phase")),
             "tracking_ok": tracking_ok,
             "tracking_error_deg": tracking_error,
+            "live_motion_active": activity.get("live_motion_active"),
+            "live_motion_source": activity.get("live_motion_source"),
+            "mount_target_reached": bool(activity.get("mount_target_reached")),
+            "mount_hold_at_target": bool(activity.get("mount_hold_at_target")),
+            "mount_target_reached_tol_deg": activity.get("mount_target_reached_tol_deg"),
+            "encoder_motion_deadband_deg": activity.get("encoder_motion_deadband_deg"),
+            "encoder_motion_delta_az_deg": activity.get("encoder_motion_delta_az_deg"),
+            "encoder_motion_delta_el_deg": activity.get("encoder_motion_delta_el_deg"),
         },
         "antenna": {
             "command_az_deg": command_lon,

--- a/necst/web/status_model.py
+++ b/necst/web/status_model.py
@@ -109,6 +109,41 @@ def current_record_name(root: Path) -> Optional[str]:
         return None
 
 
+def progress_record_dir(root: Path, record_name: Optional[Any]) -> Optional[Path]:
+    """Return the progress sidecar directory for a record name, if known."""
+    record = str(record_name or "").strip()
+    if not record:
+        record = current_record_name(root) or ""
+    if not record:
+        return None
+    return root / safe_name(record)
+
+
+def default_record_root() -> Path:
+    """Return the NECST FileWriter root used by recorder.py.
+
+    The recorder defaults to ``$NECST_RECORD_ROOT`` or ``~/data``.  This helper
+    mirrors that logic for display only; it does not create directories.
+    """
+    return Path(os.environ.get("NECST_RECORD_ROOT", str(Path.home() / "data"))).expanduser()
+
+
+def recording_data_dir(record_name: Optional[Any]) -> Optional[Path]:
+    """Return the expected observation data directory for a record name.
+
+    NECST RecorderController calls ``Recorder(record_root).start_recording(name)``.
+    When ``name`` is relative, files are written under the record root; if ``name``
+    is already absolute, pathlib keeps it absolute.
+    """
+    record = str(record_name or "").strip()
+    if not record or record == "-":
+        return None
+    path = Path(record).expanduser()
+    if path.is_absolute():
+        return path
+    return default_record_root() / path
+
+
 def latest_events_path(
     root: Path, snapshot: Optional[Mapping[str, Any]] = None
 ) -> Optional[Path]:
@@ -629,6 +664,12 @@ def build_operator_status(
     observation_type = _first_present(obs, "type", "mode")
     observation_record = obs.get("record_name")
     observation_target = obs.get("target")
+    progress_record_directory = (
+        str(progress_record_dir(Path(str(paths.get("root") or "")) if isinstance(paths, Mapping) and paths.get("root") else progress_root(), observation_record))
+        if observation_record
+        else None
+    )
+    recording_directory = str(recording_data_dir(observation_record)) if observation_record else None
 
     active_task = _first_present(
         activity,
@@ -693,6 +734,8 @@ def build_operator_status(
             "record_name": observation_record,
             "obs_file": obs.get("obs_file"),
             "target": observation_target,
+            "recording_dir": recording_directory,
+            "progress_record_dir": progress_record_directory,
             "elapsed_sec": _finite_float(timing.get("elapsed_sec")),
             "remaining_sec": _finite_float(timing.get("estimated_remaining_sec")),
             "remaining_method": timing.get("remaining_method"),
@@ -773,10 +816,19 @@ def build_progress_status_state(
     plan = read_json(plan_path) if plan_path else None
     all_events = read_all_events(events_path)
     events = all_events[-events_limit:] if events_limit > 0 else []
+    record_name_for_paths = None
+    if isinstance(snapshot, Mapping):
+        record_name_for_paths = (_as_mapping(snapshot.get("observation"))).get("record_name")
+    record_name_for_paths = record_name_for_paths or current_record_name(root)
+    prog_record_dir = progress_record_dir(root, record_name_for_paths)
+    data_record_dir = recording_data_dir(record_name_for_paths)
     paths = {
+        "root": str(root),
         "snapshot": str(snapshot_path) if snapshot_path else None,
         "events": str(events_path) if events_path else None,
         "plan": str(plan_path) if plan_path else None,
+        "progress_record_dir": str(prog_record_dir) if prog_record_dir else None,
+        "recording_dir": str(data_record_dir) if data_record_dir else None,
     }
     compact_status = build_operator_status(
         snapshot if isinstance(snapshot, Mapping) else None,

--- a/necst/web/status_model.py
+++ b/necst/web/status_model.py
@@ -378,8 +378,8 @@ def merge_live_telemetry(
         if isinstance(live_payload.get("last_message_age_sec"), dict)
         else {}
     )
-    command_topic_age = _topic_age_sec(live_payload, "command", cmd)
-    command_topic_fresh = bool(command_topic_age is not None and command_topic_age <= live_status_max_age_sec())
+    command_topic_age = _topic_receipt_age_sec(live_payload, "command")
+    command_topic_fresh = _topic_received_fresh(live_payload, "command")
     direct_cmd_az = _finite_float(
         _first_present(cmd, "command_lon_deg", "cmd_az_deg", "az_cmd_deg")
     )
@@ -686,6 +686,33 @@ def _topic_age_sec(
     return None
 
 
+def _topic_receipt_age_sec(
+    live_payload: Mapping[str, Any],
+    key: str,
+) -> Optional[float]:
+    """Return age since the local subscriber actually received this topic.
+
+    This intentionally does *not* use timestamps carried inside the message.
+    For antenna command and control topics, message timestamps may describe the
+    planned command time rather than the wall-clock arrival time.  Using those
+    timestamps made old or interpolated command data look live after abort.
+    """
+    ages = live_payload.get("last_message_age_sec")
+    if isinstance(ages, Mapping):
+        age = _finite_float(ages.get(key))
+        if age is not None:
+            return age
+    return None
+
+
+def _topic_received_fresh(
+    live_payload: Mapping[str, Any],
+    key: str,
+) -> bool:
+    age = _topic_receipt_age_sec(live_payload, key)
+    return bool(age is not None and age <= live_status_max_age_sec())
+
+
 def _topic_is_fresh(
     live_payload: Mapping[str, Any],
     key: str,
@@ -736,17 +763,17 @@ def _live_truth_scrub_stale_motion(
     section = live_payload.get("section_status") if isinstance(live_payload.get("section_status"), Mapping) else {}
     control = live_payload.get("control") if isinstance(live_payload.get("control"), Mapping) else {}
 
-    queue_fresh = _topic_is_fresh(live_payload, "queue_status", queue)
+    queue_fresh = _topic_received_fresh(live_payload, "queue_status")
     try:
         queue_depth = int(queue.get("queue_depth", 0)) if isinstance(queue, Mapping) else 0
     except Exception:
         queue_depth = 0
     queue_active = bool(queue_fresh and (queue.get("active") or queue_depth > 0))
 
-    section_fresh = _topic_is_fresh(live_payload, "section_status", section)
+    section_fresh = _topic_received_fresh(live_payload, "section_status")
     section_active = bool(section_fresh and section.get("active"))
 
-    control_fresh = _topic_is_fresh(live_payload, "control", control)
+    control_fresh = _topic_received_fresh(live_payload, "control")
     control_active = bool(control_fresh and (control.get("controlled") or control.get("tight")))
 
     live_motion_active = bool(command_valid or queue_active or section_active or control_active)

--- a/necst/web/status_model.py
+++ b/necst/web/status_model.py
@@ -143,6 +143,45 @@ def default_record_root() -> Path:
     return Path(os.environ.get("NECST_RECORD_ROOT", str(Path.home() / "data"))).expanduser()
 
 
+def record_path_display_mode() -> str:
+    """Return the preferred path kind for operator-facing record display.
+
+    The operator usually copies the path into an analysis notebook on the local
+    PC or mounted filesystem, so the default is ``local``.  Set
+    ``NECST_CONSOLE_RECORD_PATH_MODE=container`` (or
+    ``NECST_CONSOLE_SHOW_CONTAINER_RECORD_PATH=1``) only when the Docker/container
+    path itself should be displayed.
+    """
+    legacy_container_flag = os.environ.get(
+        "NECST_CONSOLE_SHOW_CONTAINER_RECORD_PATH", ""
+    ).strip().lower()
+    if legacy_container_flag in {"1", "true", "yes", "on", "container"}:
+        return "container"
+    mode = os.environ.get("NECST_CONSOLE_RECORD_PATH_MODE", "local").strip().lower()
+    if mode in {"container", "docker", "internal"}:
+        return "container"
+    return "local"
+
+
+def local_record_root() -> Path:
+    """Return the local-PC/mounted record root used for operator display.
+
+    A configured host-side mount point is preferred.  If none is configured, use
+    the recorder root as the best available path instead of hiding the field.
+    This keeps the UI useful by default; deployments that explicitly want the
+    Docker/container path can set ``NECST_CONSOLE_RECORD_PATH_MODE=container``.
+    """
+    for name in (
+        "NECST_CONSOLE_LOCAL_RECORD_ROOT",
+        "NECST_RECORD_LOCAL_ROOT",
+        "NECST_LOCAL_RECORD_ROOT",
+    ):
+        value = os.environ.get(name, "").strip()
+        if value:
+            return Path(value).expanduser()
+    return default_record_root()
+
+
 def recording_data_dir(record_name: Optional[Any]) -> Optional[Path]:
     """Return the expected observation data directory for a record name.
 
@@ -157,6 +196,20 @@ def recording_data_dir(record_name: Optional[Any]) -> Optional[Path]:
     if path.is_absolute():
         return path
     return default_record_root() / path
+
+
+def local_recording_data_dir(record_name: Optional[Any]) -> Optional[Path]:
+    """Return the local-PC/mounted display path for a record name."""
+    record = str(record_name or "").strip()
+    root = local_record_root()
+    if not record or record == "-":
+        return None
+    path = Path(record).expanduser()
+    # Absolute record names cannot be safely remapped without an explicit
+    # path mapping table; fall back to the absolute path we actually know.
+    if path.is_absolute():
+        return path
+    return root / path
 
 
 def latest_events_path(
@@ -1055,6 +1108,8 @@ def build_operator_status(
         else None
     )
     recording_directory = str(recording_data_dir(observation_record)) if observation_record else None
+    local_recording_directory = str(local_recording_data_dir(observation_record)) if observation_record else None
+    record_display_mode = record_path_display_mode()
 
     if activity.get("live_motion_active") is False:
         active_task = "idle"
@@ -1131,6 +1186,8 @@ def build_operator_status(
             "obs_file": obs.get("obs_file"),
             "target": observation_target,
             "recording_dir": recording_directory,
+            "local_recording_dir": local_recording_directory,
+            "record_path_display_mode": record_display_mode,
             "progress_record_dir": progress_record_directory,
             "elapsed_sec": _finite_float(timing.get("elapsed_sec")),
             "remaining_sec": _finite_float(timing.get("estimated_remaining_sec")),
@@ -1226,6 +1283,7 @@ def build_progress_status_state(
     record_name_for_paths = record_name_for_paths or current_record_name(root)
     prog_record_dir = progress_record_dir(root, record_name_for_paths)
     data_record_dir = recording_data_dir(record_name_for_paths)
+    local_data_record_dir = local_recording_data_dir(record_name_for_paths)
     paths = {
         "root": str(root),
         "snapshot": str(snapshot_path) if snapshot_path else None,
@@ -1233,6 +1291,8 @@ def build_progress_status_state(
         "plan": str(plan_path) if plan_path else None,
         "progress_record_dir": str(prog_record_dir) if prog_record_dir else None,
         "recording_dir": str(data_record_dir) if data_record_dir else None,
+        "local_recording_dir": str(local_data_record_dir) if local_data_record_dir else None,
+        "record_path_display_mode": record_path_display_mode(),
     }
     compact_status = build_operator_status(
         snapshot if isinstance(snapshot, Mapping) else None,

--- a/necst/web/status_model.py
+++ b/necst/web/status_model.py
@@ -366,29 +366,65 @@ def merge_live_telemetry(
         if isinstance(live_payload.get("az_unwrap_status"), dict)
         else {}
     )
-    # Always start from direct command/encoder telemetry.  The pointing_status
-    # topic can be present while invalid (for example basis=missing-command);
-    # in that case its cmd/enc fields are NaN and must not mask a valid encoder
-    # topic.  Pointing status may overwrite these values only when it provides
-    # finite values for the same quantity.
-    if cmd:
+    # Always start from direct encoder telemetry.  Command display is stricter:
+    # it must represent a real, fresh command status topic (or a valid
+    # pointing_status command), not an observation plan, old progress snapshot,
+    # or interpolated section.  Otherwise Command Az/El can keep moving after
+    # abort even when no command topic is being published.
+    command_valid = False
+    command_source = "none"
+    live_ages = (
+        live_payload.get("last_message_age_sec")
+        if isinstance(live_payload.get("last_message_age_sec"), dict)
+        else {}
+    )
+    command_topic_age = _finite_float(live_ages.get("command"))
+    command_topic_fresh = (
+        command_topic_age is not None
+        and command_topic_age <= live_status_max_age_sec()
+    )
+    direct_cmd_az = _finite_float(
+        _first_present(cmd, "command_lon_deg", "cmd_az_deg", "az_cmd_deg")
+    )
+    direct_cmd_el = _finite_float(
+        _first_present(cmd, "command_lat_deg", "cmd_el_deg", "el_cmd_deg")
+    )
+    if direct_cmd_az is not None and direct_cmd_el is not None and command_topic_fresh:
         antenna_update.update(cmd)
+        command_valid = True
+        command_source = "command_topic"
     if enc:
         antenna_update.update(enc)
 
     if pointing:
         antenna_update["pointing_status_available"] = True
-        antenna_update["pointing_status_valid"] = bool(pointing.get("valid", False))
+        pointing_valid = bool(pointing.get("valid", False))
+        antenna_update["pointing_status_valid"] = pointing_valid
         cmd_az = _finite_float(pointing.get("cmd_az_deg"))
         cmd_el = _finite_float(pointing.get("cmd_el_deg"))
         enc_az = _finite_float(pointing.get("enc_az_deg"))
         enc_el = _finite_float(pointing.get("enc_el_deg"))
-        if cmd_az is not None and cmd_el is not None:
+        pointing_cmd_age = _finite_float(pointing.get("cmd_age_sec"))
+        pointing_cmd_fresh = (
+            pointing_cmd_age is not None
+            and pointing_cmd_age <= live_status_max_age_sec()
+        )
+        pointing_command_stale = bool(pointing.get("command_stale", False))
+        if (
+            not command_valid
+            and pointing_valid
+            and not pointing_command_stale
+            and pointing_cmd_fresh
+            and cmd_az is not None
+            and cmd_el is not None
+        ):
             antenna_update["command_lon_deg"] = cmd_az
             antenna_update["command_lat_deg"] = cmd_el
             antenna_update["command_frame"] = "altaz"
             antenna_update["command_unit"] = "deg"
             antenna_update["command_time_unix"] = pointing.get("command_time_unix")
+            command_valid = True
+            command_source = "pointing_status"
         if enc_az is not None and enc_el is not None:
             antenna_update["encoder_lon_deg"] = enc_az
             antenna_update["encoder_lat_deg"] = enc_el
@@ -445,6 +481,25 @@ def merge_live_telemetry(
         # NECST's antenna_tracking topic already performs the correct comparison.
         antenna_update.setdefault("tracking_status_available", False)
     if antenna_update:
+        antenna_section = out.setdefault("antenna", {})
+        if not command_valid:
+            for key in (
+                "command_lon_deg",
+                "command_lat_deg",
+                "cmd_az_deg",
+                "cmd_el_deg",
+                "az_cmd_deg",
+                "el_cmd_deg",
+                "command_frame",
+                "command_unit",
+                "command_time_unix",
+            ):
+                antenna_section.pop(key, None)
+                antenna_update.pop(key, None)
+        antenna_update["command_valid"] = bool(command_valid)
+        antenna_update["command_source"] = command_source
+        if command_topic_age is not None:
+            antenna_update["command_topic_age_sec"] = command_topic_age
         out.setdefault("antenna", {}).update(antenna_update)
     weather_payload = (
         live_payload.get("weather")

--- a/necst/web/status_model.py
+++ b/necst/web/status_model.py
@@ -378,11 +378,8 @@ def merge_live_telemetry(
         if isinstance(live_payload.get("last_message_age_sec"), dict)
         else {}
     )
-    command_topic_age = _finite_float(live_ages.get("command"))
-    command_topic_fresh = (
-        command_topic_age is not None
-        and command_topic_age <= live_status_max_age_sec()
-    )
+    command_topic_age = _topic_age_sec(live_payload, "command", cmd)
+    command_topic_fresh = bool(command_topic_age is not None and command_topic_age <= live_status_max_age_sec())
     direct_cmd_az = _finite_float(
         _first_present(cmd, "command_lon_deg", "cmd_az_deg", "az_cmd_deg")
     )
@@ -483,19 +480,8 @@ def merge_live_telemetry(
     if antenna_update:
         antenna_section = out.setdefault("antenna", {})
         if not command_valid:
-            for key in (
-                "command_lon_deg",
-                "command_lat_deg",
-                "cmd_az_deg",
-                "cmd_el_deg",
-                "az_cmd_deg",
-                "el_cmd_deg",
-                "command_frame",
-                "command_unit",
-                "command_time_unix",
-            ):
-                antenna_section.pop(key, None)
-                antenna_update.pop(key, None)
+            _clear_command_fields(antenna_section)
+            _clear_command_fields(antenna_update)
         antenna_update["command_valid"] = bool(command_valid)
         antenna_update["command_source"] = command_source
         if command_topic_age is not None:
@@ -660,10 +646,161 @@ def merge_live_telemetry(
             # present.
             if data.get("latest_control_line_index") is None:
                 data["latest_control_line_index"] = line_index
+    _live_truth_scrub_stale_motion(out, live_payload, command_valid=command_valid)
     return apply_dynamic_remaining(out)
 
 
 
+
+
+def _topic_age_sec(
+    live_payload: Mapping[str, Any],
+    key: str,
+    payload: Optional[Mapping[str, Any]] = None,
+    *,
+    now_unix: Optional[float] = None,
+) -> Optional[float]:
+    """Return the age of a live ROS topic sample, if known.
+
+    Console live telemetry records ``last_message_age_sec`` explicitly.  The
+    standalone progress monitor may also carry a payload timestamp.  Treat
+    missing age as unknown, not fresh.
+    """
+    ages = live_payload.get("last_message_age_sec")
+    if isinstance(ages, Mapping):
+        age = _finite_float(ages.get(key))
+        if age is not None:
+            return age
+    if payload is not None:
+        now = float(now_unix if now_unix is not None else time.time())
+        for ts_key in (
+            "publish_time_unix",
+            "time_unix",
+            "command_time_unix",
+            "encoder_time_unix",
+            "query_time_unix",
+        ):
+            ts = _finite_float(payload.get(ts_key))
+            if ts is not None:
+                return max(0.0, now - ts)
+    return None
+
+
+def _topic_is_fresh(
+    live_payload: Mapping[str, Any],
+    key: str,
+    payload: Optional[Mapping[str, Any]] = None,
+) -> bool:
+    age = _topic_age_sec(live_payload, key, payload)
+    return bool(age is not None and age <= live_status_max_age_sec())
+
+
+def _clear_command_fields(mapping: Dict[str, Any]) -> None:
+    for key in (
+        "command_lon_deg",
+        "command_lat_deg",
+        "cmd_az_deg",
+        "cmd_el_deg",
+        "az_cmd_deg",
+        "el_cmd_deg",
+        "command_frame",
+        "command_unit",
+        "command_time_unix",
+        "command_name",
+    ):
+        mapping.pop(key, None)
+
+
+def _live_truth_scrub_stale_motion(
+    out: Dict[str, Any],
+    live_payload: Mapping[str, Any],
+    *,
+    command_valid: bool,
+) -> None:
+    """Remove stale planned/sidecar motion fields when live ROS says idle.
+
+    The progress sidecar can legitimately lag after ``necst abort`` or a local
+    launcher failure.  In operator-facing displays, command and motion must be
+    shown only when backed by fresh live command / section / queue status.
+    """
+    if not isinstance(out, dict) or not isinstance(live_payload, Mapping):
+        return
+
+    antenna = out.setdefault("antenna", {})
+    if isinstance(antenna, dict) and not command_valid:
+        _clear_command_fields(antenna)
+        antenna["command_valid"] = False
+        antenna.setdefault("command_source", "none")
+
+    queue = live_payload.get("queue_status") if isinstance(live_payload.get("queue_status"), Mapping) else {}
+    section = live_payload.get("section_status") if isinstance(live_payload.get("section_status"), Mapping) else {}
+    control = live_payload.get("control") if isinstance(live_payload.get("control"), Mapping) else {}
+
+    queue_fresh = _topic_is_fresh(live_payload, "queue_status", queue)
+    try:
+        queue_depth = int(queue.get("queue_depth", 0)) if isinstance(queue, Mapping) else 0
+    except Exception:
+        queue_depth = 0
+    queue_active = bool(queue_fresh and (queue.get("active") or queue_depth > 0))
+
+    section_fresh = _topic_is_fresh(live_payload, "section_status", section)
+    section_active = bool(section_fresh and section.get("active"))
+
+    control_fresh = _topic_is_fresh(live_payload, "control", control)
+    control_active = bool(control_fresh and (control.get("controlled") or control.get("tight")))
+
+    live_motion_active = bool(command_valid or queue_active or section_active or control_active)
+    activity = out.setdefault("activity", {})
+    if not isinstance(activity, dict):
+        return
+    activity["live_motion_active"] = live_motion_active
+    activity["live_motion_source"] = (
+        "command" if command_valid else
+        "queue_status" if queue_active else
+        "section_status" if section_active else
+        "control_status" if control_active else
+        "none"
+    )
+
+    # If fresh live status does not support motion, old sidecar/planned values
+    # such as ON/line/moving must not remain visible as current state.
+    if live_motion_active:
+        return
+
+    for key in (
+        "motion_stage",
+        "drive_kind",
+        "active_task",
+        "control_section_kind",
+        "control_section_label",
+        "control_id",
+        "control_section_uid",
+        "control_status_basis",
+        "control_section_start_unix",
+        "control_section_stop_unix",
+        "control_section_command_time_unix",
+        "control_section_publish_time_unix",
+        "control_section_query_time_unix",
+        "control_section_duration_sec",
+        "control_section_fraction",
+        "phase",
+    ):
+        activity.pop(key, None)
+    activity["active_task"] = "idle"
+    activity["phase"] = "IDLE"
+    activity["motion_stage"] = "idle"
+    activity["drive_kind"] = "idle"
+    activity["control_section_active"] = False
+    activity["control_section_fresh"] = False
+    activity["control_section_age_sec"] = _topic_age_sec(live_payload, "section_status", section)
+
+    geometry = out.get("geometry")
+    if isinstance(geometry, dict):
+        for key in (
+            "current_line_label",
+            "live_section_geometry",
+        ):
+            geometry.pop(key, None)
 
 def _first_present(mapping: Mapping[str, Any], *keys: str) -> Any:
     for key in keys:
@@ -735,21 +872,29 @@ def build_operator_status(
     )
     recording_directory = str(recording_data_dir(observation_record)) if observation_record else None
 
-    active_task = _first_present(
-        activity,
-        "active_task",
-        "phase",
-        "drive_kind",
-        "motion_stage",
-    )
-    if active_task in (None, ""):
-        active_task = "observation" if lifecycle_state not in {"idle", "unknown"} else "idle"
+    if activity.get("live_motion_active") is False:
+        active_task = "idle"
+    else:
+        active_task = _first_present(
+            activity,
+            "active_task",
+            "phase",
+            "drive_kind",
+            "motion_stage",
+        )
+        if active_task in (None, ""):
+            active_task = "observation" if lifecycle_state not in {"idle", "unknown"} else "idle"
 
-    command_lon = _finite_float(
-        _first_present(antenna, "command_lon_deg", "cmd_az_deg", "az_cmd_deg")
+    command_fields_valid = antenna.get("command_valid") is not False
+    command_lon = (
+        _finite_float(_first_present(antenna, "command_lon_deg", "cmd_az_deg", "az_cmd_deg"))
+        if command_fields_valid
+        else None
     )
-    command_lat = _finite_float(
-        _first_present(antenna, "command_lat_deg", "cmd_el_deg", "el_cmd_deg")
+    command_lat = (
+        _finite_float(_first_present(antenna, "command_lat_deg", "cmd_el_deg", "el_cmd_deg"))
+        if command_fields_valid
+        else None
     )
     encoder_lon = _finite_float(
         _first_present(antenna, "encoder_lon_deg", "enc_az_deg", "az_deg")
@@ -812,7 +957,7 @@ def build_operator_status(
         },
         "motion": {
             "active_task": active_task,
-            "stage": _first_present(activity, "motion_stage", "phase"),
+            "stage": ("idle" if activity.get("live_motion_active") is False else _first_present(activity, "motion_stage", "phase")),
             "tracking_ok": tracking_ok,
             "tracking_error_deg": tracking_error,
         },

--- a/necst/web/status_model.py
+++ b/necst/web/status_model.py
@@ -18,6 +18,21 @@ import time
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional
 
+# Field feedback showed stopped encoder samples can jitter by about 2e-4 deg.
+# Use a looser tolerance for UI completion/hold detection than the display
+# precision, otherwise a fixed Az/El mount-move can remain incorrectly blocked.
+MOUNT_TARGET_REACHED_TOL_DEG = 5.0e-4
+MOUNT_HOLD_STAGE_NAMES = {
+    "tracking",
+    "track",
+    "holding",
+    "hold",
+    "target_hold",
+    "target hold",
+    "command_hold",
+    "command hold",
+}
+
 
 def safe_name(value: Any) -> str:
     original = str(value or "unknown")
@@ -200,6 +215,37 @@ def _finite_float(value: Any) -> Optional[float]:
     except Exception:
         return None
     return out if math.isfinite(out) else None
+
+
+def _axis_delta_deg(a: Optional[float], b: Optional[float], *, wrap: bool = False) -> Optional[float]:
+    if a is None or b is None:
+        return None
+    direct = abs(float(a) - float(b))
+    if not wrap:
+        return direct
+    try:
+        wrapped = abs(((float(a) - float(b) + 180.0) % 360.0) - 180.0)
+    except Exception:
+        return direct
+    return min(direct, wrapped)
+
+
+def _mount_target_reached(
+    *,
+    current_az: Optional[float],
+    current_el: Optional[float],
+    command_az: Optional[float],
+    command_el: Optional[float],
+    tolerance_deg: float = MOUNT_TARGET_REACHED_TOL_DEG,
+) -> bool:
+    az_delta = _axis_delta_deg(current_az, command_az, wrap=True)
+    el_delta = _axis_delta_deg(current_el, command_el, wrap=False)
+    return bool(
+        az_delta is not None
+        and el_delta is not None
+        and az_delta <= tolerance_deg
+        and el_delta <= tolerance_deg
+    )
 
 
 def _as_mapping(value: Any) -> Mapping[str, Any]:
@@ -750,10 +796,51 @@ def _live_truth_scrub_stale_motion(
     encoder_motion_fresh = _topic_received_fresh(live_payload, "encoder")
     encoder_moving = bool(encoder_motion_fresh and encoder_motion.get("moving"))
 
+    current_az = _finite_float(
+        _first_present(antenna, "encoder_lon_deg", "enc_az_deg", "az_deg")
+    )
+    current_el = _finite_float(
+        _first_present(antenna, "encoder_lat_deg", "enc_el_deg", "el_deg")
+    )
+    command_az = (
+        _finite_float(_first_present(antenna, "command_lon_deg", "cmd_az_deg", "az_cmd_deg"))
+        if command_valid
+        else None
+    )
+    command_el = (
+        _finite_float(_first_present(antenna, "command_lat_deg", "cmd_el_deg", "el_cmd_deg"))
+        if command_valid
+        else None
+    )
+    mount_target_reached = _mount_target_reached(
+        current_az=current_az,
+        current_el=current_el,
+        command_az=command_az,
+        command_el=command_el,
+    )
+    section_stage_lower = section_stage.lower()
+    control_stage_lower = control_stage.lower()
+    hold_stage_active = bool(
+        (section_active and section_stage_lower in MOUNT_HOLD_STAGE_NAMES)
+        or (control_active and control_stage_lower in MOUNT_HOLD_STAGE_NAMES)
+    )
+    mount_hold_at_target = bool(
+        command_valid
+        and mount_target_reached
+        and not encoder_moving
+        and hold_stage_active
+    )
+
     # command_valid keeps Tracking diagnostics meaningful, but by itself it is
     # not physical movement.  Prefer explicit motion topics; use the encoder
-    # only as a deadbanded fallback for manual motion cases.
-    live_motion_active = bool(section_active or queue_active or control_active or encoder_moving)
+    # only as a deadbanded fallback for manual motion cases.  A fixed Az/El
+    # mount-move may leave the low-level controller in a "tracking"/hold stage
+    # after the mount has reached the target; that must not block the next
+    # mount-move in the operator UI.
+    live_motion_active = bool(
+        (section_active or queue_active or control_active or encoder_moving)
+        and not mount_hold_at_target
+    )
     if section_active:
         motion_source = "section_status"
     elif queue_active:
@@ -775,6 +862,40 @@ def _live_truth_scrub_stale_motion(
     activity["encoder_motion_deadband_deg"] = encoder_motion.get("deadband_deg")
     activity["encoder_motion_delta_az_deg"] = encoder_motion.get("delta_az_deg")
     activity["encoder_motion_delta_el_deg"] = encoder_motion.get("delta_el_deg")
+    activity["mount_target_reached"] = bool(mount_target_reached)
+    activity["mount_target_reached_tol_deg"] = MOUNT_TARGET_REACHED_TOL_DEG
+
+    if mount_hold_at_target:
+        for key in (
+            "motion_stage",
+            "drive_kind",
+            "active_task",
+            "control_section_kind",
+            "control_section_label",
+            "control_id",
+            "control_section_uid",
+            "control_status_basis",
+            "control_section_start_unix",
+            "control_section_stop_unix",
+            "control_section_command_time_unix",
+            "control_section_publish_time_unix",
+            "control_section_query_time_unix",
+            "control_section_duration_sec",
+            "control_section_fraction",
+            "phase",
+        ):
+            activity.pop(key, None)
+        activity["live_motion_active"] = False
+        activity["live_motion_source"] = "mount_target_reached"
+        activity["active_task"] = "idle"
+        activity["phase"] = "IDLE"
+        activity["motion_stage"] = "idle"
+        activity["drive_kind"] = "idle"
+        activity["control_section_active"] = False
+        activity["control_section_fresh"] = bool(section_fresh or control_fresh)
+        activity["control_section_age_sec"] = _topic_age_sec(live_payload, "section_status", section)
+        activity["mount_hold_at_target"] = True
+        return
 
     if section_active:
         if section_stage:

--- a/necst/web/status_model.py
+++ b/necst/web/status_model.py
@@ -366,18 +366,32 @@ def merge_live_telemetry(
         if isinstance(live_payload.get("az_unwrap_status"), dict)
         else {}
     )
+    # Always start from direct command/encoder telemetry.  The pointing_status
+    # topic can be present while invalid (for example basis=missing-command);
+    # in that case its cmd/enc fields are NaN and must not mask a valid encoder
+    # topic.  Pointing status may overwrite these values only when it provides
+    # finite values for the same quantity.
+    if cmd:
+        antenna_update.update(cmd)
+    if enc:
+        antenna_update.update(enc)
+
     if pointing:
         antenna_update["pointing_status_available"] = True
         antenna_update["pointing_status_valid"] = bool(pointing.get("valid", False))
-        if pointing.get("cmd_az_deg") is not None:
-            antenna_update["command_lon_deg"] = pointing.get("cmd_az_deg")
-            antenna_update["command_lat_deg"] = pointing.get("cmd_el_deg")
+        cmd_az = _finite_float(pointing.get("cmd_az_deg"))
+        cmd_el = _finite_float(pointing.get("cmd_el_deg"))
+        enc_az = _finite_float(pointing.get("enc_az_deg"))
+        enc_el = _finite_float(pointing.get("enc_el_deg"))
+        if cmd_az is not None and cmd_el is not None:
+            antenna_update["command_lon_deg"] = cmd_az
+            antenna_update["command_lat_deg"] = cmd_el
             antenna_update["command_frame"] = "altaz"
             antenna_update["command_unit"] = "deg"
             antenna_update["command_time_unix"] = pointing.get("command_time_unix")
-        if pointing.get("enc_az_deg") is not None:
-            antenna_update["encoder_lon_deg"] = pointing.get("enc_az_deg")
-            antenna_update["encoder_lat_deg"] = pointing.get("enc_el_deg")
+        if enc_az is not None and enc_el is not None:
+            antenna_update["encoder_lon_deg"] = enc_az
+            antenna_update["encoder_lat_deg"] = enc_el
             antenna_update["encoder_frame"] = "altaz"
             antenna_update["encoder_unit"] = "deg"
             antenna_update["encoder_time_unix"] = pointing.get("encoder_time_unix")
@@ -401,11 +415,6 @@ def merge_live_telemetry(
         antenna_update["delta_el_deg"] = pointing.get("delta_el_deg")
         antenna_update["delta_az_cos_el_deg"] = pointing.get("delta_az_cos_el_deg")
         antenna_update["pointing_basis"] = pointing.get("basis")
-    else:
-        if cmd:
-            antenna_update.update(cmd)
-        if enc:
-            antenna_update.update(enc)
     if az_unwrap and az_unwrap.get("enabled"):
         antenna_update["az_unwrap"] = dict(az_unwrap)
         antenna_update["az_unwrap_enabled"] = True

--- a/necst/web/status_model.py
+++ b/necst/web/status_model.py
@@ -459,7 +459,6 @@ def merge_live_telemetry(
     # and may contain interpolated/extrapolated command values even after the
     # real altaz command stream stops.  Do not use it for Current, Command,
     # Tracking, or Moving state in operator-facing displays.
-    pointing: Dict[str, Any] = {}
     az_unwrap = (
         live_payload.get("az_unwrap_status")
         if isinstance(live_payload.get("az_unwrap_status"), dict)
@@ -472,11 +471,6 @@ def merge_live_telemetry(
     # even when no real command topic is being published.
     command_valid = False
     command_source = "none"
-    live_ages = (
-        live_payload.get("last_message_age_sec")
-        if isinstance(live_payload.get("last_message_age_sec"), dict)
-        else {}
-    )
     command_topic_age = _topic_receipt_age_sec(live_payload, "command")
     command_topic_fresh = _topic_received_fresh(live_payload, "command")
     direct_cmd_az = _finite_float(

--- a/necst/web/status_model.py
+++ b/necst/web/status_model.py
@@ -86,7 +86,9 @@ def read_json(path: Optional[Path]) -> Optional[Dict[str, Any]]:
         return {"_error": f"failed to read {path}: {exc}"}
 
 
-def read_jsonl(path: Optional[Path], limit: Optional[int] = None) -> List[Dict[str, Any]]:
+def read_jsonl(
+    path: Optional[Path], limit: Optional[int] = None
+) -> List[Dict[str, Any]]:
     if path is None:
         return []
     try:
@@ -140,7 +142,9 @@ def default_record_root() -> Path:
     The recorder defaults to ``$NECST_RECORD_ROOT`` or ``~/data``.  This helper
     mirrors that logic for display only; it does not create directories.
     """
-    return Path(os.environ.get("NECST_RECORD_ROOT", str(Path.home() / "data"))).expanduser()
+    return Path(
+        os.environ.get("NECST_RECORD_ROOT", str(Path.home() / "data"))
+    ).expanduser()
 
 
 def record_path_display_mode() -> str:
@@ -152,9 +156,9 @@ def record_path_display_mode() -> str:
     ``NECST_CONSOLE_SHOW_CONTAINER_RECORD_PATH=1``) only when the Docker/container
     path itself should be displayed.
     """
-    legacy_container_flag = os.environ.get(
-        "NECST_CONSOLE_SHOW_CONTAINER_RECORD_PATH", ""
-    ).strip().lower()
+    legacy_container_flag = (
+        os.environ.get("NECST_CONSOLE_SHOW_CONTAINER_RECORD_PATH", "").strip().lower()
+    )
     if legacy_container_flag in {"1", "true", "yes", "on", "container"}:
         return "container"
     mode = os.environ.get("NECST_CONSOLE_RECORD_PATH_MODE", "local").strip().lower()
@@ -270,7 +274,9 @@ def _finite_float(value: Any) -> Optional[float]:
     return out if math.isfinite(out) else None
 
 
-def _axis_delta_deg(a: Optional[float], b: Optional[float], *, wrap: bool = False) -> Optional[float]:
+def _axis_delta_deg(
+    a: Optional[float], b: Optional[float], *, wrap: bool = False
+) -> Optional[float]:
     if a is None or b is None:
         return None
     direct = abs(float(a) - float(b))
@@ -315,7 +321,9 @@ def apply_dynamic_remaining(
     if not isinstance(snapshot, dict):
         return snapshot
     timing = snapshot.get("time")
-    lifecycle = snapshot.get("lifecycle") if isinstance(snapshot.get("lifecycle"), dict) else {}
+    lifecycle = (
+        snapshot.get("lifecycle") if isinstance(snapshot.get("lifecycle"), dict) else {}
+    )
     if not isinstance(timing, dict):
         return snapshot
     state = str(lifecycle.get("state") or "").lower()
@@ -329,6 +337,7 @@ def apply_dynamic_remaining(
             0.0, completion - float(now_unix if now_unix is not None else time.time())
         )
     return snapshot
+
 
 def _live_payload_has_position(live_payload: Mapping[str, Any]) -> bool:
     """Return True when live ROS telemetry has enough antenna data to display.
@@ -700,9 +709,6 @@ def merge_live_telemetry(
     return apply_dynamic_remaining(out)
 
 
-
-
-
 def _topic_age_sec(
     live_payload: Mapping[str, Any],
     key: str,
@@ -823,24 +829,46 @@ def _live_truth_scrub_stale_motion(
         antenna["tracking_status_available"] = False
         antenna.setdefault("command_source", "none")
 
-    queue = live_payload.get("queue_status") if isinstance(live_payload.get("queue_status"), Mapping) else {}
-    section = live_payload.get("section_status") if isinstance(live_payload.get("section_status"), Mapping) else {}
-    control = live_payload.get("control") if isinstance(live_payload.get("control"), Mapping) else {}
-    encoder_motion = live_payload.get("encoder_motion") if isinstance(live_payload.get("encoder_motion"), Mapping) else {}
+    queue = (
+        live_payload.get("queue_status")
+        if isinstance(live_payload.get("queue_status"), Mapping)
+        else {}
+    )
+    section = (
+        live_payload.get("section_status")
+        if isinstance(live_payload.get("section_status"), Mapping)
+        else {}
+    )
+    control = (
+        live_payload.get("control")
+        if isinstance(live_payload.get("control"), Mapping)
+        else {}
+    )
+    encoder_motion = (
+        live_payload.get("encoder_motion")
+        if isinstance(live_payload.get("encoder_motion"), Mapping)
+        else {}
+    )
 
     section_fresh = _topic_received_fresh(live_payload, "section_status")
     section_active = bool(section_fresh and section.get("active"))
-    section_stage = str(section.get("section_kind") or section.get("section_label") or "").strip()
+    section_stage = str(
+        section.get("section_kind") or section.get("section_label") or ""
+    ).strip()
 
     queue_fresh = _topic_received_fresh(live_payload, "queue_status")
     try:
-        queue_depth = int(queue.get("queue_depth", 0)) if isinstance(queue, Mapping) else 0
+        queue_depth = (
+            int(queue.get("queue_depth", 0)) if isinstance(queue, Mapping) else 0
+        )
     except Exception:
         queue_depth = 0
     queue_active = bool(queue_fresh and (queue.get("active") or queue_depth > 0))
 
     control_fresh = _topic_received_fresh(live_payload, "control")
-    control_stage = str(control.get("section_kind") or control.get("section_label") or "").strip()
+    control_stage = str(
+        control.get("section_kind") or control.get("section_label") or ""
+    ).strip()
     control_active = bool(
         control_fresh
         and (control.get("controlled") or control.get("tight") or control_stage)
@@ -856,12 +884,16 @@ def _live_truth_scrub_stale_motion(
         _first_present(antenna, "encoder_lat_deg", "enc_el_deg", "el_deg")
     )
     command_az = (
-        _finite_float(_first_present(antenna, "command_lon_deg", "cmd_az_deg", "az_cmd_deg"))
+        _finite_float(
+            _first_present(antenna, "command_lon_deg", "cmd_az_deg", "az_cmd_deg")
+        )
         if command_valid
         else None
     )
     command_el = (
-        _finite_float(_first_present(antenna, "command_lat_deg", "cmd_el_deg", "el_cmd_deg"))
+        _finite_float(
+            _first_present(antenna, "command_lat_deg", "cmd_el_deg", "el_cmd_deg")
+        )
         if command_valid
         else None
     )
@@ -877,9 +909,20 @@ def _live_truth_scrub_stale_motion(
         (section_active and section_stage_lower in MOUNT_HOLD_STAGE_NAMES)
         or (control_active and control_stage_lower in MOUNT_HOLD_STAGE_NAMES)
     )
-    lifecycle = out.get("lifecycle") if isinstance(out.get("lifecycle"), Mapping) else {}
-    lifecycle_state = str(_first_present(lifecycle, "state", "status") or "").strip().lower()
-    lifecycle_final_or_idle = lifecycle_state in {"", "idle", "finished", "aborted", "error", "failed"}
+    lifecycle = (
+        out.get("lifecycle") if isinstance(out.get("lifecycle"), Mapping) else {}
+    )
+    lifecycle_state = (
+        str(_first_present(lifecycle, "state", "status") or "").strip().lower()
+    )
+    lifecycle_final_or_idle = lifecycle_state in {
+        "",
+        "idle",
+        "finished",
+        "aborted",
+        "error",
+        "failed",
+    }
 
     # A fixed Az/El mount-move can leave fresh low-level status such as
     # section=SKY, stage=tracking, or queue/control active even after the mount
@@ -899,9 +942,7 @@ def _live_truth_scrub_stale_motion(
     # Otherwise the operator can get trapped in MOUNT MOVING after pressing STOP
     # simply because a low-level section_status kept reporting SKY.
     mount_final_idle_without_command = bool(
-        lifecycle_final_or_idle
-        and not command_valid
-        and not encoder_moving
+        lifecycle_final_or_idle and not command_valid and not encoder_moving
     )
 
     # command_valid keeps Tracking diagnostics meaningful, but by itself it is
@@ -961,7 +1002,9 @@ def _live_truth_scrub_stale_motion(
             activity.pop(key, None)
         activity["live_motion_active"] = False
         activity["live_motion_source"] = (
-            "mount_target_reached" if mount_hold_at_target else "final_idle_no_encoder_motion"
+            "mount_target_reached"
+            if mount_hold_at_target
+            else "final_idle_no_encoder_motion"
         )
         activity["active_task"] = "idle"
         activity["phase"] = "IDLE"
@@ -969,9 +1012,13 @@ def _live_truth_scrub_stale_motion(
         activity["drive_kind"] = "idle"
         activity["control_section_active"] = False
         activity["control_section_fresh"] = bool(section_fresh or control_fresh)
-        activity["control_section_age_sec"] = _topic_age_sec(live_payload, "section_status", section)
+        activity["control_section_age_sec"] = _topic_age_sec(
+            live_payload, "section_status", section
+        )
         activity["mount_hold_at_target"] = bool(mount_hold_at_target)
-        activity["mount_final_idle_without_command"] = bool(mount_final_idle_without_command)
+        activity["mount_final_idle_without_command"] = bool(
+            mount_final_idle_without_command
+        )
         return
 
     if section_active:
@@ -980,11 +1027,15 @@ def _live_truth_scrub_stale_motion(
             activity["control_section_kind"] = section_stage
         activity["control_section_active"] = True
         activity["control_section_fresh"] = True
-        activity["control_section_age_sec"] = _topic_age_sec(live_payload, "section_status", section)
+        activity["control_section_age_sec"] = _topic_age_sec(
+            live_payload, "section_status", section
+        )
         return
 
     if queue_active:
-        if not activity.get("motion_stage") or str(activity.get("motion_stage")).lower() in {"idle", "none", "unknown"}:
+        if not activity.get("motion_stage") or str(
+            activity.get("motion_stage")
+        ).lower() in {"idle", "none", "unknown"}:
             activity["motion_stage"] = "moving"
         return
 
@@ -992,7 +1043,9 @@ def _live_truth_scrub_stale_motion(
         if control_stage:
             activity["motion_stage"] = control_stage
             activity["control_section_kind"] = control_stage
-        elif not activity.get("motion_stage") or str(activity.get("motion_stage")).lower() in {"idle", "none", "unknown"}:
+        elif not activity.get("motion_stage") or str(
+            activity.get("motion_stage")
+        ).lower() in {"idle", "none", "unknown"}:
             activity["motion_stage"] = "moving"
         return
 
@@ -1030,7 +1083,9 @@ def _live_truth_scrub_stale_motion(
     activity["drive_kind"] = "idle"
     activity["control_section_active"] = False
     activity["control_section_fresh"] = False
-    activity["control_section_age_sec"] = _topic_age_sec(live_payload, "section_status", section)
+    activity["control_section_age_sec"] = _topic_age_sec(
+        live_payload, "section_status", section
+    )
 
     geometry = out.get("geometry")
     if isinstance(geometry, dict):
@@ -1039,6 +1094,8 @@ def _live_truth_scrub_stale_motion(
             "live_section_geometry",
         ):
             geometry.pop(key, None)
+
+
 def _first_present(mapping: Mapping[str, Any], *keys: str) -> Any:
     for key in keys:
         value = mapping.get(key)
@@ -1103,12 +1160,27 @@ def build_operator_status(
     observation_record = obs.get("record_name")
     observation_target = obs.get("target")
     progress_record_directory = (
-        str(progress_record_dir(Path(str(paths.get("root") or "")) if isinstance(paths, Mapping) and paths.get("root") else progress_root(), observation_record))
+        str(
+            progress_record_dir(
+                (
+                    Path(str(paths.get("root") or ""))
+                    if isinstance(paths, Mapping) and paths.get("root")
+                    else progress_root()
+                ),
+                observation_record,
+            )
+        )
         if observation_record
         else None
     )
-    recording_directory = str(recording_data_dir(observation_record)) if observation_record else None
-    local_recording_directory = str(local_recording_data_dir(observation_record)) if observation_record else None
+    recording_directory = (
+        str(recording_data_dir(observation_record)) if observation_record else None
+    )
+    local_recording_directory = (
+        str(local_recording_data_dir(observation_record))
+        if observation_record
+        else None
+    )
     record_display_mode = record_path_display_mode()
 
     if activity.get("live_motion_active") is False:
@@ -1122,16 +1194,22 @@ def build_operator_status(
             "motion_stage",
         )
         if active_task in (None, ""):
-            active_task = "observation" if lifecycle_state not in {"idle", "unknown"} else "idle"
+            active_task = (
+                "observation" if lifecycle_state not in {"idle", "unknown"} else "idle"
+            )
 
     command_fields_valid = antenna.get("command_valid") is True
     command_lon = (
-        _finite_float(_first_present(antenna, "command_lon_deg", "cmd_az_deg", "az_cmd_deg"))
+        _finite_float(
+            _first_present(antenna, "command_lon_deg", "cmd_az_deg", "az_cmd_deg")
+        )
         if command_fields_valid
         else None
     )
     command_lat = (
-        _finite_float(_first_present(antenna, "command_lat_deg", "cmd_el_deg", "el_cmd_deg"))
+        _finite_float(
+            _first_present(antenna, "command_lat_deg", "cmd_el_deg", "el_cmd_deg")
+        )
         if command_fields_valid
         else None
     )
@@ -1196,19 +1274,27 @@ def build_operator_status(
         "progress": {
             "percent": _progress_percent(snap),
             "total": compact_plan_total,
-            "current": _first_present(snap_plan, "current", "current_index", "current_id"),
+            "current": _first_present(
+                snap_plan, "current", "current_index", "current_id"
+            ),
             "label": _first_present(snap_plan, "label", "mode", "role"),
         },
         "motion": {
             "active_task": active_task,
-            "stage": ("idle" if activity.get("live_motion_active") is False else _first_present(activity, "motion_stage", "phase")),
+            "stage": (
+                "idle"
+                if activity.get("live_motion_active") is False
+                else _first_present(activity, "motion_stage", "phase")
+            ),
             "tracking_ok": tracking_ok,
             "tracking_error_deg": tracking_error,
             "live_motion_active": activity.get("live_motion_active"),
             "live_motion_source": activity.get("live_motion_source"),
             "mount_target_reached": bool(activity.get("mount_target_reached")),
             "mount_hold_at_target": bool(activity.get("mount_hold_at_target")),
-            "mount_target_reached_tol_deg": activity.get("mount_target_reached_tol_deg"),
+            "mount_target_reached_tol_deg": activity.get(
+                "mount_target_reached_tol_deg"
+            ),
             "encoder_motion_deadband_deg": activity.get("encoder_motion_deadband_deg"),
             "encoder_motion_delta_az_deg": activity.get("encoder_motion_delta_az_deg"),
             "encoder_motion_delta_el_deg": activity.get("encoder_motion_delta_el_deg"),
@@ -1223,10 +1309,15 @@ def build_operator_status(
             "tracking_status_age_sec": _finite_float(
                 antenna.get("tracking_status_age_sec")
             ),
-            "az_unwrap": antenna.get("az_unwrap") if isinstance(antenna.get("az_unwrap"), Mapping) else None,
+            "az_unwrap": (
+                antenna.get("az_unwrap")
+                if isinstance(antenna.get("az_unwrap"), Mapping)
+                else None
+            ),
         },
         "chopper": {
-            "state": _first_present(chopper, "state", "position_state", "status") or "unknown",
+            "state": _first_present(chopper, "state", "position_state", "status")
+            or "unknown",
             "position": chopper_position,
             "age_sec": _age_sec(chopper_time, now_unix=now),
             "raw": dict(chopper) if chopper else {},
@@ -1279,7 +1370,9 @@ def build_progress_status_state(
     events = all_events[-events_limit:] if events_limit > 0 else []
     record_name_for_paths = None
     if isinstance(snapshot, Mapping):
-        record_name_for_paths = (_as_mapping(snapshot.get("observation"))).get("record_name")
+        record_name_for_paths = (_as_mapping(snapshot.get("observation"))).get(
+            "record_name"
+        )
     record_name_for_paths = record_name_for_paths or current_record_name(root)
     prog_record_dir = progress_record_dir(root, record_name_for_paths)
     data_record_dir = recording_data_dir(record_name_for_paths)
@@ -1291,7 +1384,9 @@ def build_progress_status_state(
         "plan": str(plan_path) if plan_path else None,
         "progress_record_dir": str(prog_record_dir) if prog_record_dir else None,
         "recording_dir": str(data_record_dir) if data_record_dir else None,
-        "local_recording_dir": str(local_data_record_dir) if local_data_record_dir else None,
+        "local_recording_dir": (
+            str(local_data_record_dir) if local_data_record_dir else None
+        ),
         "record_path_display_mode": record_path_display_mode(),
     }
     compact_status = build_operator_status(
@@ -1302,7 +1397,9 @@ def build_progress_status_state(
         server_time_unix=now,
     )
     return {
-        "ok": isinstance(snapshot, dict) and bool(snapshot) and not snapshot.get("_error"),
+        "ok": isinstance(snapshot, dict)
+        and bool(snapshot)
+        and not snapshot.get("_error"),
         "root": str(root),
         "paths": paths,
         "raw_snapshot": raw_snapshot or {},

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,9 @@ setup(
     entry_points={
         "console_scripts": executor_entrypoints
         + [
+            "necst=necst.cli:main",
+            "necst-console=necst.web.console_entry:main",
+            "necst-console-log=necst.web.console_log_cli:main",
             "necst-spectral-resolve=necst.rx.spectral_recording_setup:main_resolve",
             "necst-spectral-validate=necst.rx.spectral_recording_setup:main_validate",
             "necst-lo-profile=necst.rx.spectral_recording_sg:main_lo_profile",

--- a/tests/core/test_commander.py
+++ b/tests/core/test_commander.py
@@ -16,6 +16,19 @@ from necst.utils import spinning
 from ..conftest import TesterNode, destroy
 
 
+def _wait_for_antenna_stop(com):
+    timelimit = time.monotonic() + 3
+    while time.monotonic() < timelimit:
+        speed = com.get_message("speed")
+        if speed.az < 1e-5 and speed.el < 1e-5:
+            return
+        time.sleep(0.02)
+
+    speed = com.get_message("speed")
+    assert speed.az < 1e-5
+    assert speed.el < 1e-5
+
+
 class TestCommander(TesterNode):
     NodeName = "test_commander"
 
@@ -120,22 +133,23 @@ class TestCommander(TesterNode):
         pid = AntennaPIDController()
         dev = AntennaDeviceSimulator()
 
-        with spinning([auth_server, horizontal, pid, dev], n_thread=5):
-            com.get_privilege()
-            com.antenna(
-                "point", target=(340, 80, "altaz"), unit="deg", wait=False
-            )  # To accelerate to non-zero speed.
-            _ = com.get_message("speed")
-            time.sleep(5)  # Additional acceleration time
-            assert com.get_message("speed").az > 1e-4
-            assert com.get_message("speed").el > 1e-4
+        try:
+            with spinning([auth_server, horizontal, pid, dev], n_thread=5):
+                com.get_privilege()
+                com.antenna(
+                    "point", target=(340, 80, "altaz"), unit="deg", wait=False
+                )  # To accelerate to non-zero speed.
+                _ = com.get_message("speed")
+                time.sleep(5)  # Additional acceleration time
+                assert com.get_message("speed").az > 1e-4
+                assert com.get_message("speed").el > 1e-4
 
-            com.antenna("stop")
-            assert com.get_message("speed").az < 1e-5
-            assert com.get_message("speed").el < 1e-5
+                com.antenna("stop")
+                _wait_for_antenna_stop(com)
 
-            com.quit_privilege()
-        destroy([com, auth_server, horizontal, pid, dev])
+                com.quit_privilege()
+        finally:
+            destroy([com, auth_server, horizontal, pid, dev])
 
     def test_antenna_stop_even_though_command_is_supplied(self):
         com = Commander()
@@ -144,23 +158,24 @@ class TestCommander(TesterNode):
         pid = AntennaPIDController()
         dev = AntennaDeviceSimulator()
 
-        with spinning([auth_server, horizontal, pid, dev], n_thread=5):
-            com.get_privilege()
+        try:
+            with spinning([auth_server, horizontal, pid, dev], n_thread=5):
+                com.get_privilege()
 
-            com.antenna(
-                "point", target=(340, 80, "altaz"), unit="deg", wait=False
-            )  # To accelerate to non-zero speed.
-            _ = com.get_message("speed")
-            time.sleep(5)  # Additional acceleration time
-            assert com.get_message("speed").az > 1e-4
-            assert com.get_message("speed").el > 1e-4
+                com.antenna(
+                    "point", target=(340, 80, "altaz"), unit="deg", wait=False
+                )  # To accelerate to non-zero speed.
+                _ = com.get_message("speed")
+                time.sleep(5)  # Additional acceleration time
+                assert com.get_message("speed").az > 1e-4
+                assert com.get_message("speed").el > 1e-4
 
-            com.antenna("stop", target=(30, 45, "altaz"), unit="deg")
-            assert com.get_message("speed").az < 1e-5
-            assert com.get_message("speed").el < 1e-5
+                com.antenna("stop", target=(30, 45, "altaz"), unit="deg")
+                _wait_for_antenna_stop(com)
 
-            com.quit_privilege()
-        destroy([com, auth_server, horizontal, pid, dev])
+                com.quit_privilege()
+        finally:
+            destroy([com, auth_server, horizontal, pid, dev])
 
     def test_pid_parameter_change(self):
         com = Commander()


### PR DESCRIPTION
## Summary

- Add `TimeSyncPoller` background thread to `progress.py` — monitors NTP/chrony sync state of telescope hosts (chronyc/ntpq/xntpdq/ntpdc)
- Add `apply_display_derivations()` — computes LST and RA/Dec ↔ Galactic coordinate cross-frame transforms for the dashboard
- Add `apply_dynamic_remaining()` — count-down estimated remaining time from `estimated_completion_unix`
- Update `progress-demo.py` — add synthetic `time_sync` and `chopper` cards to the demo fixture
- Add `bin/chopper.py` — new `necst chopper` CLI entry point
- Update `necst/core/emergency.py` — add `main_chopper()` and helper functions for chopper control

## Details

### Time sync monitoring (`bin/progress.py`)
- `TimeSyncPoller` — low-frequency background thread (default every 60 s) querying NTP state via `chronyc tracking`, `ntpq`, `xntpdq`, or `ntpdc`
- Supports `auto` method fallback: `chrony → ntpq → xntpdq → ntpdc`
- Multi-host config via `[progress.time_sync]` section in site TOML (e.g. `OMU1p85m_config.toml`)
- Fails closed — if config is absent or tools are not installed, the indicator is simply hidden

### Config example (site TOML)

```toml
[progress.time_sync]
enabled = true
interval_sec = 60
timeout_sec = 2
ok_offset_ms = 5
warn_offset_ms = 20
bad_after_failures = 3

[[progress.time_sync.hosts]]
name = "localhost"
host = "localhost"
method = "chrony"

[[progress.time_sync.hosts]]
name = "xffts"
host = "xffts"
method = "ntpq"
```

### Chopper CLI (`bin/chopper.py` + `necst/core/emergency.py`)
- `necst chopper in` (alias: `insert`) — insert chopper
- `necst chopper out` (alias: `remove`) — remove chopper
- `necst chopper status` (alias: `?`) — read current state
- Handles both real motor hardware (position-based) and ChopperSimulator (boolean-only)
- Simulator mode auto-detected from `config.simulator = true`

```bash
necst chopper in
necst chopper out --timeout-sec 30
necst chopper status
```

## Test plan

- [ ] `python bin/progress-demo.py` — verify demo server shows time_sync card alternating OK/bad every 30 s
- [ ] With `[progress.time_sync]` config — verify time sync card appears with correct host statuses
- [ ] Without `[progress.time_sync]` config — verify dashboard still works (fails closed)
- [ ] LST row appears when `updated_at_unix` is present in snapshot
- [ ] `necst chopper status` — prints current state without privilege
- [ ] `necst chopper in` / `necst chopper out` — moves and waits for confirmation
- [ ] Simulator mode: boolean-only status (position=0) handled correctly

Closes #474