### PR TITLE
fix: create save directory before CCD capture + optical_pointing progress reporting

### DIFF
--- a/bin/progress.py
+++ b/bin/progress.py
@@ -5539,6 +5539,8 @@ function mapAxisLabels(rows) {
   }
   const r = rows.find(x=>x.frame) || rows[0] || {};
   const frame = r.frame || 'map'; const unit = r.unit || 'deg';
+  if (frameLooksRadec(frame)) return {x:`RA (${unit})`, y:`Dec (${unit})`, unit};
+  if (frameLooksGalactic(frame)) return {x:`Galactic l (${unit})`, y:`Galactic b (${unit})`, unit};
   return {x:`${frame} x (${unit})`, y:`${frame} y (${unit})`, unit};
 }
 function fmtAxisNumber(v, axes) {

--- a/necst/procedures/observations/optical_pointing.py
+++ b/necst/procedures/observations/optical_pointing.py
@@ -55,7 +55,7 @@ class OpticalPointing(Observation):
                     f"(RA={float(sorted_list['ra'][i]):.3f}, "
                     f"Dec={float(sorted_list['dec'][i]):.3f})"
                 ),
-                "mode": "OPTICAL_POINTING",
+                "mode": "POINT",
                 "role": "pointing",
                 "obs_id": str(i),
                 "drive_kind": "point",

--- a/necst/procedures/observations/optical_pointing.py
+++ b/necst/procedures/observations/optical_pointing.py
@@ -44,56 +44,95 @@ class OpticalPointing(Observation):
         date = obsdatetime.strftime("%Y%m%d_%H%M%S")
         save_directory = config.ccd_controller.pic_captured_path + "/" + date
 
-        captured_num = 0
-
-        try:
-            for i in range(len(sorted_list)):
-                self.com.antenna(
-                    "point",
-                    target=(
+        total = len(sorted_list)
+        plan = [
+            {
+                "item_uid": f"opticalpointing:{i:05d}",
+                "index0": i,
+                "total": total,
+                "label": (
+                    f"Star {i + 1}/{total} "
+                    f"(RA={float(sorted_list['ra'][i]):.3f}, "
+                    f"Dec={float(sorted_list['dec'][i]):.3f})"
+                ),
+                "mode": "OPTICAL_POINTING",
+                "role": "pointing",
+                "obs_id": str(i),
+                "drive_kind": "point",
+                "geometry": {
+                    "kind": "point",
+                    "frame": "fk5",
+                    "unit": "deg",
+                    "target": [
                         float(sorted_list["ra"][i]),
                         float(sorted_list["dec"][i]),
                         "fk5",
-                    ),
-                    unit="deg",
-                    wait=True,
-                )
-                time.sleep(3.0)
-                save_filename = date + "No" + str(i) + ".JPG"
-                save_path = save_directory + "/" + save_filename
+                    ],
+                },
+            }
+            for i in range(total)
+        ]
+        self.progress.set_plan(plan, observation_type=self.observation_type)
 
-                coord_before = self.com.antenna("?")
-                az_before, el_before, time_before = (
-                    coord_before.lon,
-                    coord_before.lat,
-                    coord_before.time,
-                )
-                if drive_test is False:
-                    self.com.ccd("capture", name=save_path)
+        captured_num = 0
 
-                coord_after = self.com.antenna("?")
-                az_after, el_after, time_after = (
-                    coord_after.lon,
-                    coord_after.lat,
-                    coord_after.time,
-                )
+        try:
+            for i in range(total):
+                item = plan[i]
+                geometry = item["geometry"]
+                with self.progress.item(**item):
+                    with self.progress.drive(
+                        kind="point", stage="moving", geometry=geometry
+                    ):
+                        self.com.antenna(
+                            "point",
+                            target=(
+                                float(sorted_list["ra"][i]),
+                                float(sorted_list["dec"][i]),
+                                "fk5",
+                            ),
+                            unit="deg",
+                            wait=True,
+                        )
+                    time.sleep(3.0)
+                    save_filename = date + "No" + str(i) + ".JPG"
+                    save_path = save_directory + "/" + save_filename
 
-                cap_az = (az_before + az_after) / 2
-                cap_el = (el_before + el_after) / 2
-                ra = float(sorted_list["ra"][i])
-                dec = float(sorted_list["dec"][i])
-                cap_time = (time_before + time_after) / 2
-                captured_num += 1
-                time.sleep(8.0)
-                self.logger.info(f"Target {i+1}/{len(sorted_list)} is completed.")
-                data = [cap_az, cap_el, ra, dec]
-                self.com.metadata(
-                    "set",
-                    optical_data=data,
-                    position=f"No{i}",
-                    id=date,
-                    time=cap_time,
-                )
+                    coord_before = self.com.antenna("?")
+                    az_before, el_before, time_before = (
+                        coord_before.lon,
+                        coord_before.lat,
+                        coord_before.time,
+                    )
+                    if drive_test is False:
+                        with self.progress.drive(
+                            kind="hold", stage="capturing", geometry=geometry
+                        ):
+                            self.com.ccd("capture", name=save_path)
+
+                    coord_after = self.com.antenna("?")
+                    az_after, el_after, time_after = (
+                        coord_after.lon,
+                        coord_after.lat,
+                        coord_after.time,
+                    )
+
+                    cap_az = (az_before + az_after) / 2
+                    cap_el = (el_before + el_after) / 2
+                    ra = float(sorted_list["ra"][i])
+                    dec = float(sorted_list["dec"][i])
+                    cap_time = (time_before + time_after) / 2
+                    captured_num += 1
+                    time.sleep(8.0)
+                    self.logger.info(f"Target {i+1}/{len(sorted_list)} is completed.")
+                    data = [cap_az, cap_el, ra, dec]
+                    self.com.metadata(
+                        "set",
+                        optical_data=data,
+                        position=f"No{i}",
+                        id=date,
+                        time=cap_time,
+                    )
         except KeyboardInterrupt:
             self.logger.info("Operation was Interrupted. Stopping antenna...")
             self.com.antenna("stop")

--- a/necst/rx/ccd.py
+++ b/necst/rx/ccd.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from neclib.devices import CcdController as CCD_Device
 
 from necst_msgs.srv import CCDCommand
@@ -26,6 +28,7 @@ class CCDController(DeviceNode):
         self, request: CCDCommand.Request, response: CCDCommand.Response
     ) -> CCDCommand.Response:
         if request.capture:
+            Path(request.savepath).parent.mkdir(parents=True, exist_ok=True)
             self.ccd.capture(request.savepath)
             self.logger.info("Capturing the target is completed.")
             response.captured = True


### PR DESCRIPTION
Closes #480

PR #481と同内容だが、こちらは実機（`necst_ws`）が実際に動かしている `#474-feat/progress-timesync-display-derivations`（PR #476）をベースにしたブランチ。`necst console` 等 #476 の機能はmainに未マージのため、実機での動作確認はこちらのブランチを使う。

## 問題

`optical_pointing` は観測ごとにタイムスタンプ付きの新規サブディレクトリ（`pic_captured_path/<date>/`）へ画像を保存しようとするが、そのディレクトリを作成する処理がどこにも無かった。

`gp_file_save()` は保存先ディレクトリを自動作成しないため、実機（OMU1.85m, raspi上のCCDノード）で撮影（シャッター）自体は成功するのに、その後のファイル保存で

```
gphoto2.GPhoto2Error: [-1] Unspecified error
```

となり、`necst/rx/ccd.py` の `capture()` サービスコールバックが例外を送出。これが `rclpy` の `executor.spin()` まで伝播し、CCDノードのプロセスごとクラッシュしていた。necst側（クライアント）では以降 `ccd_cmd` サービスに応答が無くなり `NECSTTimeoutError` になる。

## 修正

1. `necst/rx/ccd.py` の `capture()` で、`self.ccd.capture(...)` 呼び出し前に保存先ディレクトリを作成
2. `OpticalPointing.run()` に `ObservationProgressReporter` の `set_plan()`/`item()`/`drive()` を追加し、星ごとの進捗（moving/capturing）を `bin/progress.py` のWeb UIから見えるようにした（`mode: "POINT"` で grid/psw と同じクラッター回避表示に統一）
3. `mapAxisLabels()` がRA/Dec系frameの軸を素の`fk5`等ではなく `RA (deg)`/`Dec (deg)` と表示するように

## テスト計画

- [ ] 実機（raspi）で `necst optical_pointing` を実行し、新規タイムスタンプディレクトリへの初回撮影が保存まで成功することを確認
- [ ] 既存ディレクトリが存在する場合（2回目以降の実行）も問題なく動作することを確認（`exist_ok=True`）
- [ ] `bin/progress.py` のWeb UI/`--watch`で、optical_pointing実行中に星ごとの進捗（moving/capturing）がRA/Dec軸で表示されることを確認