### PR TITLE
#475 feat: add necst chopper CLI command

### DIFF
--- a/bin/chopper.py
+++ b/bin/chopper.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+"""Move or query the chopper through the unified `necst` CLI."""
+
+import sys
+
+from necst.core.emergency import main_chopper
+
+if __name__ == "__main__":
+    sys.exit(main_chopper())

--- a/necst/core/emergency.py
+++ b/necst/core/emergency.py
@@ -9,6 +9,7 @@ from typing import Optional
 
 import rclpy
 
+from .. import config
 from .commander import Commander
 
 
@@ -234,3 +235,286 @@ def main_mount_move(argv: Optional[list[str]] = None) -> int:
             pass
         com.destroy_node()
         _shutdown_if_needed(should_shutdown)
+
+
+def _chopper_config_positions() -> tuple[Optional[int], Optional[int]]:
+    try:
+        insert_position = int(config.chopper_motor_position["insert"])
+        remove_position = int(config.chopper_motor_position["remove"])
+        return insert_position, remove_position
+    except Exception:
+        return None, None
+
+
+def _chopper_msg_position(msg) -> Optional[int]:
+    try:
+        return int(getattr(msg, "position"))
+    except Exception:
+        return None
+
+
+def _chopper_msg_insert_flag(msg) -> Optional[bool]:
+    try:
+        value = getattr(msg, "insert")
+    except Exception:
+        return None
+    return None if value is None else bool(value)
+
+
+def _chopper_simulator_uses_boolean_only_status() -> bool:
+    """Return True when the active chopper status is expected to be simulator-like.
+
+    NECST's ChopperSimulator publishes only the boolean insert flag; the int32
+    position field remains the ROS default value 0.  Real hardware must keep
+    using motor positions, so this fallback is enabled only when the active site
+    config explicitly says simulator=true.
+    """
+    try:
+        return bool(getattr(config, "simulator", False))
+    except Exception:
+        return False
+
+
+def _chopper_zero_is_boolean_only_simulator_for_target(
+    target_position: int,
+) -> bool:
+    """Return True when position=0 may stand for a simulator-only boolean state.
+
+    If the requested endpoint itself is 0, position=0 is a real endpoint and is
+    already handled by the explicit position match.  The boolean-only fallback
+    is therefore needed only for simulator targets whose configured endpoint is
+    non-zero, e.g. NANTEN2 OUT/remove=250 while ChopperSimulator still publishes
+    position=0, insert=False.
+    """
+    return _chopper_simulator_uses_boolean_only_status() and int(target_position) != 0
+
+
+def _chopper_status_matches(msg, target_position: int, target_insert: bool) -> bool:
+    position = _chopper_msg_position(msg)
+    insert_flag = _chopper_msg_insert_flag(msg)
+    target_position = int(target_position)
+
+    # Trust an explicit motor step only when the optional boolean flag is not
+    # contradicting it.  The real controller derives the flag from the motor
+    # endpoint, so a conflicting flag/position pair is inconsistent telemetry
+    # and must not be treated as completed.
+    if position is not None and position == target_position:
+        return insert_flag is None or insert_flag == bool(target_insert)
+
+    # If the boolean flag is absent or contradicts the requested state, the
+    # requested state has not been confirmed.
+    if insert_flag is None or insert_flag != bool(target_insert):
+        return False
+
+    # At this point the boolean flag agrees with the requested state but the
+    # motor position did not explicitly match the target.  Accept boolean-only
+    # telemetry only when the position field is genuinely absent.  The ROS
+    # simulator publishes an int32 default 0 even though it only models the
+    # boolean state, so accept that special case only when the active NECST
+    # configuration is explicitly in simulator mode.  In real hardware mode,
+    # position=0 can be an actual counter value and must not be treated as
+    # "unknown".
+    if position is None:
+        return True
+    if (
+        position == 0
+        and _chopper_zero_is_boolean_only_simulator_for_target(target_position)
+    ):
+        return True
+    return False
+
+
+def _format_chopper_status(msg) -> tuple[str, str]:
+    """Return operator-facing chopper status and detail string."""
+    position = _chopper_msg_position(msg)
+    insert_position, remove_position = _chopper_config_positions()
+    insert_flag = _chopper_msg_insert_flag(msg)
+
+    simulator_boolean_only = _chopper_simulator_uses_boolean_only_status()
+
+    if (
+        position is not None
+        and insert_position is not None
+        and position == insert_position
+        and insert_flag is not False
+    ):
+        state = "IN"
+    elif (
+        position is not None
+        and remove_position is not None
+        and position == remove_position
+        and insert_flag is not True
+    ):
+        state = "OUT"
+    elif simulator_boolean_only and position == 0 and insert_flag is True:
+        state = "IN"
+    elif simulator_boolean_only and position == 0 and insert_flag is False:
+        state = "OUT"
+    elif insert_flag is True:
+        state = "IN?"
+    elif insert_flag is False:
+        state = "OUT?"
+    else:
+        state = "UNKNOWN"
+
+    timestamp = getattr(msg, "time", None)
+    try:
+        age_sec = max(0.0, time.time() - float(timestamp))
+        age_text = f", age={age_sec:.1f}s"
+    except Exception:
+        age_text = ""
+
+    detail = f"position={position}, insert={insert_flag}{age_text}"
+    return state, detail
+
+
+def _wait_chopper_position(
+    com: Commander, target_position: int, target_insert: bool, timeout_sec: float
+) -> None:
+    """Wait for chopper status to reach target position/flag with a timeout."""
+    deadline = time.monotonic() + max(0.0, float(timeout_sec))
+    last_state = "UNKNOWN"
+    last_detail = "no status received"
+    while time.monotonic() <= deadline:
+        try:
+            msg = com.get_message("chopper", timeout_sec=0.2)
+            state, detail = _format_chopper_status(msg)
+            last_state, last_detail = state, detail
+            if _chopper_status_matches(msg, target_position, target_insert):
+                return
+        except Exception as exc:
+            last_state, last_detail = "UNKNOWN", str(exc)
+        time.sleep(0.1)
+    raise TimeoutError(
+        "chopper did not reach target position "
+        f"{target_position} within {timeout_sec:.1f}s "
+        f"(last: {last_state}, {last_detail})"
+    )
+
+
+def main_chopper(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="necst chopper",
+        description=(
+            "Move or query the chopper.  'in' inserts the ambient load; "
+            "'out' removes it.  'status' only reads telemetry."
+        ),
+    )
+    parser.add_argument(
+        "command",
+        choices=["in", "out", "status", "insert", "remove", "?"],
+        help="Chopper command: in/out/status.  insert/remove/? are aliases.",
+    )
+    parser.add_argument(
+        "--no-wait",
+        action="store_true",
+        help="Return after publishing the command without waiting for status.",
+    )
+    parser.add_argument(
+        "--timeout-sec",
+        type=float,
+        default=10.0,
+        help="Maximum time to wait for in/out completion (default: 10).",
+    )
+    parser.add_argument(
+        "--settle-sec",
+        type=float,
+        default=0.2,
+        help="ROS discovery settle delay before publishing/querying (default: 0.2).",
+    )
+    parser.add_argument(
+        "--repeat",
+        type=int,
+        default=3,
+        help="Number of command publications for in/out (default: 3).",
+    )
+    parser.add_argument(
+        "--interval-sec",
+        type=float,
+        default=0.1,
+        help="Interval between repeated command publications (default: 0.1).",
+    )
+    args = parser.parse_args(argv)
+
+    command = str(args.command).lower()
+    if command == "insert":
+        command = "in"
+    elif command == "remove":
+        command = "out"
+    elif command == "?":
+        command = "status"
+
+    should_shutdown = _ensure_rclpy()
+    com = Commander()
+    try:
+        if args.settle_sec > 0:
+            time.sleep(float(args.settle_sec))
+
+        if command == "status":
+            try:
+                msg = com.get_message(
+                    "chopper", timeout_sec=max(0.0, float(args.timeout_sec))
+                )
+            except Exception as exc:
+                print(f"failed to read chopper status: {exc}", file=sys.stderr)
+                return 1
+            state, detail = _format_chopper_status(msg)
+            print(f"chopper {state}: {detail}")
+            return 0
+
+        if command == "in":
+            commander_cmd = "insert"
+            label = "IN"
+            target_insert = True
+            target_position = int(config.chopper_motor_position["insert"])
+        elif command == "out":
+            commander_cmd = "remove"
+            label = "OUT"
+            target_insert = False
+            target_position = int(config.chopper_motor_position["remove"])
+        else:
+            parser.error(f"unknown command: {args.command!r}")
+
+        print(f"Chopper command: {label}")
+        print(f"  target position = {target_position}")
+
+        if not com.get_privilege():
+            print("failed to acquire NECST privilege", file=sys.stderr)
+            return 2
+
+        repeat = max(1, int(args.repeat))
+        interval = max(0.0, float(args.interval_sec))
+        for i in range(repeat):
+            com.chopper(commander_cmd, wait=False)
+            if i + 1 < repeat:
+                time.sleep(interval)
+
+        if not args.no_wait:
+            try:
+                _wait_chopper_position(
+                    com,
+                    target_position,
+                    target_insert,
+                    timeout_sec=max(0.0, float(args.timeout_sec)),
+                )
+                msg = com.get_message("chopper", timeout_sec=0.5)
+                state, detail = _format_chopper_status(msg)
+                print(f"chopper {state}: {detail}")
+            except KeyboardInterrupt:
+                print("interrupted while waiting for chopper status", file=sys.stderr)
+                return 130
+        return 0
+    except TimeoutError as exc:
+        print(f"timeout: {exc}", file=sys.stderr)
+        return 1
+    except KeyboardInterrupt:
+        print("interrupted", file=sys.stderr)
+        return 130
+    finally:
+        try:
+            com.quit_privilege()
+        except Exception:
+            pass
+        com.destroy_node()
+        _shutdown_if_needed(should_shutdown)
+


### PR DESCRIPTION
## Summary

- Add `bin/chopper.py` — new `necst chopper` CLI entry point
- Update `necst/core/emergency.py` — add `main_chopper()` and helper functions for chopper control

## Details

### `bin/chopper.py`
Thin wrapper following the same pattern as `bin/stop.py` and `bin/abort.py`.

### `necst/core/emergency.py` additions
- `main_chopper()` — argparse CLI with subcommands: `in`, `out`, `status` (aliases: `insert`, `remove`, `?`)
- `_chopper_config_positions()` — reads `config.chopper_motor_position[insert/remove]`
- `_chopper_status_matches()` — confirms chopper reached target; handles both real motor (position-based) and ChopperSimulator (boolean-only)
- `_chopper_simulator_uses_boolean_only_status()` — detects simulator mode via `config.simulator`
- `_format_chopper_status()` — returns human-readable state: `IN` / `OUT` / `IN?` / `OUT?` / `UNKNOWN`
- `_wait_chopper_position()` — polls until status matches target within timeout

## Test plan

- [ ] `necst chopper status` — prints current chopper state without privilege
- [ ] `necst chopper in` — inserts chopper and waits for IN confirmation
- [ ] `necst chopper out` — removes chopper and waits for OUT confirmation
- [ ] `necst chopper in --no-wait` — sends command and returns immediately
- [ ] Simulator mode: verify boolean-only status (position=0) is handled correctly when `config.simulator = true`
- [ ] Timeout: `necst chopper in --timeout-sec 5` raises TimeoutError if chopper is stuck

Closes #475