### PR TITLE
fix: create save directory before CCD capture, fix az-unwrap drive jumps, keep sidereal tracking

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 jobs:
   compile:

--- a/bin/progress.py
+++ b/bin/progress.py
@@ -5539,6 +5539,8 @@ function mapAxisLabels(rows) {
   }
   const r = rows.find(x=>x.frame) || rows[0] || {};
   const frame = r.frame || 'map'; const unit = r.unit || 'deg';
+  if (frameLooksRadec(frame)) return {x:`RA (${unit})`, y:`Dec (${unit})`, unit};
+  if (frameLooksGalactic(frame)) return {x:`Galactic l (${unit})`, y:`Galactic b (${unit})`, unit};
   return {x:`${frame} x (${unit})`, y:`${frame} y (${unit})`, unit};
 }
 function fmtAxisNumber(v, axes) {

--- a/bin/progress.py
+++ b/bin/progress.py
@@ -5360,6 +5360,14 @@ function gridSequencePath(pointRows, b) {
   const pts = on.map(r => `${sx(r.a[0],b)},${sy(r.a[1],b)}`).join(' ');
   return `<polyline points="${pts}" fill="none" stroke="var(--muted)" stroke-width="1.3" opacity="0.45" stroke-dasharray="4 3"/>`;
 }
+function pointSequencePath(pointRows, b) {
+  // Visiting order for plain point-by-point plans (e.g. optical pointing).
+  // Solid blue, not gray/dashed, so it never reads as the axisDecorations
+  // zero-reference line (which is gray, dashed "3 3", opacity 0.45).
+  if (pointRows.length < 2) return '';
+  const pts = pointRows.map(r => `${sx(r.a[0],b)},${sy(r.a[1],b)}`).join(' ');
+  return `<polyline points="${pts}" fill="none" stroke="#4a90d9" stroke-width="1.5" opacity="0.65"/>`;
+}
 function scheduleStep(plan) {
   if (Number.isInteger(plan?.index0) && Number.isInteger(plan?.total) && plan.total > 0) {
     const end = Number.isInteger(plan?.index0_end) && plan.index0_end >= plan.index0 ? plan.index0_end : plan.index0;
@@ -5589,7 +5597,9 @@ function renderMapSvg(snapshot, items, events, serverTimeUnix=null) {
   const pointRows = rows.filter(r=>!r.b);
   const onRows = pointRows.filter(r=>String(r.mode || r.pointLabel || '').toUpperCase()==='ON' || r.kind === 'grid_point');
   const drawRows = rowsForDrawing(rows).sort((a,b)=>({pending:0,done:1,current:2}[a.status]-{pending:0,done:1,current:2}[b.status]));
-  const sequencePath = obsType.includes('grid') ? gridSequencePath(onRows, b) : '';
+  const sequencePath = obsType.includes('grid')
+    ? gridSequencePath(onRows, b)
+    : (!ls.total && pointRows.length >= 2 ? pointSequencePath(pointRows, b) : '');
   const lineEls = drawRows.map(r => {
     if (!r.b) return renderPoint(r,b);
     const x1=sx(r.a[0],b), y1=sy(r.a[1],b), x2=sx(r.b[0],b), y2=sy(r.b[1],b);

--- a/bin/progress.py
+++ b/bin/progress.py
@@ -5362,11 +5362,22 @@ function gridSequencePath(pointRows, b) {
 }
 function pointSequencePath(pointRows, b) {
   // Visiting order for plain point-by-point plans (e.g. optical pointing).
-  // Solid blue, not gray/dashed, so it never reads as the axisDecorations
-  // zero-reference line (which is gray, dashed "3 3", opacity 0.45).
+  // Kept subtle: the traveled (done) part is a muted green tying it to the
+  // "done" dot color; the remaining part is faint neutral. Both are solid
+  // (no dash), so neither is mistaken for axisDecorations' dashed "3 3"
+  // zero-reference line even where the color is similar.
   if (pointRows.length < 2) return '';
-  const pts = pointRows.map(r => `${sx(r.a[0],b)},${sy(r.a[1],b)}`).join(' ');
-  return `<polyline points="${pts}" fill="none" stroke="#4a90d9" stroke-width="1.5" opacity="0.65"/>`;
+  let out = '';
+  for (let i = 0; i < pointRows.length - 1; i++) {
+    const p1 = pointRows[i], p2 = pointRows[i + 1];
+    const x1 = sx(p1.a[0], b), y1 = sy(p1.a[1], b);
+    const x2 = sx(p2.a[0], b), y2 = sy(p2.a[1], b);
+    const traveled = p1.status === 'done' && p2.status !== 'pending';
+    const stroke = traveled ? '#2ca02c' : 'var(--muted)';
+    const opacity = traveled ? 0.45 : 0.25;
+    out += `<line x1="${x1}" y1="${y1}" x2="${x2}" y2="${y2}" stroke="${stroke}" stroke-width="1.2" opacity="${opacity}"/>`;
+  }
+  return out;
 }
 function scheduleStep(plan) {
   if (Number.isInteger(plan?.index0) && Number.isInteger(plan?.total) && plan.total > 0) {

--- a/necst/ctrl/antenna/pid_controller.py
+++ b/necst/ctrl/antenna/pid_controller.py
@@ -220,8 +220,8 @@ class AntennaPIDController(AlertHandlerNode):
         bool
             True if cutover was applied and PID state should be reset once.
 
-        Rationale
-        ---------
+        Notes
+        -----
         We use the local append sequence, not command timestamps, because old and new
         epochs can overlap in time for point/track-like trajectories. Timestamps alone
         cannot distinguish "stale old future commands" from "fresh new commands".

--- a/necst/procedures/observations/optical_pointing.py
+++ b/necst/procedures/observations/optical_pointing.py
@@ -28,6 +28,10 @@ class OpticalPointing(Observation):
         sorted_list = opt_pointing.sort(
             catalog_file=file, magnitude=(float(magnitude[0]), float(magnitude[1]))
         )
+        current_coord = self.com.antenna("?")
+        sorted_list = opt_pointing.resolve_mount_targets(
+            sorted_list, current_az=float(current_coord.lon)
+        )
         t_tot = opt_pointing.estimate_time(sorted_list)
         if obstime is None:
             self.logger.info(f"{len(sorted_list)} stars will be captured. ")
@@ -87,11 +91,13 @@ class OpticalPointing(Observation):
                         self.com.antenna(
                             "point",
                             target=(
-                                float(sorted_list["ra"][i]),
-                                float(sorted_list["dec"][i]),
-                                "fk5",
+                                float(sorted_list["mount_az"][i]),
+                                float(sorted_list["el"][i]),
+                                "altaz",
                             ),
                             unit="deg",
+                            direct_mode=True,
+                            az_target_mode="mount",
                             wait=True,
                         )
                     time.sleep(3.0)

--- a/necst/procedures/observations/optical_pointing.py
+++ b/necst/procedures/observations/optical_pointing.py
@@ -28,10 +28,7 @@ class OpticalPointing(Observation):
         sorted_list = opt_pointing.sort(
             catalog_file=file, magnitude=(float(magnitude[0]), float(magnitude[1]))
         )
-        current_coord = self.com.antenna("?")
-        sorted_list = opt_pointing.resolve_mount_targets(
-            sorted_list, current_az=float(current_coord.lon)
-        )
+        sorted_list = opt_pointing.resolve_mount_targets(sorted_list)
         t_tot = opt_pointing.estimate_time(sorted_list)
         if obstime is None:
             self.logger.info(f"{len(sorted_list)} stars will be captured. ")

--- a/necst/procedures/observations/optical_pointing.py
+++ b/necst/procedures/observations/optical_pointing.py
@@ -55,7 +55,7 @@ class OpticalPointing(Observation):
                     f"(RA={float(sorted_list['ra'][i]):.3f}, "
                     f"Dec={float(sorted_list['dec'][i]):.3f})"
                 ),
-                "mode": "OPTICAL_POINTING",
+                "mode": "POINT",
                 "role": "pointing",
                 "obs_id": str(i),
                 "drive_kind": "point",

--- a/necst/procedures/observations/optical_pointing.py
+++ b/necst/procedures/observations/optical_pointing.py
@@ -44,56 +44,95 @@ class OpticalPointing(Observation):
         date = obsdatetime.strftime("%Y%m%d_%H%M%S")
         save_directory = config.ccd_controller.pic_captured_path + "/" + date
 
-        captured_num = 0
-
-        try:
-            for i in range(len(sorted_list)):
-                self.com.antenna(
-                    "point",
-                    target=(
+        total = len(sorted_list)
+        plan = [
+            {
+                "item_uid": f"opticalpointing:{i:05d}",
+                "index0": i,
+                "total": total,
+                "label": (
+                    f"Star {i + 1}/{total} "
+                    f"(RA={float(sorted_list['ra'][i]):.3f}, "
+                    f"Dec={float(sorted_list['dec'][i]):.3f})"
+                ),
+                "mode": "OPTICAL_POINTING",
+                "role": "pointing",
+                "obs_id": str(i),
+                "drive_kind": "point",
+                "geometry": {
+                    "kind": "point",
+                    "frame": "fk5",
+                    "unit": "deg",
+                    "target": [
                         float(sorted_list["ra"][i]),
                         float(sorted_list["dec"][i]),
                         "fk5",
-                    ),
-                    unit="deg",
-                    wait=True,
-                )
-                time.sleep(3.0)
-                save_filename = date + "No" + str(i) + ".JPG"
-                save_path = save_directory + "/" + save_filename
+                    ],
+                },
+            }
+            for i in range(total)
+        ]
+        self.progress.set_plan(plan, observation_type=self.observation_type)
 
-                coord_before = self.com.antenna("?")
-                az_before, el_before, time_before = (
-                    coord_before.lon,
-                    coord_before.lat,
-                    coord_before.time,
-                )
-                if drive_test is False:
-                    self.com.ccd("capture", name=save_path)
+        captured_num = 0
 
-                coord_after = self.com.antenna("?")
-                az_after, el_after, time_after = (
-                    coord_after.lon,
-                    coord_after.lat,
-                    coord_after.time,
-                )
+        try:
+            for i in range(total):
+                item = plan[i]
+                geometry = item["geometry"]
+                with self.progress.item(**item):
+                    with self.progress.drive(
+                        kind="point", stage="moving", geometry=geometry
+                    ):
+                        self.com.antenna(
+                            "point",
+                            target=(
+                                float(sorted_list["ra"][i]),
+                                float(sorted_list["dec"][i]),
+                                "fk5",
+                            ),
+                            unit="deg",
+                            wait=True,
+                        )
+                    time.sleep(3.0)
+                    save_filename = date + "No" + str(i) + ".JPG"
+                    save_path = save_directory + "/" + save_filename
 
-                cap_az = (az_before + az_after) / 2
-                cap_el = (el_before + el_after) / 2
-                ra = float(sorted_list["ra"][i])
-                dec = float(sorted_list["dec"][i])
-                cap_time = (time_before + time_after) / 2
-                captured_num += 1
-                time.sleep(8.0)
-                self.logger.info(f"Target {i+1}/{len(sorted_list)} is completed.")
-                data = [cap_az, cap_el, ra, dec]
-                self.com.metadata(
-                    "set",
-                    optical_data=data,
-                    position=f"No{i}",
-                    id=date,
-                    time=cap_time,
-                )
+                    coord_before = self.com.antenna("?")
+                    az_before, el_before, time_before = (
+                        coord_before.lon,
+                        coord_before.lat,
+                        coord_before.time,
+                    )
+                    if drive_test is False:
+                        with self.progress.drive(
+                            kind="hold", stage="capturing", geometry=geometry
+                        ):
+                            self.com.ccd("capture", name=save_path)
+
+                    coord_after = self.com.antenna("?")
+                    az_after, el_after, time_after = (
+                        coord_after.lon,
+                        coord_after.lat,
+                        coord_after.time,
+                    )
+
+                    cap_az = (az_before + az_after) / 2
+                    cap_el = (el_before + el_after) / 2
+                    ra = float(sorted_list["ra"][i])
+                    dec = float(sorted_list["dec"][i])
+                    cap_time = (time_before + time_after) / 2
+                    captured_num += 1
+                    time.sleep(8.0)
+                    self.logger.info(f"Target {i+1}/{len(sorted_list)} is completed.")
+                    data = [cap_az, cap_el, ra, dec]
+                    self.com.metadata(
+                        "set",
+                        optical_data=data,
+                        position=f"No{i}",
+                        id=date,
+                        time=cap_time,
+                    )
         except KeyboardInterrupt:
             self.logger.info("Operation was Interrupted. Stopping antenna...")
             self.com.antenna("stop")

--- a/necst/procedures/observations/optical_pointing.py
+++ b/necst/procedures/observations/optical_pointing.py
@@ -11,6 +11,41 @@ from .observation_base import Observation
 class OpticalPointing(Observation):
     observation_type = "OpticalPointing"
 
+    def _pin_unwrap_branch(self, sorted_list) -> None:
+        """Put the antenna on the 360deg unwrap branch this plan intends.
+
+        The plan sweeps azimuth upward from the lowest-Az stars, so every
+        target's intended mount angle is its own true azimuth (branch k=0).
+        But the antenna may be parked anywhere - e.g. near 375deg from a
+        previous observation. A plain RA/Dec command from there lets
+        DriveLimitChecker pick whichever 360deg-equivalent is nearest to that
+        parked position, i.e. the k=+1 branch, which then forces a wasted
+        ~350deg unwind a star or two later once k=+1 runs past the drive
+        limit (see necst-telescope/necst#481).
+
+        Slewing once to the first star's intended mount angle fixes that: from
+        then on the antenna is already on the k=0 branch, so for every
+        subsequent star the nearest equivalent angle *is* the intended one and
+        normal RA/Dec tracking commands stay on the branch by themselves. Only
+        this one slew bypasses tracking; all actual pointing and capture runs
+        on ordinary RA/Dec tracking commands.
+        """
+        az = float(sorted_list["mount_az"][0])
+        el = float(sorted_list["el"][0])
+        self.logger.info(f"Pinning Az unwrap branch: slewing to mount Az={az:.3f}deg")
+        cmd_id = self.com.antenna(
+            "point",
+            target=(az, el, "altaz"),
+            unit="deg",
+            direct_mode=True,
+            az_target_mode="mount",
+            wait=False,
+        )
+        # wait=True can't be used for mount-frame commands: TrackingStatus
+        # compares sky azimuth modulo 360, so it would report "arrived" at the
+        # wrong branch. wait_mount_point compares the raw mechanical angle.
+        self.com.wait_mount_point(az, el, command_id=cmd_id, timeout_sec=420)
+
     def run(
         self,
         file: str,
@@ -85,16 +120,16 @@ class OpticalPointing(Observation):
                     with self.progress.drive(
                         kind="point", stage="moving", geometry=geometry
                     ):
+                        if i == 0:
+                            self._pin_unwrap_branch(sorted_list)
                         self.com.antenna(
                             "point",
                             target=(
-                                float(sorted_list["mount_az"][i]),
-                                float(sorted_list["el"][i]),
-                                "altaz",
+                                float(sorted_list["ra"][i]),
+                                float(sorted_list["dec"][i]),
+                                "fk5",
                             ),
                             unit="deg",
-                            direct_mode=True,
-                            az_target_mode="mount",
                             wait=True,
                         )
                     time.sleep(3.0)

--- a/necst/rx/ccd.py
+++ b/necst/rx/ccd.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from neclib.devices import CcdController as CCD_Device
 
 from necst_msgs.srv import CCDCommand
@@ -26,6 +28,7 @@ class CCDController(DeviceNode):
         self, request: CCDCommand.Request, response: CCDCommand.Response
     ) -> CCDCommand.Response:
         if request.capture:
+            Path(request.savepath).parent.mkdir(parents=True, exist_ok=True)
             self.ccd.capture(request.savepath)
             self.logger.info("Capturing the target is completed.")
             response.captured = True

--- a/necst/rx/spectral_recording_runtime.py
+++ b/necst/rx/spectral_recording_runtime.py
@@ -4,8 +4,8 @@ This module is intentionally ROS-free.  ``necst.rx.spectrometer.SpectralData``
 uses these helpers for PR4/PR5, while the unit tests exercise them with simple
 Python objects.
 
-Implemented PR scope
---------------------
+Notes
+-----
 PR4:
   * active snapshot setup state;
   * setup hash validation;

--- a/necst/rx/spectral_recording_sg.py
+++ b/necst/rx/spectral_recording_sg.py
@@ -5,8 +5,8 @@ time.  The pure functions are unit-testable with fake readback objects; the CLI
 imports ``necst.core.Commander`` only when an actual apply/verify command is
 requested.
 
-Frequency convention
---------------------
+Notes
+-----
 ``sg_set_frequency_hz`` in ``lo_profile.toml`` is the frequency sent to the
 physical signal generator.  Commander currently publishes ``LocalSignal.freq``
 in GHz, so readback objects with a ``freq`` attribute are interpreted as GHz


### PR DESCRIPTION
Closes #480

## 問題1: 保存先ディレクトリが存在せずCCDノードがクラッシュ

`optical_pointing` は観測ごとにタイムスタンプ付きの新規サブディレクトリ（`pic_captured_path/<date>/`）へ画像を保存しようとするが、そのディレクトリを作成する処理がどこにも無かった。

`gp_file_save()` は保存先ディレクトリを自動作成しないため、実機（OMU1.85m, raspi上のCCDノード）で撮影（シャッター）自体は成功するのに、その後のファイル保存で

```
gphoto2.GPhoto2Error: [-1] Unspecified error
```

となり、`necst/rx/ccd.py` の `capture()` サービスコールバックが例外を送出。これが `rclpy` の `executor.spin()` まで伝播し、**CCDノードのプロセスごとクラッシュ**していた。necst側（クライアント）では以降 `ccd_cmd` サービスに応答が無くなり `NECSTTimeoutError` になる。

### 修正
1. `necst/rx/ccd.py` の `capture()` で、`self.ccd.capture(...)` 呼び出し前に保存先ディレクトリを作成するようにした。
2. `OpticalPointing.run()` が `ObservationProgressReporter` の `set_plan()`/`item()`/`drive()` を一切呼んでおらず、他の観測モード（skydip, position_switching, otf等）と違って進捗ファイル/Web UI（`bin/progress.py`）から見えなかったため、カタログ星ごとにplan itemを構築し、指向・撮影の各区間を `progress.item()`/`progress.drive()` でラップして対応させた。
3. 上記に伴い、Plan Viewの表示が正しくなるよう軸ラベル（RA/Dec表示のはずが生のフレーム名になっていた）と`mode`（`POINT`固定）も修正した。

## 問題2: az-unwrap起因の無駄な大回転駆動

光学ポインティングで、RA/Decをそのまま`HorizontalCoord`に送っていたため、`DriveLimitChecker`が星ごとに独立して「現在地に一番近い360°等価角」を選んでいた。ある星の等価角が`warning_limit_az`のすぐ外側(だが`critical_limit_az`内)に入ると、`DriveLimitChecker._select()`がその近い候補を却下し、はるかに遠いが`warning_limit_az`内の候補を選んでしまうバグがあり、隣接する星同士でも300°超の無駄な駆動が発生していた。

### 修正の経緯
最初に「駆動コマンド自体を`az_target_mode="mount"`の直接AltAz指定に切り替え、`DriveLimitChecker`の候補再選択を完全にバイパスする」実装にしたが、これは`PathFinder.track()`(地球の自転による追尾を担う部分)も同時にバイパスしてしまい、**観測終盤の星で最大1.3°近いズレが出る**（追尾が丸ごと消失する）副作用があった。

最終的な実装:
- `OpticalPointingSpec.resolve_mount_targets()`(necst-telescope/neclib#792)を追加。ソート済みの星を順に走査し、各星について「直前に解決した角度に一番近い360°等価角」を選ぶ。1番目の星は現在地に依存せず生の値をそのまま使う（現在地に合わせること自体が形を変えた「近道」になるため）。
- **観測開始時に1回だけ**、`_pin_unwrap_branch()`で1番目の星の意図した角度へmountフレームの直接AltAzスルーを行い、アンテナを正しいunwrapの枝に乗せる。
- それ以降は**全ての星（1番目も含む）を通常のRA/Dec追尾コマンドで駆動**する。アンテナが既に正しい枝に乗っているので、`DriveLimitChecker`が選ぶ「一番近い等価角」が自動的に意図した枝になり、地球の自転による追尾も維持される。

このバグ修正は、他の観測モード(grid/psw/otf等)に影響する`DriveLimitChecker`自体は変更せず、**光学ポインティングにスコープを限定**している。

## 問題3: 観測順序が見えない

Plan Viewが星の散布図だけで、どの順に観測するか分からなかった。星を訪問順に繋ぐパスを追加した（通過済み区間=薄い緑、未通過区間=ほぼ目立たないグレー、いずれも実線。既存のAz/Dec=0の灰色点線とは線種・色で区別できるようにした）。

## 問題4: CCDのkeepaliveポーリング — 撤廃済み

M100 CCDの永続セッション化(necst-telescope/ogameasure#96)に合わせ、カメラのオートパワーオフ対策として30秒おきに`keepalive()`を呼ぶタイマーを追加していたが、実機で**起動後20〜30分でsegfault**する事象を確認。USB接続自体は切断されておらず、`gp_camera_wait_for_event`の反復呼び出し自体が原因と考えられる。根本原因の特定には至らなかったため、necst/neclib/ogameasureの3リポジトリ全てから**keepaliveを完全に撤廃**した。永続セッション化自体（撮影ごとの再接続をやめる部分）は維持している。

## 問題5: このPRに対してCIが一度も動いていなかった

`.github/workflows/test.yml`の`pull_request`トリガーが`branches: [main]`に限定されており、本PRのbase（`#474-feat/progress-timesync-display-derivations`）が`main`でないため、**lintもpytestも一度も実行されていなかった**。`pull_request`のbranch制限を外し、baseに関わらずCIが走るようにした。

## 依存関係

necst-telescope/neclib#792 が必要（`OpticalPointingSpec.resolve_mount_targets()`など）。

## テスト計画

- [x] 実機（raspi）で `necst optical_pointing` を実行し、新規タイムスタンプディレクトリへの初回撮影が保存まで成功することを確認
- [x] Q-Lookで`antenna/altaz::lon`が星から星への移動で不要な大ジャンプをしないことを確認
- [x] 地球の自転による追尾が維持されていることをコードで追跡・確認（実機での定量確認はまだ）
- [ ] `bin/progress.py` のWeb UI/`--watch`で、optical_pointing実行中に星ごとの進捗（moving/capturing）が表示されることを確認
- [ ] 長時間観測（40分超）でCCD側に異常が出ないことを確認