### PR TITLE
release: v4.1.0

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>necst</name>
-  <version>4.0.20</version>
+  <version>4.1.0</version>
   <description>NEw Control System for Telescope</description>
   <maintainer email="k.nishikawa@a.phys.nagoya-u.ac.jp">Kaoru Nishikawa</maintainer>
   <license>MIT</license>

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ executor_entrypoints = get_executor_entrypoints()
 
 setup(
     name=package_name,
-    version="4.0.20",
+    version="4.1.0",
     packages=find_packages(),
     data_files=[
         ("share/ament_index/resource_index/packages", ["resource/" + package_name]),


### PR DESCRIPTION
## Summary

- bump Python package version from `4.0.20` to `4.1.0`
- bump ROS package version from `4.0.20` to `4.1.0`

## Checks

- [x] `setup.py` and `package.xml` versions are synchronized
- [ ] CI passes

## Release

After merging, create the `v4.1.0` tag and GitHub Release from `main`.